### PR TITLE
Pep8 compliance

### DIFF
--- a/cocotb/ANSI.py
+++ b/cocotb/ANSI.py
@@ -28,7 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 '''
     Some constants for doing ANSI stuff.
 '''
-
+# flake8: noqa (skip this file for flake8: pypi.python.org/pypi/flake8)
 _ESCAPE = "\033["
 
 

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -70,9 +70,11 @@ fork = scheduler.add
 # FIXME is this really required?
 _rlock = threading.RLock()
 
+
 def mem_debug(port):
     import cocotb.memdebug
     cocotb.memdebug.start(port)
+
 
 def _initialise_testbench(root_name):
     """
@@ -89,7 +91,6 @@ def _initialise_testbench(root_name):
     if memcheck_port is not None:
         mem_debug(int(memcheck_port))
 
-
     exec_path = os.getenv('SIM_ROOT')
     if exec_path is None:
         exec_path = 'Unknown'
@@ -98,7 +99,8 @@ def _initialise_testbench(root_name):
     if version is None:
         log.info("Unable to determine Cocotb version from %s" % exec_path)
     else:
-        log.info("Running tests with Cocotb v%s from %s" % (version, exec_path))
+        log.info("Running tests with Cocotb v%s from %s" %
+                 (version, exec_path))
 
     # Create the base handle type
 
@@ -138,6 +140,7 @@ def _initialise_testbench(root_name):
     _rlock.release()
     return True
 
+
 def _sim_event(level, message):
     """Function that can be called externally to signal an event"""
     SIM_INFO = 0
@@ -147,11 +150,15 @@ def _sim_event(level, message):
 
     if level is SIM_TEST_FAIL:
         scheduler.log.error("Failing test at simulator request")
-        scheduler.finish_test(TestFailure("Failure from external source: %s" % message))
+        scheduler.finish_test(TestFailure("Failure from external source: %s" %
+                              message))
     elif level is SIM_FAIL:
-        # We simply return here as the simulator will exit so no cleanup is needed
-        scheduler.log.error("Failing test at simulator request before test run completion: %s" % message)
-        scheduler.finish_scheduler(SimFailure("Failing test at simulator request before test run completion %s" % message))
+        # We simply return here as the simulator will exit
+        # so no cleanup is needed
+        msg = ("Failing test at simulator request before test run completion: "
+               "%s" % message)
+        scheduler.log.error(msg)
+        scheduler.finish_scheduler(SimFailure(msg))
     else:
         scheduler.log.error("Unsupported sim event")
 
@@ -171,4 +178,3 @@ def process_plusargs():
                 plusargs[name] = value
             else:
                 plusargs[option[1:]] = True
-

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -28,24 +28,26 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 
 from __future__ import print_function
-from math import log,ceil
+from math import log, ceil
 from cocotb.utils import get_python_integer_types
+
 
 def resolve(string):
     for char in BinaryValue._resolve_to_0:
         string = string.replace(char, "0")
     return string
 
+
 class BinaryRepresentation():
-    UNSIGNED         = 0
-    SIGNED_MAGNITUDE = 1
-    TWOS_COMPLEMENT  = 2
+    UNSIGNED         = 0  # noqa
+    SIGNED_MAGNITUDE = 1  # noqa
+    TWOS_COMPLEMENT  = 2  # noqa
 
 
 class BinaryValue(object):
     """Represenatation of values in binary format.
 
-    The underlying value can be set or accessed using three aliasing attributes,
+    The underlying value can be set or accessed using three aliasing attributes
 
         - BinaryValue.integer is an integer
         - BinaryValue.signed_integer is a signed integer
@@ -64,19 +66,20 @@ class BinaryValue(object):
     '*'
 
     """
-    _resolve_to_0    = "xXzZuU"
-    _permitted_chars = "xXzZuU" + "01"
+    _resolve_to_0    = "xXzZuU"  # noqa
+    _permitted_chars = "xXzZuU" + "01"  # noqa
 
-
-    def __init__(self, value=None, bits=None, bigEndian=True, binaryRepresentation=BinaryRepresentation.UNSIGNED):
+    def __init__(self, value=None, bits=None, bigEndian=True,
+                 binaryRepresentation=BinaryRepresentation.UNSIGNED):
         """
         Kwagrs:
             Value (string or int or long): value to assign to the bus
 
-            bits (int): Number of bits to use for the underlying binary representation
+            bits (int): Number of bits to use for the underlying binary
+                        representation
 
-            bigEndian (bool): Interpret the binary as big-endian when converting
-                                to/from a string buffer.
+            bigEndian (bool): Interpret the binary as big-endian when
+                                converting to/from a string buffer.
         """
         self._str = ""
         self._bits = bits
@@ -87,7 +90,7 @@ class BinaryValue(object):
                             BinaryRepresentation.SIGNED_MAGNITUDE : self._convert_to_signed_mag ,
                             BinaryRepresentation.TWOS_COMPLEMENT  : self._convert_to_twos_comp  ,
                             }
-    
+
         self._convert_from = {
                             BinaryRepresentation.UNSIGNED         : self._convert_from_unsigned   ,
                             BinaryRepresentation.SIGNED_MAGNITUDE : self._convert_from_signed_mag ,
@@ -113,15 +116,16 @@ class BinaryValue(object):
             except ValueError:
                 self.buff = value
 
-    def _convert_to_unsigned(self,x):
+    def _convert_to_unsigned(self, x):
         x = bin(x)
-        if x[0]=='-':
-            raise ValueError('Attempt to assigned negative number to unsigned BinaryValue')
+        if x[0] == '-':
+            raise ValueError('Attempt to assigned negative number to unsigned '
+                             'BinaryValue')
         return self._adjust_unsigned(x[2:])
-                
-    def _convert_to_signed_mag(self,x):
+
+    def _convert_to_signed_mag(self, x):
         x = bin(x)
-        if x[0]=='-':
+        if x[0] == '-':
             binstr = self._adjust_signed_mag('1' + x[3:])
         else:
             binstr = self._adjust_signed_mag('0' + x[2:])
@@ -129,39 +133,38 @@ class BinaryValue(object):
             binstr = binstr[::-1]
         return binstr
 
-    def _convert_to_twos_comp(self,x):
+    def _convert_to_twos_comp(self, x):
         if x < 0:
-            ceil_log2 = int(ceil(log(abs(x),2)))
-            binstr = bin(2**(ceil_log2+1)+x)[2:]
+            ceil_log2 = int(ceil(log(abs(x), 2)))
+            binstr = bin(2 ** (ceil_log2 + 1) + x)[2:]
             binstr = self._adjust_twos_comp(binstr)
-            pass
         else:
             binstr = self._adjust_twos_comp('0' + bin(x)[2:])
         if self.big_endian:
             binstr = binstr[::-1]
         return binstr
-    
-    def _convert_from_unsigned(self,x):
+
+    def _convert_from_unsigned(self, x):
         return int(resolve(x), 2)
-    
-    def _convert_from_signed_mag(self,x):
+
+    def _convert_from_signed_mag(self, x):
         rv = int(resolve(self._str[1:]), 2)
         if self._str[0] == '1':
             rv = rv * -1
         return rv
-    
-    def _convert_from_twos_comp(self,x):
-        if x[0]=='1':
+
+    def _convert_from_twos_comp(self, x):
+        if x[0] == '1':
             binstr = x[1:]
             binstr = self._invert(binstr)
-            rv     = int(binstr,2) + 1
+            rv = int(binstr, 2) + 1
             if x[0] == '1':
                 rv = rv * -1
         else:
             rv = int(resolve(x), 2)
         return rv
-    
-    def _invert(self,x):
+
+    def _invert(self, x):
         inverted = ''
         for bit in x:
             if bit == '0':
@@ -171,38 +174,40 @@ class BinaryValue(object):
             else:
                 inverted = inverted + bit
         return inverted
-    
-    def _adjust_unsigned(self,x):
+
+    def _adjust_unsigned(self, x):
         if self._bits is None:
             return x
         l = len(x)
         if l <= self._bits:
             if self.big_endian:
-                rv = x + '0' * (self._bits-l)
+                rv = x + '0' * (self._bits - l)
             else:
-                rv = '0' * (self._bits-l) + x
+                rv = '0' * (self._bits - l) + x
         elif l > self._bits:
-            print("WARNING truncating value to match requested number of bits (%d -> %d)" % (l,self._bits))
+            print("WARNING truncating value to match requested number of bits "
+                  "(%d -> %d)" % (l, self._bits))
             if self.big_endian:
                 rv = x[l - self._bits:]
             else:
                 rv = x[:l - self._bits]
         return rv
 
-    def _adjust_signed_mag(self,x):
+    def _adjust_signed_mag(self, x):
         """Pad/truncate the bit string to the correct length"""
         if self._bits is None:
             return x
         l = len(x)
         if l <= self._bits:
             if self.big_endian:
-                rv = x[:-1] + '0' * (self._bits-1-l)
+                rv = x[:-1] + '0' * (self._bits - 1 - l)
                 rv = rv + x[-1]
             else:
-                rv = '0' * (self._bits-1-l) + x[1:]
+                rv = '0' * (self._bits - 1 - l) + x[1:]
                 rv = x[0] + rv
         elif l > self._bits:
-            print("WARNING truncating value to match requested number of bits (%d -> %d)" % (l,self._bits))
+            print("WARNING truncating value to match requested number of bits "
+                  "(%d -> %d)" % (l, self._bits))
             if self.big_endian:
                 rv = x[l - self._bits:]
             else:
@@ -210,22 +215,23 @@ class BinaryValue(object):
         else:
             rv = x
         return rv
-        
-    def _adjust_twos_comp(self,x):
+
+    def _adjust_twos_comp(self, x):
         if self._bits is None:
             return x
         l = len(x)
         if l <= self._bits:
             if self.big_endian:
-                rv = x +  x[-1] * (self._bits-l)
+                rv = x + x[-1] * (self._bits - l)
             else:
-                rv = x[0] * (self._bits-l) + x
+                rv = x[0] * (self._bits - l) + x
         elif l > self._bits:
-            print("WARNING truncating value to match requested number of bits (%d -> %d)" % (l,self._bits))
+            print("WARNING truncating value to match requested number of bits "
+                  "(%d -> %d)" % (l, self._bits))
             if self.big_endian:
                 rv = x[l - self._bits:]
             else:
-                rv = x[:-(l-self._bits)]
+                rv = x[:-(l - self._bits)]
         else:
             rv = x
         return rv
@@ -242,14 +248,17 @@ class BinaryValue(object):
         if (ival & signbit) == 0:
             return ival
         else:
-            return -1 * (1+(int(~ival) & (signbit - 1)))
+            return -1 * (1 + (int(~ival) & (signbit - 1)))
 
     def set_value(self, integer):
         self._str = self._convert_to[self.binaryRepresentation](integer)
 
-    value = property(get_value, set_value, None, "Integer access to the value *** deprecated ***")
-    integer = property(get_value, set_value, None, "Integer access to the value")
-    signed_integer = property(get_value_signed, set_value, None, "Signed integer access to the value")
+    value = property(get_value, set_value, None,
+                     "Integer access to the value *** deprecated ***")
+    integer = property(get_value, set_value, None,
+                       "Integer access to the value")
+    signed_integer = property(get_value_signed, set_value, None,
+                              "Signed integer access to the value")
 
     def get_buff(self):
         """Attribute self.buff represents the value as a binary string buffer
@@ -274,7 +283,7 @@ class BinaryValue(object):
     def get_hex_buff(self):
         bstr = self.get_buff()
         hstr = '%0*X' % ((len(bstr) + 3) // 4, int(bstr, 2))
-        return hstr    
+        return hstr
 
     def set_buff(self, buff):
         self._str = ""
@@ -292,33 +301,38 @@ class BinaryValue(object):
         l = len(self._str)
         if l < self._bits:
             if self.big_endian:
-                self._str = self._str + "0" * (self._bits-l)
+                self._str = self._str + "0" * (self._bits - l)
             else:
-                self._str = "0" * (self._bits-l) + self._str
+                self._str = "0" * (self._bits - l) + self._str
         elif l > self._bits:
-            print("WARNING truncating value to match requested number of bits (%d)" % l)
+            print("WARNING truncating value to match requested number of bits "
+                  " (%d)" % l)
             self._str = self._str[l - self._bits:]
 
-    buff = property(get_buff, set_buff, None, "Access to the value as a buffer")
+    buff = property(get_buff, set_buff, None,
+                    "Access to the value as a buffer")
 
     def get_binstr(self):
-        """Attribute binstr is the binary representation stored as a string of 1s and 0s"""
+        """Attribute binstr is the binary representation stored as a string of
+        1s and 0s"""
         return self._str
 
     def set_binstr(self, string):
         for char in string:
             if char not in BinaryValue._permitted_chars:
-                raise ValueError("Attempting to assign character %s to a %s" % (char, self.__class__.__name__))
+                raise ValueError("Attempting to assign character %s to a %s" %
+                                 (char, self.__class__.__name__))
         self._str = string
         self._adjust()
 
-    binstr = property(get_binstr, set_binstr, None, "Access to the binary string")
+    binstr = property(get_binstr, set_binstr, None,
+                      "Access to the binary string")
 
     def hex(self):
         try:
             return hex(self.get_value())
         except:
-            return hex(int(self.binstr,2))
+            return hex(int(self.binstr, 2))
 
     def __le__(self, other):
         self.assign(other)
@@ -343,7 +357,8 @@ class BinaryValue(object):
 
         """
         for char in self._str:
-            if char == "1": return True
+            if char == "1":
+                return True
         return False
 
     def __cmp__(self, other):
@@ -408,7 +423,7 @@ class BinaryValue(object):
         """Preserves X values"""
         self.binstr = self.binstr[-other:] + self.binstr[:-other]
         return self
-    
+
     def __invert__(self):
         """Preserves X values"""
         self.binstr = self._invert(self.binstr)
@@ -416,79 +431,88 @@ class BinaryValue(object):
 
     def __len__(self):
         return len(self.binstr)
-    
+
     def __getitem__(self, key):
-        ''' BinaryValue uses verilog/vhdl style slices as opposed to python style'''
+        ''' BinaryValue uses verilog/vhdl style slices as opposed to python
+        style'''
         if isinstance(key, slice):
             first, second = key.start, key.stop
             if self.big_endian:
                 if first < 0 or second < 0:
-                    raise IndexError('BinaryValue does not support negative indices')
-                if second > self._bits-1:
+                    raise IndexError('BinaryValue does not support negative '
+                                     'indices')
+                if second > self._bits - 1:
                     raise IndexError('High index greater than number of bits.')
                 if first > second:
-                    raise IndexError('Big Endian indices must be specified low to high')
-                _binstr = self.binstr[first:(second+1)]
-                pass
+                    raise IndexError('Big Endian indices must be specified '
+                                     'low to high')
+                _binstr = self.binstr[first:(second + 1)]
             else:
                 if first < 0 or second < 0:
-                    raise IndexError('BinaryValue does not support negative indices')
-                if first > self._bits-1:
+                    raise IndexError('BinaryValue does not support negative '
+                                     'indices')
+                if first > self._bits - 1:
                     raise IndexError('High index greater than number of bits.')
                 if second > first:
-                    raise IndexError('Litte Endian indices must be specified high to low')
+                    raise IndexError('Litte Endian indices must be specified '
+                                     'high to low')
                 high = self._bits - second
-                low  = self._bits - 1 - first
+                low = self._bits - 1 - first
                 _binstr = self.binstr[low:high]
-                pass
         else:
             index = key
-            if index > self._bits-1:
+            if index > self._bits - 1:
                 raise IndexError('Index greater than number of bits.')
             _binstr = self.binstr[index]
-        rv = BinaryValue(bits=len(_binstr),bigEndian=self.big_endian,binaryRepresentation=self.binaryRepresentation)
+        rv = BinaryValue(bits=len(_binstr), bigEndian=self.big_endian,
+                         binaryRepresentation=self.binaryRepresentation)
         rv.set_binstr(_binstr)
         return rv
-    
+
     def __setitem__(self, key, val):
-        ''' BinaryValue uses verilog/vhdl style slices as opposed to python style'''
-        if not isinstance(val,str):
+        ''' BinaryValue uses verilog/vhdl style slices as opposed to python
+        style'''
+        if not isinstance(val, str):
             raise TypeError('BinaryValue slices only accept string values')
         if isinstance(key, slice):
             first, second = key.start, key.stop
             if self.big_endian:
                 if first < 0 or second < 0:
-                    raise IndexError('BinaryValue does not support negative indices')
-                if second > self._bits-1:
+                    raise IndexError('BinaryValue does not support negative '
+                                     'indices')
+                if second > self._bits - 1:
                     raise IndexError('High index greater than number of bits.')
                 if first > second:
-                    raise IndexError('Big Endian indices must be specified low to high')
-                if len(val) > (second+1-first):
-                    raise ValueError("String length must be equal to slice length")
+                    raise IndexError('Big Endian indices must be specified '
+                                     'low to high')
+                if len(val) > (second + 1 - first):
+                    raise ValueError('String length must be equal to slice '
+                                     'length')
                 slice_1 = self.binstr[:first]
-                slice_2 = self.binstr[second+1:]
+                slice_2 = self.binstr[second + 1:]
                 self.binstr = slice_1 + val + slice_2
-                pass
             else:
                 if first < 0 or second < 0:
-                    raise IndexError('BinaryValue does not support negative indices')
-                if first > self._bits-1:
+                    raise IndexError('BinaryValue does not support negative '
+                                     'indices')
+                if first > self._bits - 1:
                     raise IndexError('High index greater than number of bits.')
                 if second > first:
-                    raise IndexError('Litte Endian indices must be specified high to low')
+                    raise IndexError('Litte Endian indices must be specified '
+                                     'high to low')
                 high = self._bits - second
-                low  = self._bits - 1 - first
+                low = self._bits - 1 - first
                 if len(val) > (high - low):
-                    raise ValueError("String length must be equal to slice length")
-                slice_1 = self.binstr[:low] 
+                    raise ValueError('String length must be equal to slice '
+                                     'length')
+                slice_1 = self.binstr[:low]
                 slice_2 = self.binstr[high:]
                 self.binstr = slice_1 + val + slice_2
-                pass
         else:
             index = key
-            if index > self._bits-1:
+            if index > self._bits - 1:
                 raise IndexError('Index greater than number of bits.')
-            self.binstr = self.binstr[:index] + val + self.binstr[index+1:]
+            self.binstr = self.binstr[:index] + val + self.binstr[index + 1:]
 
 if __name__ == "__main__":
     import doctest

--- a/cocotb/bus.py
+++ b/cocotb/bus.py
@@ -34,6 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 """
 from cocotb.result import TestError
 
+
 class Bus(object):
     """
         Wraps up a collection of signals
@@ -44,7 +45,7 @@ class Bus(object):
 
         for example a bus named "stream_in" with signals ["valid", "data"]
             dut.stream_in_valid
-            dut.stream_in_data            
+            dut.stream_in_data
 
         TODO:
             Support for struct/record ports where signals are member names
@@ -52,11 +53,13 @@ class Bus(object):
     def __init__(self, entity, name, signals, optional_signals=[]):
         """
         Args:
-            entity (SimHandle):   SimHandle instance to the entity containing the bus
-            name (str):           name of the bus. None for nameless bus, e.g.
-                                  bus-signals in an interface or a modport
-                                  (untested on struct/record, but could work here as well)
-            signals (list):       array of signal names
+            entity (SimHandle): SimHandle instance to the entity containing the
+                                bus
+            name (str):         name of the bus. None for nameless bus, e.g.
+                                bus-signals in an interface or a modport
+                                (untested on struct/record, but could work here
+                                as well)
+            signals (list):     array of signal names
 
         Kwargs:
             optiona_signals (list): array of optional signal names
@@ -86,16 +89,16 @@ class Bus(object):
                 setattr(self, signal, hdl)
                 self._signals[signal] = getattr(self, signal)
             else:
-                self._entity.log.debug("Ignoring optional missing signal %s on bus %s"
-                    % (signal, name))
-
+                self._entity.log.debug("Ignoring optional missing signal "
+                                       "%s on bus %s" % (signal, name))
 
     def drive(self, obj, strict=False):
         """
         Drives values onto the bus.
 
         Args:
-            obj (any type) : object with attribute names that match the bus signals
+            obj (any type) : object with attribute names that match the bus
+                             signals
 
         Kwargs:
             strict (bool)  : Check that all signals are being assigned
@@ -106,9 +109,12 @@ class Bus(object):
         for name, hdl in self._signals.items():
             if not hasattr(obj, name):
                 if strict:
-                    raise AttributeError("Unable to drive onto %s.%s because %s is missing attribute %s" %
-                        (self._entity.name, self._name, obj.__class__.__name__, name))
-                else: continue
+                    msg = ("Unable to drive onto %s.%s because %s is missing "
+                           "attribute %s" % self._entity.name, self._name,
+                           obj.__class__.__name__, name)
+                    raise AttributeError(msg)
+                else:
+                    continue
             val = getattr(obj, name)
             hdl <= val
 

--- a/cocotb/clock.py
+++ b/cocotb/clock.py
@@ -33,11 +33,14 @@ import cocotb
 from cocotb.log import SimLog
 from cocotb.triggers import Timer, RisingEdge
 
+
 class BaseClock(object):
     """Base class to derive from"""
     def __init__(self, signal):
         self.signal = signal
-        self.log = SimLog("cocotb.%s.%s" % (self.__class__.__name__, self.signal.name))
+        self.log = SimLog("cocotb.%s.%s" %
+                          (self.__class__.__name__, self.signal.name))
+
 
 class Clock(BaseClock):
     """

--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -43,18 +43,19 @@ import cocotb.ANSI as ANSI
 from pdb import set_trace
 
 # Column alignment
-_LEVEL_CHARS    = len("CRITICAL")
-_RECORD_CHARS   = 35
-_FILENAME_CHARS = 20
-_LINENO_CHARS   = 4
-_FUNCNAME_CHARS = 31
+_LEVEL_CHARS    = len("CRITICAL")  # noqa
+_RECORD_CHARS   = 35  # noqa
+_FILENAME_CHARS = 20  # noqa
+_LINENO_CHARS   = 4  # noqa
+_FUNCNAME_CHARS = 31  # noqa
+
 
 class SimBaseLog(logging.getLoggerClass()):
     def __init__(self, name):
         hdlr = logging.StreamHandler(sys.stdout)
         want_ansi = os.getenv("COCOTB_ANSI_OUTPUT")
         if want_ansi is None:
-            want_ansi = sys.stdout.isatty() # default to ANSI for TTYs
+            want_ansi = sys.stdout.isatty()  # default to ANSI for TTYs
         else:
             want_ansi = want_ansi == '1'
         if want_ansi:
@@ -72,6 +73,7 @@ class SimBaseLog(logging.getLoggerClass()):
 
 """ Need to play with this to get the path of the called back,
     construct our own makeRecord for this """
+
 
 class SimLog(object):
     def __init__(self, name, ident=None):
@@ -151,16 +153,18 @@ class SimLogFormatter(logging.Formatter):
     # Justify and truncate
     @staticmethod
     def ljust(string, chars):
-        if len(string) > chars: return ".." + string[(chars-2)*-1:]
+        if len(string) > chars:
+            return ".." + string[(chars - 2) * -1:]
         return string.ljust(chars)
 
     @staticmethod
     def rjust(string, chars):
-        if len(string) > chars: return ".." + string[(chars-2)*-1:]
+        if len(string) > chars:
+            return ".." + string[(chars - 2) * -1:]
         return string.rjust(chars)
 
     def _format(self, timeh, timel, level, record, msg):
-        simtime = "% 6d.%02dns" % ((timel/1000), (timel%1000)/10)
+        simtime = "% 6d.%02dns" % ((timel / 1000), (timel % 1000) / 10)
         prefix = simtime + ' ' + level + ' ' + \
             self.ljust(record.name, _RECORD_CHARS) + \
             self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS) + \
@@ -170,18 +174,18 @@ class SimLogFormatter(logging.Formatter):
         pad = "\n" + " " * (len(prefix))
         return prefix + pad.join(msg.split('\n'))
 
-
     def format(self, record):
         """pretify the log output, annotate with simulation time"""
-        if record.args: msg = record.msg % record.args
-        else:           msg = record.msg
+        if record.args:
+            msg = record.msg % record.args
+        else:
+            msg = record.msg
 
         msg = str(msg)
         level = record.levelname.ljust(_LEVEL_CHARS)
         timeh, timel = simulator.get_sim_time()
 
         return self._format(timeh, timel, level, record, msg)
-
 
 
 class SimColourLogFormatter(SimLogFormatter):
@@ -198,12 +202,14 @@ class SimColourLogFormatter(SimLogFormatter):
     def format(self, record):
         """pretify the log output, annotate with simulation time"""
 
-        if record.args: msg = record.msg % record.args
-        else:           msg = record.msg
+        if record.args:
+            msg = record.msg % record.args
+        else:
+            msg = record.msg
 
         msg = SimColourLogFormatter.loglevel2colour[record.levelno] % msg
-        level = SimColourLogFormatter.loglevel2colour[record.levelno] % \
-                                        record.levelname.ljust(_LEVEL_CHARS)
+        level = (SimColourLogFormatter.loglevel2colour[record.levelno] %
+                 record.levelname.ljust(_LEVEL_CHARS))
 
         timeh, timel = simulator.get_sim_time()
         return self._format(timeh, timel, level, record, msg)

--- a/cocotb/memdebug.py
+++ b/cocotb/memdebug.py
@@ -28,6 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 import cherrypy
 import dowser
 
+
 def start(port):
     cherrypy.tree.mount(dowser.Root())
     cherrypy.config.update({

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -47,14 +47,17 @@ if "COVERAGE" in os.environ:
     try:
         import coverage
     except ImportError as e:
-        sys.stderr.write("Coverage collection requested but coverage module not availble\n")
-        sys.stderr.write("Import error was: %s\n" % repr(e))
+        msg = ("Coverage collection requested but coverage module not availble"
+               "\n"
+               "Import error was: %s\n" % repr(e))
+        sys.stderr.write(msg)
 
 import cocotb
 import cocotb.ANSI as ANSI
 from cocotb.log import SimLog
 from cocotb.result import TestError, TestFailure, TestSuccess, SimFailure
 from cocotb.xunit_reporter import XUnitReporter
+
 
 def _my_import(name):
     mod = __import__(name)
@@ -90,16 +93,19 @@ class RegressionManager(object):
         self.skipped = 0
         self.failures = 0
         self.xunit = XUnitReporter()
-        self.xunit.add_testsuite(name="all", tests=repr(self.ntests), package="all")
+        self.xunit.add_testsuite(name="all", tests=repr(self.ntests),
+                                 package="all")
 
         if coverage is not None:
             self.log.info("Enabling coverage collection of Python code")
             self._cov = coverage.coverage(branch=True, omit=["*cocotb*"])
             self._cov.start()
 
-        self._dut = cocotb.handle.SimHandle(simulator.get_root_handle(self._root_name))
+        self._dut = cocotb.handle.SimHandle(simulator.get_root_handle(
+                                            self._root_name))
         if self._dut is None:
-            raise AttributeError("Can not find Root Handle (%s)" % self._root_name)
+            raise AttributeError("Can not find Root Handle (%s)" %
+                                 self._root_name)
 
         # Auto discovery
         for module_name in self._modules:
@@ -111,7 +117,7 @@ class RegressionManager(object):
                 for test in self._functions.rsplit(','):
                     if not hasattr(module, test):
                         raise AttributeError("Test %s doesn't exist in %s" %
-                            (test, module_name))
+                                             (test, module_name))
 
                     self._queue.append(getattr(module, test)(self._dut))
                     self.ntests += 1
@@ -124,32 +130,36 @@ class RegressionManager(object):
                         skip = test.skip
                     except TestError:
                         skip = True
-                        self.log.warning("Failed to initialise test %s" % thing.name)
+                        self.log.warning("Failed to initialise test %s" %
+                                         thing.name)
 
                     if skip:
                         self.log.info("Skipping test %s" % thing.name)
-                        self.xunit.add_testcase(name=thing.name, classname=module_name, time="0.0")
+                        self.xunit.add_testcase(name=thing.name,
+                                                classname=module_name,
+                                                time="0.0")
                         self.xunit.add_skipped()
-                        self.skipped += 1                        
+                        self.skipped += 1
                     else:
                         self._queue.append(test)
                         self.ntests += 1
 
-        self._queue.sort(key=lambda test: "%s.%s" % (test.module, test.funcname))
+        self._queue.sort(key=lambda test: "%s.%s" %
+                         (test.module, test.funcname))
 
         for valid_tests in self._queue:
             self.log.info("Found test %s.%s" %
-                        (valid_tests.module,
-                         valid_tests.funcname))
+                          (valid_tests.module,
+                           valid_tests.funcname))
 
     def tear_down(self):
         """It's the end of the world as we know it"""
         if self.failures:
             self.log.error("Failed %d out of %d tests (%d skipped)" %
-                (self.failures, self.count -1, self.skipped))
+                           (self.failures, self.count - 1, self.skipped))
         else:
-            self.log.info("Passed %d tests (%d skipped)"  %
-                (self.count-1, self.skipped))
+            self.log.info("Passed %d tests (%d skipped)" %
+                          (self.count - 1, self.skipped))
         if self._cov:
             self._cov.stop()
             self.log.info("Writing coverage data")
@@ -159,12 +169,11 @@ class RegressionManager(object):
         self.xunit.write()
         simulator.stop_simulator()
 
-
     def next_test(self):
         """Get the next test to run"""
-        if not self._queue: return None
+        if not self._queue:
+            return None
         return self._queue.pop(0)
-
 
     def handle_result(self, result):
         """Handle a test result
@@ -173,47 +182,63 @@ class RegressionManager(object):
 
         Args: result (TestComplete exception)
         """
-        self.xunit.add_testcase(name =self._running_test.funcname,
+        self.xunit.add_testcase(name=self._running_test.funcname,
                                 classname=self._running_test.module,
-                                time=repr(time.time() - self._running_test.start_time) )
+                                time=repr(time.time() -
+                                          self._running_test.start_time))
 
-        if isinstance(result, TestSuccess) and not self._running_test.expect_fail and not self._running_test.expect_error:
-            self.log.info("Test Passed: %s" % self._running_test.funcname)
+        running_test_funcname = self._running_test.funcname
 
-        elif isinstance(result, TestFailure) and self._running_test.expect_fail:
-            self.log.info("Test failed as expected: %s (result was %s)" % (
-                          self._running_test.funcname, result.__class__.__name__))
+        # Helper for logging result
+        def _result_was():
+            result_was = ("%s (result was %s)" %
+                          (running_test_funcname, result.__class__.__name__))
+            return result_was
 
-        elif isinstance(result, TestSuccess) and self._running_test.expect_error:
-            self.log.error("Test passed but we expected an error: %s (result was %s)" % (
-                           self._running_test.funcname, result.__class__.__name__))
-            self.xunit.add_failure(stdout=repr(str(result)), stderr="\n".join(self._running_test.error_messages))
+        if (isinstance(result, TestSuccess) and
+                not self._running_test.expect_fail and
+                not self._running_test.expect_error):
+            self.log.info("Test Passed: %s" % running_test_funcname)
+
+        elif (isinstance(result, TestFailure) and
+                self._running_test.expect_fail):
+            self.log.info("Test failed as expected: " + _result_was())
+
+        elif (isinstance(result, TestSuccess) and
+              self._running_test.expect_error):
+            self.log.error("Test passed but we expected an error: " +
+                           _result_was())
+            self.xunit.add_failure(stdout=repr(str(result)),
+                                   stderr="\n".join(
+                                   self._running_test.error_messages))
             self.failures += 1
 
         elif isinstance(result, TestSuccess):
-            self.log.error("Test passed but we expected a failure: %s (result was %s)" % (
-                           self._running_test.funcname, result.__class__.__name__))
-            self.xunit.add_failure(stdout=repr(str(result)), stderr="\n".join(self._running_test.error_messages))
+            self.log.error("Test passed but we expected a failure: " +
+                           _result_was())
+            self.xunit.add_failure(stdout=repr(str(result)),
+                                   stderr="\n".join(
+                                   self._running_test.error_messages))
             self.failures += 1
 
         elif isinstance(result, TestError) and self._running_test.expect_error:
-            self.log.info("Test errored as expected: %s (result was %s)" % (
-                          self._running_test.funcname, result.__class__.__name__))
+            self.log.info("Test errored as expected: " + _result_was())
 
         elif isinstance(result, SimFailure):
             if self._running_test.expect_error:
-                self.log.info("Test errored as expected: %s (result was %s)" % (
-                              self._running_test.funcname, result.__class__.__name__))
+                self.log.info("Test errored as expected: " + _result_was())
             else:
-                self.log.error("Test error has lead to simulator shuttting us down")
+                self.log.error("Test error has lead to simulator shuttting us "
+                               "down")
                 self.failures += 1
                 self.tear_down()
                 return
 
         else:
-            self.log.error("Test Failed: %s (result was %s)" % (
-                        self._running_test.funcname, result.__class__.__name__))
-            self.xunit.add_failure(stdout=repr(str(result)), stderr="\n".join(self._running_test.error_messages))
+            self.log.error("Test Failed: " + _result_was())
+            self.xunit.add_failure(stdout=repr(str(result)),
+                                   stderr="\n".join(
+                                   self._running_test.error_messages))
             self.failures += 1
 
         self.execute()
@@ -222,16 +247,16 @@ class RegressionManager(object):
         self._running_test = cocotb.regression.next_test()
         if self._running_test:
             # Want this to stand out a little bit
-            self.log.info("%sRunning test %d/%d:%s %s" % (
-               ANSI.BLUE_BG +ANSI.BLACK_FG,
-                    self.count, self.ntests,
-               ANSI.DEFAULT_FG + ANSI.DEFAULT_BG,
-                    self._running_test.funcname))
+            self.log.info("%sRunning test %d/%d:%s %s" %
+                          (ANSI.BLUE_BG + ANSI.BLACK_FG,
+                           self.count, self.ntests,
+                           ANSI.DEFAULT_FG + ANSI.DEFAULT_BG,
+                           self._running_test.funcname))
             if self.count is 1:
                 test = cocotb.scheduler.add(self._running_test)
             else:
                 test = cocotb.scheduler.new_test(self._running_test)
-            self.count+=1
+            self.count += 1
         else:
             self.tear_down()
 
@@ -345,7 +370,7 @@ class TestFactory(object):
         Generates exhasutive set of tests using the cartesian product of the
         possible keyword arguments.
 
-        The generated tests are appended to the namespace of the calling 
+        The generated tests are appended to the namespace of the calling
         module.
 
         Args:
@@ -364,25 +389,34 @@ class TestFactory(object):
 
         d = self.kwargs
 
-        for index, testoptions in enumerate( (dict(zip(d, v)) for v in product(*d.values())) ):
+        for index, testoptions in enumerate((
+                                            dict(zip(d, v)) for v in
+                                            product(*d.values())
+                                            )):
 
             name = "%s%s%s_%03d" % (prefix, self.name, postfix, index + 1)
             doc = "Automatically generated test\n\n"
 
             for optname, optvalue in testoptions.items():
                 if callable(optvalue):
-                    if not optvalue.__doc__: desc = "No docstring supplied"
-                    else: desc = optvalue.__doc__.split('\n')[0]
-                    doc += "\t%s: %s (%s)\n" % (optname, optvalue.__name__, desc)
+                    if not optvalue.__doc__:
+                        desc = "No docstring supplied"
+                    else:
+                        desc = optvalue.__doc__.split('\n')[0]
+                    doc += "\t%s: %s (%s)\n" % (optname, optvalue.__name__,
+                                                desc)
                 else:
                     doc += "\t%s: %s\n" % (optname, repr(optvalue))
 
-            cocotb.log.debug("Adding generated test \"%s\" to module \"%s\"" % (name, mod.__name__))
+            cocotb.log.debug("Adding generated test \"%s\" to module \"%s\"" %
+                             (name, mod.__name__))
             kwargs = {}
             kwargs.update(self.kwargs_constant)
             kwargs.update(testoptions)
             if hasattr(mod, name):
-                cocotb.log.error("Overwriting %s in module %s. This causes previously defined testcase "
-                                 "not to be run. Consider setting/changing name_postfix" % (name, mod))
-            setattr(mod, name, _create_test(self.test_function, name, doc, mod, *self.args, **kwargs))
-
+                cocotb.log.error("Overwriting %s in module %s. "
+                                 "This causes previously defined testcase "
+                                 "not to be run. Consider setting/changing "
+                                 "name_postfix" % (name, mod))
+            setattr(mod, name, _create_test(self.test_function, name, doc, mod,
+                                            *self.args, **kwargs))

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -28,8 +28,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 # TODO: Coule use cStringIO?
 import traceback
 import sys
-#from StringIO import StringIO
+# from StringIO import StringIO
 from io import StringIO, BytesIO
+
 
 def raise_error(obj, msg):
     """
@@ -52,6 +53,7 @@ def raise_error(obj, msg):
     exception.stderr.write(buff.getvalue())
     raise exception
 
+
 def create_error(obj, msg):
     """
     As above, but return the exception rather than raise it, simply to avoid
@@ -68,6 +70,7 @@ class ReturnValue(StopIteration):
     def __init__(self, retval):
         self.retval = retval
 
+
 class TestComplete(StopIteration):
     """
         Exceptions are used to pass test results around.
@@ -77,10 +80,18 @@ class TestComplete(StopIteration):
         self.stdout = StringIO()
         self.stderr = StringIO()
 
-class TestError(TestComplete): pass
 
-class TestFailure(TestComplete): pass
+class TestError(TestComplete):
+    pass
 
-class TestSuccess(TestComplete): pass
 
-class SimFailure(TestComplete): pass
+class TestFailure(TestComplete):
+    pass
+
+
+class TestSuccess(TestComplete):
+    pass
+
+
+class SimFailure(TestComplete):
+    pass

--- a/cocotb/scoreboard.py
+++ b/cocotb/scoreboard.py
@@ -60,19 +60,23 @@ class Scoreboard(object):
 
     @property
     def result(self):
-        """Determine the test result - do we have any pending data remaining?"""
+        """Determine the test result, do we have any pending data remaining?"""
         fail = False
         for monitor, expected_output in self.expected.items():
             if callable(expected_output):
-                self.log.debug("Can't check all data returned for %s since expected output is \
-                                callable function rather than a list" % str(monitor))
+                self.log.debug("Can't check all data returned for %s since "
+                               "expected output is callable function rather "
+                               "than a list" % str(monitor))
                 continue
             if len(expected_output):
-                self.log.warn("Still expecting %d transactions on %s" % (len(expected_output), str(monitor)))
+                self.log.warn("Still expecting %d transactions on %s" %
+                              (len(expected_output), str(monitor)))
                 for index, transaction in enumerate(expected_output):
-                    self.log.info("Expecting %d:\n%s" % (index, hexdump(str(transaction))))
+                    self.log.info("Expecting %d:\n%s" %
+                                  (index, hexdump(str(transaction))))
                     if index > 5:
-                        self.log.info("... and %d more to come" % (len(expected_output) - index - 1))
+                        self.log.info("... and %d more to come" %
+                                      (len(expected_output) - index - 1))
                         break
                 fail = True
         if fail:
@@ -80,7 +84,6 @@ class Scoreboard(object):
         if self.errors:
             return TestFailure("Errors were recorded during the test")
         return TestSuccess()
-
 
     def compare(self, got, exp, log, strict_type=True):
         """
@@ -92,9 +95,12 @@ class Scoreboard(object):
         # Compare the types
         if strict_type and type(got) != type(exp):
             self.errors += 1
-            log.error("Received transaction is a different type to expected transaction")
-            log.info("Got: %s but expected %s" % (str(type(got)), str(type(exp))))
-            if self._imm: raise TestFailure("Received transaction of wrong type")
+            log.error("Received transaction is a different type to expected "
+                      "transaction")
+            log.info("Got: %s but expected %s" %
+                     (str(type(got)), str(type(exp))))
+            if self._imm:
+                raise TestFailure("Received transaction of wrong type")
             return
         # Or convert to a string before comparison
         elif not strict_type:
@@ -111,53 +117,62 @@ class Scoreboard(object):
             log.info("Expected:\n" + hexdump(strexp))
             if not isinstance(exp, str):
                 try:
-                    for word in exp: log.info(str(word))
+                    for word in exp:
+                        log.info(str(word))
                 except:
                     pass
             log.info("Received:\n" + hexdump(strgot))
             if not isinstance(got, str):
                 try:
-                    for word in got: log.info(str(word))
+                    for word in got:
+                        log.info(str(word))
                 except:
                     pass
             log.warning("Difference:\n%s" % hexdiffs(strexp, strgot))
-            if self._imm: raise TestFailure("Received transaction differed from expected transaction")
+            if self._imm:
+                raise TestFailure("Received transaction differed from expected"
+                                  "transaction")
         else:
-            # Don't want to fail the test if we're passed something without __len__
+            # Don't want to fail the test
+            # if we're passed something without __len__
             try:
-                log.debug("Received expected transaction %d bytes" % (len(got)))
+                log.debug("Received expected transaction %d bytes" %
+                          (len(got)))
                 log.debug(repr(got))
-            except: pass
+            except:
+                pass
 
-
-
-
-    def add_interface(self, monitor, expected_output, compare_fn=None, reorder_depth=0, strict_type=True):
+    def add_interface(self, monitor, expected_output, compare_fn=None,
+                      reorder_depth=0, strict_type=True):
         """Add an interface to be scoreboarded.
 
-            Provides a function which the monitor will callback with received transactions
+            Provides a function which the monitor will callback with received
+            transactions
 
             Simply check against the expected output.
 
         """
-        # save a handle to the expected output so we can check if all expected data has
-        # been received at the end of a test.
+        # save a handle to the expected output so we can check if all expected
+        # data has been received at the end of a test.
         self.expected[monitor] = expected_output
 
         # Enforce some type checking as we only work with a real monitor
         if not isinstance(monitor, Monitor):
-            raise TypeError("Expected monitor on the interface but got %s" % (monitor.__class__.__name__))
+            raise TypeError("Expected monitor on the interface but got %s" %
+                            (monitor.__class__.__name__))
 
         if compare_fn is not None:
             if callable(compare_fn):
                 monitor.add_callback(compare_fn)
                 return
-            raise TypeError("Expected a callable compare function but got %s" % str(type(compare_fn)))
+            raise TypeError("Expected a callable compare function but got %s" %
+                            str(type(compare_fn)))
 
         self.log.info("Created with reorder_depth %d" % reorder_depth)
 
         def check_received_transaction(transaction):
-            """Called back by the monitor when a new transaction has been received"""
+            """Called back by the monitor when a new transaction has been
+            received"""
 
             log = logging.getLogger(self.log.name + '.' + monitor.name)
 
@@ -165,7 +180,7 @@ class Scoreboard(object):
                 exp = expected_output(transaction)
 
             elif len(expected_output):
-                for i in range(min((reorder_depth+1), len(expected_output))):
+                for i in range(min((reorder_depth + 1), len(expected_output))):
                     if expected_output[i] == transaction:
                         break
                 else:
@@ -173,9 +188,12 @@ class Scoreboard(object):
                 exp = expected_output.pop(i)
             else:
                 self.errors += 1
-                log.error("Received a transaction but wasn't expecting anything")
+                log.error("Received a transaction but wasn't expecting "
+                          "anything")
                 log.info("Got: %s" % (hexdump(str(transaction))))
-                if self._imm: raise TestFailure("Received a transaction but wasn't expecting anything")
+                if self._imm:
+                    raise TestFailure("Received a transaction but wasn't "
+                                      "expecting anything")
                 return
 
             self.compare(transaction, exp, log, strict_type=strict_type)

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -42,6 +42,7 @@ from cocotb.result import raise_error
 class TriggerException(Exception):
     pass
 
+
 class Trigger(object):
     """Base class to derive from"""
     def __init__(self):
@@ -57,11 +58,13 @@ class Trigger(object):
         self.primed = False
 
     def __del__(self):
-        """Ensure if a trigger drops out of scope we remove any pending callbacks"""
+        """Ensure if a trigger drops out of scope we remove any pending
+        callbacks"""
         self.unprime()
 
     def __str__(self):
         return self.__class__.__name__
+
 
 class PythonTrigger(Trigger):
     """Python triggers don't use GPI at all
@@ -84,9 +87,9 @@ class GPITrigger(Trigger):
         Trigger.__init__(self)
 
         # Required to ensure documentation can build
-        #if simulator is not None:
+        # if simulator is not None:
         #    self.cbhdl = simulator.create_callback(self)
-        #else:
+        # else:
         self.cbhdl = None
 
     def unprime(self):
@@ -116,13 +119,15 @@ class Timer(GPITrigger):
     def prime(self, callback):
         """Register for a timed callback"""
         if self.cbhdl is None:
-            self.cbhdl = simulator.register_timed_callback(self.time_ps, callback, self)
+            self.cbhdl = simulator.register_timed_callback(self.time_ps,
+                                                           callback, self)
             if self.cbhdl is None:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
         Trigger.prime(self)
 
     def __str__(self):
         return self.__class__.__name__ + "(%dps)" % self.time_ps
+
 
 class Edge(GPITrigger):
     """
@@ -135,13 +140,18 @@ class Edge(GPITrigger):
     def prime(self, callback):
         """Register notification of a value change via a callback"""
         if self.cbhdl is None:
-            self.cbhdl = simulator.register_value_change_callback(self.signal._handle, callback, 3, self)
+            self.cbhdl = simulator.register_value_change_callback(self.signal.
+                                                                  _handle,
+                                                                  callback,
+                                                                  3,
+                                                                  self)
             if self.cbhdl is None:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
         Trigger.prime(self)
 
     def __str__(self):
         return self.__class__.__name__ + "(%s)" % self.signal.name
+
 
 class _ReadOnly(GPITrigger):
     """
@@ -162,8 +172,11 @@ class _ReadOnly(GPITrigger):
         return self.__class__.__name__ + "(readonly)"
 
 _ro = _ReadOnly()
+
+
 def ReadOnly():
     return _ro
+
 
 class _ReadWrite(GPITrigger):
     """
@@ -175,8 +188,8 @@ class _ReadWrite(GPITrigger):
 
     def prime(self, callback):
         if self.cbhdl is None:
-            #import pdb
-            #pdb.set_trace()
+            # import pdb
+            # pdb.set_trace()
             self.cbhdl = simulator.register_rwsynch_callback(callback, self)
             if self.cbhdl is None:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
@@ -186,8 +199,11 @@ class _ReadWrite(GPITrigger):
         return self.__class__.__name__ + "(readwritesync)"
 
 _rw = _ReadWrite()
+
+
 def ReadWrite():
     return _rw
+
 
 class _NextTimeStep(GPITrigger):
     """
@@ -207,26 +223,34 @@ class _NextTimeStep(GPITrigger):
         return self.__class__.__name__ + "(nexttimestep)"
 
 _nxts = _NextTimeStep()
+
+
 def NextTimeStep():
     return _nxts
+
 
 class _RisingOrFallingEdge(Edge):
     def __init__(self, signal, rising):
         Edge.__init__(self, signal)
-        if rising == True:
+        if rising is True:
             self._rising = 1
         else:
             self._rising = 2
 
     def prime(self, callback):
         if self.cbhdl is None:
-            self.cbhdl = simulator.register_value_change_callback(self.signal._handle, callback, self._rising, self)
+            self.cbhdl = simulator.register_value_change_callback(self.signal.
+                                                                  _handle,
+                                                                  callback,
+                                                                  self._rising,
+                                                                  self)
             if self.cbhdl is None:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
         Trigger.prime(self)
 
     def __str__(self):
         return self.__class__.__name__ + "(%s)" % self.signal.name
+
 
 class _RisingEdge(_RisingOrFallingEdge):
     """
@@ -235,8 +259,10 @@ class _RisingEdge(_RisingOrFallingEdge):
     def __init__(self, signal):
         _RisingOrFallingEdge.__init__(self, signal, rising=True)
 
+
 def RisingEdge(signal):
     return signal._r_edge
+
 
 class _FallingEdge(_RisingOrFallingEdge):
     """
@@ -245,8 +271,10 @@ class _FallingEdge(_RisingOrFallingEdge):
     def __init__(self, signal):
         _RisingOrFallingEdge.__init__(self, signal, rising=False)
 
+
 def FallingEdge(signal):
     return signal._f_edge
+
 
 class ClockCycles(Edge):
     """
@@ -267,11 +295,17 @@ class ClockCycles(Edge):
                     self._callback(self)
                     return
 
-            self.cbhdl = simulator.register_value_change_callback(self.signal._handle, _check, self)
+            self.cbhdl = simulator.register_value_change_callback(self.signal.
+                                                                  _handle,
+                                                                  _check,
+                                                                  self)
             if self.cbhdl is None:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
 
-        self.cbhdl = simulator.register_value_change_callback(self.signal._handle, _check, self)
+        self.cbhdl = simulator.register_value_change_callback(self.signal.
+                                                              _handle,
+                                                              _check,
+                                                              self)
         if self.cbhdl is None:
             raise_error(self, "Unable set up %s Trigger" % (str(self)))
         Trigger.prime(self)
@@ -289,13 +323,17 @@ class Combine(PythonTrigger):
     def __init__(self, *args):
         PythonTrigger.__init__(self)
         self._triggers = args
-        # TODO: check that trigger is an iterable containing only Trigger objects
+        # TODO: check that trigger is an iterable containing
+        # only Trigger objects
         try:
             for trigger in self._triggers:
                 if not isinstance(trigger, Trigger):
-                    raise TriggerException("All combined triggers must be instances of Trigger! Got: %s" % trigger.__class__.__name__)
+                    raise TriggerException("All combined triggers must be "
+                                           "instances of Trigger! Got: %s" %
+                                           trigger.__class__.__name__)
         except Exception:
-            raise TriggerException("%s requires a list of Trigger objects" % self.__class__.__name__)
+            raise TriggerException("%s requires a list of Trigger objects" %
+                                   self.__class__.__name__)
 
     def prime(self, callback):
         self._callback = callback
@@ -336,7 +374,6 @@ class _Event(PythonTrigger):
         self._callback(self)
 
 
-
 class Event(PythonTrigger):
     """
     Event to permit synchronisation between two coroutines
@@ -365,7 +402,8 @@ class Event(PythonTrigger):
             trigger()
 
     def wait(self):
-        """This can be yielded to block this coroutine until another wakes it"""
+        """This can be yielded to block this coroutine
+        until another wakes it"""
         return _Event(self)
 
     def clear(self):
@@ -408,7 +446,7 @@ class Lock(PythonTrigger):
     def __init__(self, name=""):
         PythonTrigger.__init__(self)
         self._pending_unprimed = []
-        self._pending_primed   = []
+        self._pending_primed = []
         self.name = name
         self.locked = False
 
@@ -429,11 +467,11 @@ class Lock(PythonTrigger):
         self._pending_unprimed.append(trig)
         return trig
 
-
     def release(self):
 
         if not self.locked:
-            raise_error(self, "Attempt to release an unacquired Lock %s" % (str(self)))
+            raise_error(self, "Attempt to release an unacquired Lock %s" %
+                        (str(self)))
 
         self.locked = False
 
@@ -446,8 +484,9 @@ class Lock(PythonTrigger):
         trigger()
 
     def __str__(self):
-        return self.__class__.__name__ + "(%s) [%s waiting]" % (
-                self.name, len(self._pending_primed))
+        return "%s(%s) [%s waiting]" % (str(self.__class__.__name__),
+                                        self.name,
+                                        len(self._pending_primed))
 
     def __nonzero__(self):
         """Provide boolean of a Lock"""
@@ -481,9 +520,9 @@ class _Join(PythonTrigger):
     def retval(self):
         return self._coroutine.retval
 
-    #def prime(self, callback):
-        #"""Register our calback for when the coroutine exits"""
-        #Trigger.prime(self)
+    # def prime(self, callback):
+        # """Register our calback for when the coroutine exits"""
+        # Trigger.prime(self)
 
     def __str__(self):
         return self.__class__.__name__ + "(%s)" % self._coroutine.__name__

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -31,16 +31,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 
 import ctypes
 
+
 # python2 to python3 helper functions
 def get_python_integer_types():
     try:
         isinstance(1, long)
     except NameError:
-        return (int,) # python 3
+        return (int,)  # python 3
     else:
-        return (int, long) # python 2
+        return (int, long)  # python 2
 
 # Ctypes helper functions
+
 
 def pack(ctypes_obj):
     """Convert a ctypes structure into a python string
@@ -53,7 +55,8 @@ def pack(ctypes_obj):
     Returns:
         New python string containing the bytes from memory holding ctypes_obj
     """
-    return ctypes.string_at(ctypes.addressof(ctypes_obj), ctypes.sizeof(ctypes_obj))
+    return ctypes.string_at(ctypes.addressof(ctypes_obj),
+                            ctypes.sizeof(ctypes_obj))
 
 
 def unpack(ctypes_obj, string, bytes=None):
@@ -70,8 +73,9 @@ def unpack(ctypes_obj, string, bytes=None):
     Raises:
         ValueError, MemoryError
 
-    If the length of the string is not the correct size for the memory footprint of the
-    ctypes structure then the bytes keyword argument must be used
+    If the length of the string is not the correct size for the memory
+    footprint of the ctypes structure then the bytes keyword argument must
+    be used
     """
     if bytes is None:
         if len(string) != ctypes.sizeof(ctypes_obj):
@@ -86,19 +90,17 @@ def unpack(ctypes_obj, string, bytes=None):
     ctypes.memmove(ctypes.addressof(ctypes_obj), string, bytes)
 
 
-
-
 import cocotb.ANSI as ANSI
 
 
 def _sane_color(x):
-    r=""
+    r = ""
     for i in x:
         j = ord(i)
         if (j < 32) or (j >= 127):
-            r+="."
+            r += "."
         else:
-            r+=i
+            r += i
     return r
 
 
@@ -106,35 +108,36 @@ def hexdump(x):
     """Hexdump a buffer"""
     # adapted from scapy.utils.hexdump
     rs = ""
-    x=str(x)
+    x = str(x)
     l = len(x)
     i = 0
     while i < l:
         rs += "%04x   " % i
         for j in range(16):
-            if i+j < l:
-                rs += "%02X " % ord(x[i+j])
+            if i + j < l:
+                rs += "%02X " % ord(x[i + j])
             else:
-                rs +=  "   "
-            if j%16 == 7:
+                rs += "   "
+            if j % 16 == 7:
                 rs += ""
         rs += "  "
-        rs += _sane_color(x[i:i+16]) + "\n"
+        rs += _sane_color(x[i:i + 16]) + "\n"
         i += 16
     return rs
 
-def hexdiffs(x,y):
+
+def hexdiffs(x, y):
     """Return a diff string showing differences between 2 binary strings"""
     # adapted from scapy.utils.hexdiff
 
     def sane(x):
-        r=""
+        r = ""
         for i in x:
             j = ord(i)
             if (j < 32) or (j >= 127):
-                r=r+"."
+                r = r + "."
             else:
-                r=r+i
+                r = r + i
         return r
 
     def highlight(string, colour=ANSI.YELLOW_FG):
@@ -142,46 +145,43 @@ def hexdiffs(x,y):
 
     rs = ""
 
-    x=str(x)[::-1]
-    y=str(y)[::-1]
-    SUBST=1
-    INSERT=1
-    d={}
-    d[-1,-1] = 0,(-1,-1)
+    x = str(x)[::-1]
+    y = str(y)[::-1]
+    SUBST = 1
+    INSERT = 1
+    d = {}
+    d[-1, -1] = 0, (-1, -1)
     for j in range(len(y)):
-        d[-1,j] = d[-1,j-1][0]+INSERT, (-1,j-1)
+        d[-1, j] = d[-1, j - 1][0] + INSERT, (-1, j - 1)
     for i in range(len(x)):
-        d[i,-1] = d[i-1,-1][0]+INSERT, (i-1,-1)
+        d[i, -1] = d[i - 1, -1][0] + INSERT, (i - 1, -1)
 
     for j in range(len(y)):
         for i in range(len(x)):
-            d[i,j] = min( ( d[i-1,j-1][0]+SUBST*(x[i] != y[j]), (i-1,j-1) ),
-                          ( d[i-1,j][0]+INSERT, (i-1,j) ),
-                          ( d[i,j-1][0]+INSERT, (i,j-1) ) )
-
+            d[i, j] = min((d[i-1, j-1][0] + SUBST*(x[i] != y[j]), (i-1, j-1)),
+                          (d[i - 1, j][0] + INSERT, (i - 1, j)),
+                          (d[i, j - 1][0] + INSERT, (i, j - 1)))
 
     backtrackx = []
     backtracky = []
-    i=len(x)-1
-    j=len(y)-1
+    i = len(x) - 1
+    j = len(y) - 1
     while not (i == j == -1):
-        i2,j2 = d[i,j][1]
+        i2, j2 = d[i, j][1]
         backtrackx.append(x[i2+1:i+1])
         backtracky.append(y[j2+1:j+1])
-        i,j = i2,j2
-
-
+        i, j = i2, j2
 
     x = y = i = 0
-    colorize = { 0: lambda x:x,
-                -1: lambda x:x,
-                 1: lambda x:x }
+    colorize = { 0: lambda x: x,  # noqa
+                -1: lambda x: x,  # noqa
+                 1: lambda x: x}  # noqa
 
-    dox=1
-    doy=0
+    dox = 1
+    doy = 0
     l = len(backtrackx)
     while i < l:
-        separate=0
+        separate = 0
         linex = backtrackx[i:i+16]
         liney = backtracky[i:i+16]
         xx = sum(len(k) for k in linex)
@@ -190,7 +190,7 @@ def hexdiffs(x,y):
             dox = 0
             doy = 1
         if dox and linex == liney:
-            doy=1
+            doy = 1
 
         if dox:
             xd = y
@@ -199,11 +199,11 @@ def hexdiffs(x,y):
                 j += 1
                 xd -= 1
             if dox != doy:
-                rs +=  highlight("%04x" % xd) + " "
+                rs += highlight("%04x" % xd) + " "
             else:
-                rs +=  highlight("%04x" % xd, colour=ANSI.CYAN_FG)  + " "
+                rs += highlight("%04x" % xd, colour=ANSI.CYAN_FG) + " "
             x += xx
-            line=linex
+            line = linex
         else:
             rs += "    "
         if doy:
@@ -212,12 +212,12 @@ def hexdiffs(x,y):
             while not liney[j]:
                 j += 1
                 yd -= 1
-            if doy-dox != 0:
+            if doy - dox != 0:
                 rs += " " + highlight("%04x" % yd)
             else:
-                rs +=  highlight("%04x" % yd, colour=ANSI.CYAN_FG)
+                rs += highlight("%04x" % yd, colour=ANSI.CYAN_FG)
             y += yy
-            line=liney
+            line = liney
         else:
             rs += "    "
 
@@ -225,16 +225,19 @@ def hexdiffs(x,y):
 
         cl = ""
         for j in range(16):
-            if i+j < l:
+            if i + j < l:
                 if line[j]:
                     if linex[j] != liney[j]:
-                        rs += highlight("%02X" % ord(line[j]), colour=ANSI.RED_FG)
+                        rs += highlight("%02X" % ord(line[j]),
+                                        colour=ANSI.RED_FG)
                     else:
                         rs += "%02X" % ord(line[j])
-                    if linex[j]==liney[j]:
-                        cl += highlight(_sane_color(line[j]), colour=ANSI.MAGENTA_FG)
+                    if linex[j] == liney[j]:
+                        cl += highlight(_sane_color(line[j]),
+                                        colour=ANSI.MAGENTA_FG)
                     else:
-                        cl += highlight(sane(line[j]), colour=ANSI.CYAN_BG+ANSI.BLACK_FG)
+                        cl += highlight(sane(line[j]),
+                                        colour=ANSI.CYAN_BG + ANSI.BLACK_FG)
                 else:
                     rs += "  "
                     cl += " "
@@ -243,17 +246,16 @@ def hexdiffs(x,y):
             if j == 7:
                 rs += " "
 
-
         rs += " " + cl + '\n'
 
         if doy or not yy:
-            doy=0
-            dox=1
+            doy = 0
+            dox = 1
             i += 16
         else:
             if yy:
-                dox=0
-                doy=1
+                dox = 0
+                doy = 1
             else:
                 i += 16
     return rs
@@ -262,14 +264,14 @@ def hexdiffs(x,y):
 if __name__ == "__main__":
     import random
     a = ""
-    for char in range(random.randint(250,500)):
-        a += chr(random.randint(0,255))
+    for char in range(random.randint(250, 500)):
+        a += chr(random.randint(0, 255))
     b = a
-    for error in range(random.randint(2,9)):
+    for error in range(random.randint(2, 9)):
         offset = random.randint(0, len(a))
-        b = b[:offset] + chr(random.randint(0,255)) + b[offset+1:]
+        b = b[:offset] + chr(random.randint(0, 255)) + b[offset+1:]
 
-    diff = hexdiffs(a,b)
+    diff = hexdiffs(a, b)
     print(diff)
 
     space = '\n' + (" " * 20)

--- a/cocotb/wavedrom.py
+++ b/cocotb/wavedrom.py
@@ -31,6 +31,7 @@ import cocotb
 from cocotb.bus import Bus
 from cocotb.triggers import RisingEdge, ReadOnly
 
+
 class Wavedrom(object):
     """
     Base class for a wavedrom compatible tracer
@@ -54,7 +55,8 @@ class Wavedrom(object):
 
         def _lastval(samples):
             for x in range(len(samples)-1, -1, -1):
-                if samples[x] not in "=.|": return samples[x]
+                if samples[x] not in "=.|":
+                    return samples[x]
             return None
 
         for name, hdl in self._hdls.items():
@@ -62,13 +64,18 @@ class Wavedrom(object):
             valstr = val.binstr.lower()
 
             # Decide what character to use to represent this signal
-            if len(valstr) == 1: char = valstr
-            elif "x" in valstr:  char = "x"
-            elif "u" in valstr:  char = "u"
-            elif "z" in valstr:  char = "z"
+            if len(valstr) == 1:
+                char = valstr
+            elif "x" in valstr:
+                char = "x"
+            elif "u" in valstr:
+                char = "u"
+            elif "z" in valstr:
+                char = "z"
             else:
-                if len(self._data[name]) and self._data[name][-1] == int(val) \
-                            and self._samples[name][-1] in "=.":
+                if (len(self._data[name]) and
+                        self._data[name][-1] == int(val) and
+                        self._samples[name][-1] in "=."):
                     char = "."
                 else:
                     char = "="
@@ -110,7 +117,7 @@ class Wavedrom(object):
 
         if add_clock:
             tracelen = len(traces[-1]["wave"])
-            siglist.insert(0, {"name": "clk", "wave" : "p" + "."*(tracelen-1)})
+            siglist.insert(0, {"name": "clk", "wave": "p" + "."*(tracelen-1)})
 
         return siglist
 
@@ -151,7 +158,8 @@ class trace(object):
         while True:
             yield RisingEdge(self._clock)
             yield ReadOnly()
-            if not self._enabled: continue
+            if not self._enabled:
+                continue
             self._clocks += 1
             for sig in self._signals:
                 sig.sample()
@@ -185,11 +193,10 @@ class trace(object):
         with open(filename, "w") as f:
             f.write(self.dumpj(**kwargs))
 
-
     def dumpj(self, header="", footer=""):
-        trace = {"signal" : []}
+        trace = {"signal": []}
         trace["signal"].append(
-            {"name": "clock", "wave" : "p" + "."*(self._clocks-1)})
+            {"name": "clock", "wave": "p" + "."*(self._clocks-1)})
         for sig in self._signals:
             trace["signal"].extend(sig.get(add_clock=False))
         if header:

--- a/cocotb/xunit_reporter.py
+++ b/cocotb/xunit_reporter.py
@@ -33,6 +33,7 @@ from io import StringIO
 
 TRUNCATE_LINES = 100
 
+
 # file from  http://stackoverflow.com/questions/136168/get-last-n-lines-of-a-file-with-python-similar-to-tail
 class File(StringIO):
 
@@ -44,11 +45,11 @@ class File(StringIO):
         return lines
 
     def head(self, lines_2find=1):
-        self.seek(0)                            #Rewind file
+        self.seek(0)                            # Rewind file
         return [self.next() for x in range(lines_2find)]
 
     def tail(self, lines_2find=1):
-        self.seek(0, 2)                         #go to end of file
+        self.seek(0, 2)                         # go to end of file
         bytes_in_file = self.tell()
         lines_found, total_bytes_scanned = 0, 0
         while (lines_2find+1 > lines_found and
@@ -67,19 +68,19 @@ class XUnitReporter(object):
     def __init__(self, filename="results.xml"):
         self.results = Element("testsuites", name="results")
         self.filename = filename
-        
+
     def add_testsuite(self, **kwargs):
         self.last_testsuite = SubElement(self.results, "testsuite", **kwargs)
         return self.last_testsuite
 
     def add_testcase(self, testsuite=None, **kwargs):
-        if testsuite == None:
+        if testsuite is None:
             testsuite = self.last_testsuite
         self.last_testcase = SubElement(testsuite, "testcase", **kwargs)
         return self.last_testcase
 
     def update_testsuite(self, testsuite=None, **kwargs):
-        if testsuite == None:
+        if testsuite is None:
             testsuite = self.last_testsuite
         for k in kwargs:
             testsuite.set(k, str(kwargs[k]))
@@ -89,7 +90,7 @@ class XUnitReporter(object):
             self.results.set(k, str(kwargs[k]))
 
     def add_log(self, logfile, testcase=None):
-        if testcase == None:
+        if testcase is None:
             testcase = self.last_testcase
         log = SubElement(testcase, "system-out")
         f = File(logfile, 'r+')
@@ -97,20 +98,21 @@ class XUnitReporter(object):
         if lines > (TRUNCATE_LINES * 2):
             head = f.head(TRUNCATE_LINES)
             tail = f.tail(TRUNCATE_LINES)
-            log.text = "".join(head + list("[...truncated %d lines...]\n" % ( (lines - (TRUNCATE_LINES*2)) )) + tail)
+            log.text = "".join(head + list("[...truncated %d lines...]\n" %
+                               ((lines - (TRUNCATE_LINES*2)))) + tail)
         else:
             log.text = "".join(f.readlines())
 
     def add_failure(self, testcase=None, **kwargs):
-        if testcase == None:
+        if testcase is None:
             testcase = self.last_testcase
         log = SubElement(testcase, "failure", **kwargs)
 
     def add_skipped(self, testcase=None, **kwargs):
-        if testcase == None:
+        if testcase is None:
             testcase = self.last_testcase
         log = SubElement(testcase, "skipped", **kwargs)
-        
+
     def indent(self, elem, level=0):
         i = "\n" + level*"  "
         if len(elem):
@@ -129,4 +131,3 @@ class XUnitReporter(object):
     def write(self):
         self.indent(self.results)
         ET.ElementTree(self.results).write(self.filename, encoding="UTF-8")
-


### PR DESCRIPTION
These changes are for files which are in cocotb/cocotb. Changes include mostly:
- Deleting/putting whitespaces.
- Deleting/puttig blank lines.
- Wrapping lines which are >79 chars.
- Silencing some warnings when checking with flake.
- Removing unnecessary 'pass' statements.
This PR is about issue #6 
There are still some unused imports/variables and some other pep8 (and also logical) errors on the code. I left them untouched for now.