### PR TITLE
ius : updates to progress mixed language example under ius

### DIFF
--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -21,9 +21,7 @@ VHDL_SOURCES    = $(WPWD)/../../endian_swapper/hdl/endian_swapper.vhdl
 ifeq ($(TOPLEVEL_LANG),sv)
     VERILOG_SOURCES += $(WPWD)/../hdl/toplevel.sv
     GPI_IMPL=vpi
-ifeq ($(SIM),aldec)
     GPI_EXTRA=vhpi
-endif
 ifeq ($(SIM),modelsim)
     GPI_EXTRA=fli
 endif

--- a/makefiles/simulators/Makefile.ius
+++ b/makefiles/simulators/Makefile.ius
@@ -40,9 +40,8 @@ endif
 
 ifeq ($(GPI_IMPL),vpi)
     GPI_ARGS = -loadvpi $(LIB_DIR)/libvpi
-    EXTRA_ARGS += -sv
-    HDL_SOURCES = $(VERILOG_SOURCES)
-    GPI_LIB = $(COCOTB_VPI_LIB)
+    EXTRA_ARGS += -sv -v93
+    HDL_SOURCES = $(VERILOG_SOURCES) $(VHDL_SOURCES)
 endif
 
 ifeq ($(GPI_IMPL),vhpi)
@@ -51,8 +50,9 @@ ifeq ($(GPI_IMPL),vhpi)
     EXTRA_ARGS += -v93
     EXTRA_ARGS += -top worklib.$(TOPLEVEL)
     HDL_SOURCES = $(VHDL_SOURCES)
-    GPI_LIB = $(COCOTB_VHPI_LIB)
 endif
+
+GPI_LIB = $(COCOTB_VPI_LIB) $(COCOTB_VHPI_LIB)
 
 ifndef GPI_ARGS
    $(error "Unable to determine appropriate GPI layer to use")


### PR DESCRIPTION
Some makefile changes to get mixed lang ius sims running.
And always compile both vpi and vhpi shared libraries.

I'm still getting errors once the sim starts.
But at least the vhpi gets loaded and the vhdl sources get compiled in.

"make SIM=ius" in the mixed language example wasn't compiling libvhpi.so
And I don't see any reason to not always compile both libraries.