### PR TITLE
Added rudimentary support for EnumNets in SystemVerilog

### DIFF
--- a/include/vpi_user.h
+++ b/include/vpi_user.h
@@ -64,6 +64,7 @@ typedef uint32_t *vpiHandle;
 #define vpiStructVar           618
 #define vpiInterface           601
 #define vpiModport             606
+#define vpiEnumNet             680  /* SystemVerilog */
 
 #define vpiStop                66  /* execute simulator's $stop */
 #define vpiFinish              67  /* execute simulator's $finish */

--- a/lib/vpi/VpiImpl.cpp
+++ b/lib/vpi/VpiImpl.cpp
@@ -93,6 +93,7 @@ GpiObjHdl* VpiImpl::native_check_create(std::string &name, GpiObjHdl *parent)
         case vpiNet:
         case vpiReg:
         case vpiParameter:
+        case vpiEnumNet:
             new_obj = new VpiSignalObjHdl(this, new_hdl);
             break;
         case vpiStructVar:
@@ -133,6 +134,7 @@ GpiObjHdl* VpiImpl::native_check_create(uint32_t index, GpiObjHdl *parent)
     switch (type) {
         case vpiNet:
         case vpiNetBit:
+        case vpiEnumNet:
             new_obj = new VpiSignalObjHdl(this, new_hdl);
             break;
         case vpiModule:


### PR DESCRIPTION
It is now possible to read and write enum-nets/ports from Python
as integers, but not by using enum-names.

This could be extended by adding introspection to get a int
to enum name dictonary.