### PR TITLE
CVC support for interpreted mode

### DIFF
--- a/lib/vpi/Makefile
+++ b/lib/vpi/Makefile
@@ -39,6 +39,11 @@ SRCS        := VpiImpl.cpp VpiCbHdl.cpp
 
 CLIBS       += $(LIB_DIR)/gpivpi.vpl
 
+#temporary hack for cvc
+ifeq ($(SIM),cvc)
+    GXX_ARGS    += -DMODELSIM
+endif
+
 # More rules such that this may be needed depending on the requirements of
 # different simulators, icarus for instance loads a <name>.vpi libraray to use the vpi
 # inerface at the start of the simulation

--- a/makefiles/simulators/Makefile.cvc
+++ b/makefiles/simulators/Makefile.cvc
@@ -25,16 +25,42 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+#only interpreted mode works for the moment
+CVC_ITERP ?= 1
+
+ifeq ($(CVC_ITERP),1)
+    CVC_ARGS    += +interp
+endif
+
 # Compilation phase
-$(SIM_BUILD)/sim.vvp: $(SIM_BUILD) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(COCOTB_LIBS)
-	LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) \
-        cvc64 +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=libvpi:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+$(SIM_BUILD)/sim.vvp: $(SIM_BUILD) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
+	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
+	TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+        cvc64 $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=libvpi:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
-results.xml: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
+ifeq ($(CVC_ITERP),1)
+    results.xml: $(SIM_BUILD)/sim.vvp
+else
+    results.xml: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
         $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
+endif
+
+# Execution phase
+ifeq ($(CVC_ITERP),1)
+    debug:  $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
+	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
+        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+        gdb --args cvc64 $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=libvpi:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
+else
+    debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
+	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
+        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+        gdb --args $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
+endif
+
 
 clean::
 	-@rm -rf $(SIM_BUILD)


### PR DESCRIPTION
Only works with interpreted mode (crashes in compiled mode I see no way to debug this).
To run examples one need to use this: https://github.com/themperek/cvcx (fix for $clog2)
Need to add -DMODELSIM because vpi_free_object at https://github.com/themperek/cocotb/blob/master/lib/vpi/VpiCbHdl.cpp#L113 makes troubles.

