### PR TITLE
Fli under windows

### DIFF
--- a/examples/adder/hdl/adder.vhd
+++ b/examples/adder/hdl/adder.vhd
@@ -1,0 +1,25 @@
+-- Adder DUT
+library ieee ;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity adder is
+generic(
+    DATA_WIDTH : positive := 4);
+port(
+    A : in  unsigned(DATA_WIDTH-1 downto 0);
+    B : in  unsigned(DATA_WIDTH-1 downto 0);
+    X : out unsigned(DATA_WIDTH downto 0)
+    );
+end adder;
+
+
+architecture RTL of adder is
+begin
+
+    process(A, B)   
+    begin
+	  X <= resize(A, X'length) + B; 
+    end process;	
+
+end RTL;

--- a/examples/adder/tests/Makefile
+++ b/examples/adder/tests/Makefile
@@ -43,8 +43,15 @@ PYTHONPATH := $(WPWD)/../model:$(PYTHONPATH)
 endif
 export PYTHONPATH
 
-VERILOG_SOURCES = $(WPWD)/../hdl/adder.v
-GPI_IMPL := vpi
+ifeq ($(TOPLEVEL_LANG),verilog)
+    VERILOG_SOURCES = $(WPWD)/../hdl/adder.v
+    GPI_IMPL=vpi
+endif
+
+ifeq ($(TOPLEVEL_LANG),vhdl)
+    VHDL_SOURCES = $(WPWD)/../hdl/adder.vhd
+    GPI_IMPL=vhpi
+endif
 
 export TOPLEVEL_LANG
 

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -1,5 +1,4 @@
 
-TOPLEVEL := mean_sv
 TOPLEVEL_LANG ?= verilog
 
 PWD=$(shell pwd)
@@ -11,19 +10,29 @@ else
 WPWD=$(shell pwd)
 endif
 
-VHDL_SOURCES = $(WPWD)/../hdl/mean_pkg.vhd
-VHDL_SOURCES += $(WPWD)/../hdl/mean.vhd
+ifeq ($(TOPLEVEL_LANG),verilog)
+    VHDL_SOURCES = $(WPWD)/../hdl/mean_pkg.vhd
+    VHDL_SOURCES += $(WPWD)/../hdl/mean.vhd
 
-VCOM_ARGS = -mixedsvvh
-export VCOM_ARGS
+    VCOM_ARGS = -mixedsvvh
+    export VCOM_ARGS
+
+    VERILOG_SOURCES = $(WPWD)/../hdl/mean_sv.sv
+    TOPLEVEL = mean_sv
+    GPI_IMPL = vpi
+endif
+
+ifeq ($(TOPLEVEL_LANG),vhdl)
+    VHDL_SOURCES = $(WPWD)/../hdl/mean_pkg.vhd
+    VHDL_SOURCES += $(WPWD)/../hdl/mean.vhd
+    TOPLEVEL = mean
+    GPI_IMPL=vhpi
+endif
+
+export TOPLEVEL_LANG
 
 GENERICS = "BUS_WIDTH=2"
 export GENERICS
-
-VERILOG_SOURCES = $(WPWD)/../hdl/mean_sv.sv
-GPI_IMPL := vpi
-
-export TOPLEVEL_LANG
 
 MODULE ?= test_mean
 

--- a/lib/fli/FliImpl.cpp
+++ b/lib/fli/FliImpl.cpp
@@ -100,7 +100,7 @@ void handle_fli_callback(void *data)
 
 void FliImpl::sim_end(void)
 {
-    mti_Quit();
+    mti_Break();
 }
 
 /**

--- a/lib/fli/Makefile
+++ b/lib/fli/Makefile
@@ -30,7 +30,7 @@ include $(SIM_ROOT)/makefiles/Makefile.inc
 
 INCLUDES    += -I$(MODELSIM_BIN_DIR)/../include
 GXX_ARGS    += -DFLI_CHECKING -DUSE_CACHE
-LIBS        := -lgpilog -lgpi -lstdc++
+LIBS        := -lgpilog -lgpi -lstdc++ $(EXTRA_LIBS)
 LD_PATH     := -L$(LIB_DIR) $(EXTRA_LIBDIRS)
 LIB_NAME    := libfli
 

--- a/makefiles/simulators/Makefile.modelsim
+++ b/makefiles/simulators/Makefile.modelsim
@@ -70,8 +70,9 @@ endif
 ifeq ($(GUI),1)
 	@echo "add wave -recursive /*" >> $@
 else
+	@echo "onbreak resume" >> $@
 	@echo "run -all" >> $@
-	@echo "quit" >> $@
+	@echo "quit -f" >> $@
 endif
 
 # auto-detect modelsim dir from system path

--- a/makefiles/simulators/Makefile.modelsim
+++ b/makefiles/simulators/Makefile.modelsim
@@ -52,6 +52,8 @@ ifneq ($(GENERICS),)
 VSIM_ARGS += $(foreach gen, $(GENERICS),"-G $(gen)")
 endif
 
+.PHONY : $(SIM_BUILD)/runsim.do
+
 $(SIM_BUILD)/runsim.do : $(VHDL_SOURCES) $(VERILOG_SOURCES) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)
 	echo "if [file exists work] {vdel -all}" > $@
 	echo "vlib work" >> $@

--- a/makefiles/simulators/Makefile.modelsim
+++ b/makefiles/simulators/Makefile.modelsim
@@ -43,7 +43,7 @@ VSIM_ARGS += -onfinish exit
 endif
 
 ifeq ($(GPI_IMPL),vhpi)
-VSIM_ARGS += -foreign \"cocotb_init libfli.so\" -trace_foreign 3
+VSIM_ARGS += -foreign \"cocotb_init libfli.$(LIB_EXT)\" -trace_foreign 3
 else
 VSIM_ARGS += -pli libvpi.$(LIB_EXT)
 endif
@@ -98,7 +98,7 @@ OLD_PATH := $(shell echo "$(PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/
 
 LIB_LOAD := PATH=$(MINGW_BIN_DIR):$(OLD_PATH):$(LIB_DIR)
 NEW_PYTHONPATH := $(shell echo "$(PYTHONPATH)" | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):\//\/\1\//g' -e 's/;/:/g')
-INT_LIBS := $(COCOTB_VPI_LIB)
+INT_LIBS := $(COCOTB_VPI_LIB) $(COCOTB_FLI_LIB)
 else
 LIB_LOAD := LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)
 NEW_PYTHONPATH := $(PYTHONPATH)

--- a/makefiles/simulators/Makefile.modelsim
+++ b/makefiles/simulators/Makefile.modelsim
@@ -55,23 +55,23 @@ endif
 .PHONY : $(SIM_BUILD)/runsim.do
 
 $(SIM_BUILD)/runsim.do : $(VHDL_SOURCES) $(VERILOG_SOURCES) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)
-	echo "if [file exists work] {vdel -all}" > $@
-	echo "vlib work" >> $@
+	@echo "if [file exists work] {vdel -all}" > $@
+	@echo "vlib work" >> $@
 ifneq ($(VHDL_SOURCES),)    
-	echo "vcom $(VCOM_ARGS) $(VHDL_SOURCES)" >> $@    
+	@echo "vcom $(VCOM_ARGS) $(VHDL_SOURCES)" >> $@    
 endif
 ifneq ($(VERILOG_SOURCES),)
-	echo "vlog -timescale 1ns/100ps -mfcu +acc=rmb -sv $(VLOG_ARGS) $(VERILOG_SOURCES)" >> $@
+	@echo "vlog -timescale 1ns/100ps -mfcu +acc=rmb -sv $(VLOG_ARGS) $(VERILOG_SOURCES)" >> $@
 endif
-	echo "vsim $(VSIM_ARGS) $(TOPLEVEL)" >> $@
+	@echo "vsim $(VSIM_ARGS) $(TOPLEVEL)" >> $@
 ifeq ($(WAVES),1)
-	echo "log -recursive /*" >> $@
+	@echo "log -recursive /*" >> $@
 endif
 ifeq ($(GUI),1)
-	echo "add wave -recursive /*" >> $@
+	@echo "add wave -recursive /*" >> $@
 else
-	echo "run -all" >> $@
-	echo "quit" >> $@
+	@echo "run -all" >> $@
+	@echo "quit" >> $@
 endif
 
 # auto-detect modelsim dir from system path

--- a/makefiles/simulators/Makefile.modelsim
+++ b/makefiles/simulators/Makefile.modelsim
@@ -99,16 +99,12 @@ OLD_PATH := $(shell echo "$(PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/
 
 LIB_LOAD := PATH=$(MINGW_BIN_DIR):$(OLD_PATH):$(LIB_DIR)
 NEW_PYTHONPATH := $(shell echo "$(PYTHONPATH)" | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):\//\/\1\//g' -e 's/;/:/g')
-INT_LIBS := $(COCOTB_VPI_LIB) $(COCOTB_FLI_LIB)
 else
 LIB_LOAD := LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)
 NEW_PYTHONPATH := $(PYTHONPATH)
-INT_LIBS := $(COCOTB_VPI_LIB) $(COCOTB_FLI_LIB)
 endif
 
-# Depending on the version of modelsim the interfaces that it supports can change
-# Append or remove values to INT_LIBS depenending on your license
-results.xml: $(SIM_BUILD)/runsim.do $(COCOTB_LIBS) $(INT_LIBS)
+results.xml: $(SIM_BUILD)/runsim.do $(COCOTB_LIBS) $(COCOTB_VPI_LIB) $(COCOTB_FLI_LIB)
 	cd $(SIM_BUILD) && $(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(NEW_PYTHONPATH) \
 	$(SIM_CMD) -do runsim.do 2>&1 | tee sim.log

--- a/makefiles/simulators/Makefile.modelsim
+++ b/makefiles/simulators/Makefile.modelsim
@@ -54,7 +54,7 @@ endif
 
 $(SIM_BUILD)/runsim.do : $(VHDL_SOURCES) $(VERILOG_SOURCES) $(CUSTOM_SIM_DEPS) | $(SIM_BUILD)
 	echo "if [file exists work] {vdel -all}" > $@
-	echo "vlib work" > $@
+	echo "vlib work" >> $@
 ifneq ($(VHDL_SOURCES),)    
 	echo "vcom $(VCOM_ARGS) $(VHDL_SOURCES)" >> $@    
 endif

--- a/makefiles/simulators/Makefile.modelsim
+++ b/makefiles/simulators/Makefile.modelsim
@@ -44,8 +44,10 @@ endif
 
 ifeq ($(GPI_IMPL),vhpi)
 VSIM_ARGS += -foreign \"cocotb_init libfli.$(LIB_EXT)\" -trace_foreign 3
+COCOTB_LIBS += $(COCOTB_FLI_LIB)
 else
 VSIM_ARGS += -pli libvpi.$(LIB_EXT)
+COCOTB_LIBS += $(COCOTB_VPI_LIB)
 endif
 
 ifneq ($(GENERICS),)
@@ -104,7 +106,7 @@ LIB_LOAD := LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)
 NEW_PYTHONPATH := $(PYTHONPATH)
 endif
 
-results.xml: $(SIM_BUILD)/runsim.do $(COCOTB_LIBS) $(COCOTB_VPI_LIB) $(COCOTB_FLI_LIB)
+results.xml: $(SIM_BUILD)/runsim.do $(COCOTB_LIBS)
 	cd $(SIM_BUILD) && $(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(NEW_PYTHONPATH) \
 	$(SIM_CMD) -do runsim.do 2>&1 | tee sim.log


### PR DESCRIPTION
Added support for FLI under windows.

However, there seem to be some issues:
- The endian swapper example doesn't run under windows when TOPLEVEL_LANG=vhdl.
- Added a VHDL version of the adder example. This runs fine, except when GENERICS="DATA_WIDTH=8" (Fatal: (SIGSEGV) Bad handle or reference)
- Enabled running 'mean' example using FLI. This errors out because DATA_WIDTH constant from package cannot be found.

Would be great if you could look into this.
Thanks!   