### PR TITLE
Updated Makefile.ius with bugfixes

### DIFF
--- a/makefiles/simulators/Makefile.ius
+++ b/makefiles/simulators/Makefile.ius
@@ -39,24 +39,26 @@ else
 endif
 
 ifeq ($(GPI_IMPL),vpi)
-    GPI_ARGS = -loadvpi $(LIB_DIR)/libvpi:vlog_startup_routines_bootstrap
+    GPI_ARGS = -loadvpi $(LIB_DIR)/libvpi
     EXTRA_ARGS += -sv
     HDL_SOURCES = $(VERILOG_SOURCES)
+    GPI_LIB = $(COCOTB_VPI_LIB)
 endif
 
 ifeq ($(GPI_IMPL),vhpi)
-    GPI_ARGS = -loadvhpi $(LIB_DIR)/libvhpi:vhpi_startup_routines_bootstrap
+    GPI_ARGS = -loadvhpi $(LIB_DIR)/libvhpi
     #EXTRA_ARGS += -cdslib cds.lib
     EXTRA_ARGS += -v93
     EXTRA_ARGS += -top worklib.$(TOPLEVEL)
     HDL_SOURCES = $(VHDL_SOURCES)
+    GPI_LIB = $(COCOTB_VHPI_LIB)
 endif
 
 ifndef GPI_ARGS
    $(error "Unable to determine appropriate GPI layer to use")
 endif
 
-results.xml: $(SIM_BUILD) $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_LIB_VPI)
+results.xml: $(SIM_BUILD) $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(GPI_LIB)
 	LD_RUN_PATH=$(PYTHON_LIBDIR):$(LD_RUN_PATH) PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
                irun $(EXTRA_ARGS) $(GPI_ARGS) +access+rwc $(HDL_SOURCES) $(PLUSARGS)
 


### PR DESCRIPTION
Adding missing requirement for libvpi.so and libvhpi.so, causing them
not to be built when using Cadence Incisive.

Removed explicit call to vlog_startup_routines_bootstrap and
vhpi_startup_routines_bootstrap. This fix was tested on ius v9.2, 11.1 and 14.1 for the vlog case and 14.1 for vhdl.