### PR TITLE
Python3 support? changed the makefile to work with either python2/python3

### DIFF
--- a/makefiles/Makefile.pylib.Linux
+++ b/makefiles/Makefile.pylib.Linux
@@ -35,9 +35,9 @@ NATIVE_ARCH=$(shell uname -m)
 ARCH?=$(NATIVE_ARCH)
 
 # We might work with other Python versions
-PYTHON_VERSION?=$(shell python -c 'import distutils.sysconfig; print distutils.sysconfig.get_python_version()')
-PYTHON_LIBDIR:=$(shell python -c 'from distutils import sysconfig; print sysconfig.get_config_var("LIBDIR")')
-PYTHON_DYNLIBDIR:=$(shell python -c 'from distutils import sysconfig; print sysconfig.get_config_var("DESTSHARED")')
+PYTHON_VERSION?=$(shell python -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_version())')
+PYTHON_LIBDIR:=$(shell python -c 'from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')
+PYTHON_DYNLIBDIR:=$(shell python -c 'from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_config_var("DESTSHARED"))')
 
 # Nasty hack but there's no way in Python properly get the directories for 32-bit Python on a 64-bit system
 # TODO: Under OSX we can use "export VERSIONER_PYTHON_PREFER_32_BIT=yes", no Linux equivalent though
@@ -51,5 +51,5 @@ endif
 # is we simply link against all dynamic libraries in the Python installation
 PYLIBS = $(shell python-config --libs)
 
-PYTHON_INCLUDEDIR := $(shell python -c 'import distutils.sysconfig; print distutils.sysconfig.get_python_inc()')
+PYTHON_INCLUDEDIR := $(shell python -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())')
 PYTHON_DYN_LIB = libpython$(PYTHON_VERSION).so


### PR DESCRIPTION
Hi,

First of all, cocotb is the best thing since sliced bread. :)

Anyway, it is listed in the README that Python2.6+ is supported. But it does not work for python3k. After modifying the makefile to make it build (pull request attached), it is clear that there have been some changes to the python C api which makes the current cocotb codebase incompatible. I used all of the latest 3.4.0 dev packages available on Ubuntu 14.04.1.

Is support for python3 planned? I am considering giving it a go myself, though I'm not sure my skills are up to the task.