### PR TITLE
vhpi : populate for generate objects

### DIFF
--- a/lib/vhpi/VhpiImpl.cpp
+++ b/lib/vhpi/VhpiImpl.cpp
@@ -126,6 +126,7 @@ GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl, std::string
         case vhpiIndexedNameK:
             new_obj = new VhpiSignalObjHdl(this, new_hdl);
             break;
+        case vhpiForGenerateK:
         case vhpiCompInstStmtK:
             new_obj = new GpiObjHdl(this, new_hdl);
             break;


### PR DESCRIPTION
this doesn't really work due to #248 but at least we can populate vhpiForGenerateK objects with __getattr__