### PR TITLE
Enable cosim to build on Mac (Darwin)

### DIFF
--- a/examples/endian_swapper/cosim/Makefile
+++ b/examples/endian_swapper/cosim/Makefile
@@ -16,7 +16,7 @@ endif
 all: io_module.so _hal.so
 
 io_module.o: io.c io_module.h io.h
-	$(CC) $(GCC_FLAGS) -pthread -fno-strict-aliasing -O2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 \
+	$(CC) $(GCC_FLAGS) -fPIC -pthread -fno-strict-aliasing -O2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 \
 	-fexceptions --param=ssp-buffer-size=4 -D_GNU_SOURCE \
 	-fwrapv -DNDEBUG -I$(PYTHON_INCLUDEDIR) -c $< -o $@
 
@@ -26,7 +26,7 @@ io_module.so: io_module.o
 _hal.so: ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so
 	$(CC) -g -ldl -shared -fPIC -I$(shell pwd) $(PYTHON_LD_FLAGS) -I$(PYTHON_INCLUDEDIR) -I../hal ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so -o $@
 	if [ $(OS) = Darwin ]; then \
-		install_name_tool -change io_module.so $(PWD)/io_module.so $@; \
+		install_name_tool -change io_module.so $(shell pwd)/io_module.so $@; \
 	fi
 
 endian_swapper_hal_wrap.c: ../hal/endian_swapper_hal.h

--- a/examples/endian_swapper/cosim/Makefile
+++ b/examples/endian_swapper/cosim/Makefile
@@ -8,6 +8,10 @@ ifeq ($(ARCH),i686)
 	CC += -m32
 endif
 
+ifeq ($(OS),Darwin)
+PYTHON_LD_FLAGS += -undefined dynamic_lookup
+endif
+
 .PHONY: all
 all: io_module.so _hal.so
 
@@ -20,7 +24,10 @@ io_module.so: io_module.o
 	$(CC) -pthread -shared  $< -L$(PYTHON_LIBDIR) $(PYTHON_LD_FLAGS) -o $@
 
 _hal.so: ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so
-	$(CC) -g -ldl -shared -fPIC -I$(shell pwd) -I$(PYTHON_INCLUDEDIR) -I../hal ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so -o $@
+	$(CC) -g -ldl -shared -fPIC -I$(shell pwd) $(PYTHON_LD_FLAGS) -I$(PYTHON_INCLUDEDIR) -I../hal ../hal/endian_swapper_hal.c endian_swapper_hal_wrap.c io_module.so -o $@
+	if [ $(OS) = Darwin ]; then \
+		install_name_tool -change io_module.so $(PWD)/io_module.so $@; \
+	fi
 
 endian_swapper_hal_wrap.c: ../hal/endian_swapper_hal.h
 	$(SWIG) -python -outcurrentdir ../hal/endian_swapper_hal.h
@@ -28,6 +35,7 @@ endian_swapper_hal_wrap.c: ../hal/endian_swapper_hal.h
 .PHONY: clean
 clean:
 	-rm -rf hal.py*
+	-rm -rf _hal.so.*
 	-rm -rf *.so
 	-rm -rf *.o
 	-rm -rf endian_swapper_hal_wrap.c

--- a/include/vpi_user.h
+++ b/include/vpi_user.h
@@ -42,7 +42,7 @@
 extern "C" {
 #endif
 
-#if !defined(__linux__)
+#if !defined(__linux__) && !defined(__APPLE__)
 #ifndef VPI_DLLISPEC
 #define VPI_DLLISPEC __declspec(dllimport)
 #define VPI_DLL_LOCAL 1

--- a/lib/utils/cocotb_utils.c
+++ b/lib/utils/cocotb_utils.c
@@ -30,7 +30,7 @@
 #include <cocotb_utils.h>
 #include <stdio.h>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <dlfcn.h>
 #else
 #include <windows.h>
@@ -39,7 +39,7 @@
 void* utils_dyn_open(const char* lib_name)
 {
     void *ret = NULL;
-#ifndef __linux__
+#if ! defined(__linux__) && ! defined(__APPLE__)
     SetErrorMode(0);
     ret = LoadLibrary(lib_name);
     if (!ret) {
@@ -60,7 +60,7 @@ void* utils_dyn_open(const char* lib_name)
 void* utils_dyn_sym(void *handle, const char* sym_name)
 {
     void *entry_point;
-#ifndef __linux__
+#if ! defined(__linux__) && ! defined(__APPLE__)
     entry_point = GetProcAddress(handle, sym_name);
     if (!entry_point) {
         printf("Unable to find symbol %s\n", sym_name);

--- a/makefiles/Makefile.pylib.Darwin
+++ b/makefiles/Makefile.pylib.Darwin
@@ -1,0 +1,58 @@
+##############################################################################
+# Copyright (c) 2013 Potential Ventures Ltd
+# Copyright (c) 2013 SolarFlare Communications Inc
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Potential Ventures Ltd,
+#       SolarFlare Communications Inc nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+# All common pyhon related rules
+
+PYTHON_PREFIX = $(shell python-config --prefix)
+
+NATIVE_ARCH=$(shell uname -m)
+ARCH?=$(NATIVE_ARCH)
+
+# We might work with other Python versions
+PYTHON_MAJOR_VERSION?=$(shell python -c "from __future__ import print_function; import sys; print(sys.version_info.major)")
+PYTHON_MINOR_VERSION?=$(shell python -c "from __future__ import print_function; import sys; print(sys.version_info.minor)")
+PYTHON_VERSION?=$(shell python -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_version())')
+
+PYTHON_LIBDIR:=$(shell python -c 'from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')
+PYTHON_DYNLIBDIR:=$(shell python -c 'from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_config_var("DESTSHARED"))')
+
+# Nasty hack but there's no way in Python properly get the directories for 32-bit Python on a 64-bit system
+# TODO: Under OSX we can use "export VERSIONER_PYTHON_PREFER_32_BIT=yes", no Linux equivalent though
+ifneq ($(NATIVE_ARCH),$(ARCH))
+    PYTHON_LIBDIR:=$(subst 64,,$(PYTHON_LIBDIR))
+    PYTHON_DYNLIBDIR:=$(subst 64,,$(PYTHON_DYNLIBDIR))
+endif
+
+# Since we don't know which modules we might need or whether the simulator
+# we're using passes the RTLD_GLOBAL to dlopen or whether the OS supports
+# is we simply link against all dynamic libraries in the Python installation
+PYLIBS = $(shell python-config --libs)
+
+PYTHON_INCLUDEDIR := $(shell python -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())')
+PYTHON_DYN_LIB = libpython$(PYTHON_VERSION).dylib


### PR DESCRIPTION
OS X 10.10.2
Darwin 14.1.0
gcc points to Apple LLVM version 6.0 (clang-600.0.57)
-Added "-undefined dynamic_lookup" to hal linker options
-Changed __linux__ ifdefs to also include __APPLE__
-Added a Makefile for Darwin pointing to libpython$(PYTHON_VERSION).dylib
