### PR TITLE
Defer deletion of VHPI callback user data until callback has completed

### DIFF
--- a/lib/gpi_impl/gpi_vhpi.c
+++ b/lib/gpi_impl/gpi_vhpi.c
@@ -583,10 +583,10 @@ static void handle_vhpi_callback(const vhpiCbDataT *cb_data)
     /* A request to delete could have been done
      * inside gpi_function
      */
-    if (user_data->state == VHPI_DELETE)
+    const vhpi_cb_state_t old_state = user_data->state;
+    user_data->state = VHPI_POST_CALL;
+    if (old_state == VHPI_DELETE)
         gpi_free_cb_handle(&user_data->gpi_cb_data.hdl);
-    else
-        user_data->state = VHPI_POST_CALL;
 
     FEXIT
     return;
@@ -621,7 +621,22 @@ static void vhpi_destroy_cb_handle(gpi_cb_hdl hdl)
     FENTER
     p_vhpi_cb user_data = gpi_container_of(hdl, s_vhpi_cb, gpi_cb_data);
 
-    free(user_data);
+    switch (user_data->state) {
+    case VHPI_PRE_CALL:
+        /* The callback is already executing: flag it for deletion later
+         */
+        user_data->state = VHPI_DELETE;
+        break;
+
+    case VHPI_DELETE:
+        /* This callback has already been flagged for deletion: do nothing
+         */
+        break;
+
+    default:
+        free(user_data);
+    }
+
     FEXIT
 }
 


### PR DESCRIPTION
Calling gpi_handle_callback can result in the user_data pointer being freed by vhpi_destroy_cb_handle before the call returns. There seems to already be a mechanism for deferring the deletion using the VHPI_DELETE state however this does not appear to be set anywhere.

This patch modifies vhpi_destroy_cb_handle to set the state to VHPI_DELETE if we know the callback is currently executing.

A similar change is possibly required to the VPI code too.

FYI, the Valgrind error I get is

```
==6714== Invalid read of size 8
==6714==    at 0x9606CFE: handle_vhpi_callback (gpi_vhpi.c:575)
==6714==    by 0x466F62: rt_cycle (rtkern.c:1896)
==6714==    by 0x466346: rt_batch_exec (rtkern.c:2182)
==6714==    by 0x40DE64: main (nvc.c:413)
==6714==  Address 0x11e1e040 is 0 bytes inside a block of size 88 free'd
==6714==    at 0x4C29730: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==6714==    by 0x9606DBF: vhpi_destroy_cb_handle (gpi_vhpi.c:626)
==6714==    by 0x96047BC: gpi_free_cb_handle (gpi_common.c:200)
==6714==    by 0x118069E0: remove_callback (simulatormodule.c:835)
==6714==    by 0xEDDA033: PyEval_EvalFrameEx (in /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0)
==6714==    by 0xEDDB4AC: PyEval_EvalCodeEx (in /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0)
==6714==    by 0xEE1490F: ??? (in /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0)
==6714==    by 0xED887A2: PyObject_Call (in /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0)
==6714==    by 0xED20A2C: ??? (in /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0)
==6714==    by 0xED887A2: PyObject_Call (in /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0)
==6714==    by 0xED726B6: PyEval_CallObjectWithKeywords (in /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0)
==6714==    by 0xED7AB6F: ??? (in /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0)
==6714== 

```