### PR TITLE
Allow user to delay assignments of signals 

### DIFF
--- a/examples/functionality/tests/Makefile
+++ b/examples/functionality/tests/Makefile
@@ -51,7 +51,7 @@ endif
 
 export TOPLEVEL_LANG
 
-MODULE ?= test_cocotb,test_discovery,test_external,test_regression
+MODULE ?= test_cocotb,test_discovery,test_external,test_regression,test_inertialdelay
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim

--- a/examples/functionality/tests/test_inertialdelay.py
+++ b/examples/functionality/tests/test_inertialdelay.py
@@ -1,0 +1,26 @@
+import cocotb
+from cocotb.triggers import Timer, ReadOnly
+
+@cocotb.test()
+def test_assign_no_delay(dut):
+    dut.clk <= 0
+    yield Timer(10)
+    assert dut.clk.value == 0
+    dut.clk <= 1
+    assert dut.clk.value == 0
+    yield ReadOnly()
+    assert dut.clk.value == 1
+
+@cocotb.test()
+def test_assign_inertial_delay(dut):
+    dut.clk <= 0
+    yield Timer(10)
+    assert dut.clk.value == 0
+    dut.clk <= (1, 50)
+    assert dut.clk.value == 0
+    yield ReadOnly()
+    assert dut.clk.value == 0
+    yield Timer(49)
+    assert dut.clk.value == 0
+    yield Timer(1)
+    assert dut.clk.value == 1

--- a/include/gpi.h
+++ b/include/gpi.h
@@ -153,7 +153,9 @@ const char *gpi_get_signal_type_str(gpi_sim_hdl gpi_hdl);
 
 // Functions for setting the properties of a handle
 void gpi_set_signal_value_int(gpi_sim_hdl gpi_hdl, int value);
+void gpi_set_signal_value_int_delay(gpi_sim_hdl gpi_hdl, int value, uint64_t inertial_delay);
 void gpi_set_signal_value_str(gpi_sim_hdl gpi_hdl, const char *str);    // String of binary char(s) [1, 0, x, z]
+void gpi_set_signal_value_str_delay(gpi_sim_hdl gpi_hdl, const char *str, uint64_t inertial_delay);    // String of binary char(s) [1, 0, x, z]
 
 typedef enum gpi_edge {
     GPI_RISING = 1,

--- a/lib/gpi/GpiCommon.cpp
+++ b/lib/gpi/GpiCommon.cpp
@@ -282,11 +282,24 @@ void gpi_set_signal_value_int(gpi_sim_hdl sig_hdl, int value)
     obj_hdl->set_signal_value(value);
 }
 
+void gpi_set_signal_value_int_delay(gpi_sim_hdl sig_hdl, int value, uint64_t inertial_delay)
+{
+    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    obj_hdl->set_signal_value(value, inertial_delay);
+}
+
 void gpi_set_signal_value_str(gpi_sim_hdl sig_hdl, const char *str)
 {
     std::string value = str;
     GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
     obj_hdl->set_signal_value(value);
+}
+
+void gpi_set_signal_value_str_delay(gpi_sim_hdl sig_hdl, const char *str, uint64_t inertial_delay)
+{
+    std::string value = str;
+    GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);
+    obj_hdl->set_signal_value(value, inertial_delay);
 }
 
 gpi_sim_hdl gpi_register_value_change_callback(int (*gpi_function)(const void *),

--- a/lib/gpi/gpi_priv.h
+++ b/lib/gpi/gpi_priv.h
@@ -127,7 +127,10 @@ public:
     int m_length;
 
     virtual int set_signal_value(const int value) = 0;
+    virtual int set_signal_value(const int value, uint64_t inertial_delay) = 0;
     virtual int set_signal_value(std::string &value) = 0;
+    virtual int set_signal_value(std::string &value, uint64_t inertial_delay) = 0;
+
     //virtual GpiCbHdl monitor_value(bool rising_edge) = 0; this was for the triggers
     // but the explicit ones are probably better
 

--- a/lib/simulator/simulatormodule.c
+++ b/lib/simulator/simulatormodule.c
@@ -554,17 +554,22 @@ static PyObject *set_signal_val(PyObject *self, PyObject *args)
 {
     gpi_sim_hdl hdl;
     long value;
+    uint64_t inertial_delay=0;
     PyObject *res;
 
     PyGILState_STATE gstate;
     gstate = TAKE_GIL();
 
-    if (!PyArg_ParseTuple(args, "ll", &hdl, &value)) {
+    if (!PyArg_ParseTuple(args, "ll|K", &hdl, &value, &inertial_delay)) {
         DROP_GIL(gstate);
         return NULL;
     }
 
-    gpi_set_signal_value_int(hdl,value);
+    if (inertial_delay) {
+        gpi_set_signal_value_int_delay(hdl,value,inertial_delay);
+    } else {
+        gpi_set_signal_value_int(hdl,value);
+    }
     res = Py_BuildValue("s", "OK!");
 
     DROP_GIL(gstate);
@@ -577,17 +582,22 @@ static PyObject *set_signal_val_str(PyObject *self, PyObject *args)
 {
     gpi_sim_hdl hdl;
     const char *binstr;
+    uint64_t inertial_delay=0;
     PyObject *res;
 
     PyGILState_STATE gstate;
     gstate = TAKE_GIL();
 
-    if (!PyArg_ParseTuple(args, "ls", &hdl, &binstr)) {
+    if (!PyArg_ParseTuple(args, "ls|K", &hdl, &binstr, &inertial_delay)) {
         DROP_GIL(gstate);
         return NULL;
     }
 
-    gpi_set_signal_value_str(hdl,binstr);
+    if (inertial_delay) {
+        gpi_set_signal_value_str_delay(hdl,binstr,inertial_delay);
+    } else {
+        gpi_set_signal_value_str(hdl,binstr);
+    }
     res = Py_BuildValue("s", "OK!");
 
     DROP_GIL(gstate);

--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -170,7 +170,14 @@ int VpiSignalObjHdl::set_signal_value(std::string &value)
     value_s.value.str = &writable[0];
     value_s.format = vpiBinStrVal;
 
-    vpi_put_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s, NULL, vpiNoDelay);
+    s_vpi_time vpi_time_s;
+
+    vpi_time_s.type = vpiSimTime;
+    vpi_time_s.high = 0;
+    vpi_time_s.low  = 0;
+
+    // Use Inertial delay to schedule an event, thus behaving like a verilog testbench
+    vpi_put_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s, &vpi_time_s, vpiInertialDelay);
     check_vpi_error();
 
     FEXIT

--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -139,6 +139,11 @@ const char* VpiSignalObjHdl::get_signal_value_binstr(void)
 // Value related functions
 int VpiSignalObjHdl::set_signal_value(int value)
 {
+	return set_signal_value(value, 0);
+}
+
+int VpiSignalObjHdl::set_signal_value(int value, uint64_t inertial_delay)
+{
     FENTER
     s_vpi_value value_s;
 
@@ -148,8 +153,8 @@ int VpiSignalObjHdl::set_signal_value(int value)
     s_vpi_time vpi_time_s;
 
     vpi_time_s.type = vpiSimTime;
-    vpi_time_s.high = 0;
-    vpi_time_s.low  = 0;
+    vpi_time_s.high = (uint32_t)(inertial_delay >> 32);
+    vpi_time_s.low  = (uint32_t)(inertial_delay);
 
     // Use Inertial delay to schedule an event, thus behaving like a verilog testbench
     vpi_put_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s, &vpi_time_s, vpiInertialDelay);
@@ -160,6 +165,11 @@ int VpiSignalObjHdl::set_signal_value(int value)
 }
 
 int VpiSignalObjHdl::set_signal_value(std::string &value)
+{
+	return set_signal_value(value, 0);
+}
+
+int VpiSignalObjHdl::set_signal_value(std::string &value, uint64_t inertial_delay)
 {
     FENTER
     s_vpi_value value_s;
@@ -173,8 +183,8 @@ int VpiSignalObjHdl::set_signal_value(std::string &value)
     s_vpi_time vpi_time_s;
 
     vpi_time_s.type = vpiSimTime;
-    vpi_time_s.high = 0;
-    vpi_time_s.low  = 0;
+    vpi_time_s.high = (uint32_t)(inertial_delay >> 32);
+    vpi_time_s.low  = (uint32_t)(inertial_delay);
 
     // Use Inertial delay to schedule an event, thus behaving like a verilog testbench
     vpi_put_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s, &vpi_time_s, vpiInertialDelay);

--- a/lib/vpi/VpiImpl.h
+++ b/lib/vpi/VpiImpl.h
@@ -182,7 +182,9 @@ public:
     const char* get_signal_value_binstr(void);
 
     int set_signal_value(const int value);
+    int set_signal_value(const int value, uint64_t inertial_delay);
     int set_signal_value(std::string &value);
+    int set_signal_value(std::string &value, uint64_t inertial_delay);
 
     /* Value change callback accessor */
     GpiCbHdl *value_change_cb(unsigned int edge);


### PR DESCRIPTION
This is a possible implementation that can be used for discussion. The delay is implemented by vpiInertialDelay on vpi_put_value-calls.

The syntax used is:

``` python
@cocotb.test()
def test_inertial_delay(dut):
    ... set up a clock on dut.clk
    yield RisingEdge(clk)
    dut.my_delayed_signal <= (1, 4) #Second value of tuple is delay in simulator cycles.

```

This can make it easier to do something similar to SystemVerilog clocking from
python, re potentialventures/cocotb#203.

It is not implemented for other simulator interfaces than VPI,
eg. VHPI VHDL interface is not implemented. This could be implemented by
using vhpi_schedule_transaction as described in a comment to potentitalventures/cocotb#205.
