### PR TITLE
adding vpiNetArray support (same as vpiRegArray)

### DIFF
--- a/include/vpi_user.h
+++ b/include/vpi_user.h
@@ -61,6 +61,7 @@ typedef uint32_t *vpiHandle;
 #define vpiReg                 48   /* scalar or vector reg */
 #define vpiRegBit              49   /* bit of vector reg */
 #define vpiParameter           41   /* module parameter */
+#define vpiNetArray 	       114
 #define vpiRegArray            116  /* multidimensional reg */
 #define vpiStructVar           618
 #define vpiInterface           601

--- a/lib/vpi/VpiImpl.cpp
+++ b/lib/vpi/VpiImpl.cpp
@@ -86,6 +86,7 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl, std::string &n
         case vpiReg:
         case vpiParameter:
         case vpiRegArray:
+        case vpiNetArray:
         case vpiEnumNet:
             new_obj = new VpiSignalObjHdl(this, new_hdl);
             break;


### PR DESCRIPTION
as discussed in #218 adding vpiNetArray to acceptable types.

This does still generate a warning when initially accessing the multidimensional handles, which probably should be suppressed as also discussed in #218