### PR TITLE
Enable logging with args and kwargs

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -164,7 +164,7 @@ class SimLogFormatter(logging.Formatter):
         return string.rjust(chars)
 
     def _format(self, timeh, timel, level, record, msg):
-        simtime = "% 6d.%03dns" % ((timel / 1000), (timel % 1000))
+        simtime = "% 6d.%02dns" % ((timel / 1000), (timel % 1000) / 10)
         prefix = simtime + ' ' + level + ' ' + \
             self.ljust(record.name, _RECORD_CHARS) + \
             self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS) + \

--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -85,8 +85,7 @@ class SimLog(object):
         else:
             self._log_name = name
 
-    def _makeRecord(self, msg, level):
-
+    def _makeRecord(self, level, msg, args, extra=None):
         if self.logger.isEnabledFor(level):
             frame = inspect.stack()[2]
             info = inspect.getframeinfo(frame[0])
@@ -95,9 +94,10 @@ class SimLog(object):
                                             info.filename,
                                             info.lineno,
                                             msg,
+                                            args,
                                             None,
-                                            None,
-                                            info.function)
+                                            info.function,
+                                            extra)
             self.logger.handle(record)
 
     def _willLog(self, level):
@@ -123,23 +123,23 @@ class SimLog(object):
                                             function)
             self.logger.handle(record)
 
-    def warn(self, msg):
-        self._makeRecord(msg, logging.WARNING)
+    def warn(self, msg, *args, **kwargs):
+        self._makeRecord(logging.WARNING, msg, args, **kwargs)
 
-    def warning(self, msg):
-        self._makeRecord(msg, logging.WARNING)
+    def warning(self, msg, *args, **kwargs):
+        self._makeRecord(logging.WARNING, msg, args, **kwargs)
 
-    def debug(self, msg):
-        self._makeRecord(msg, logging.DEBUG)
+    def debug(self, msg, *args, **kwargs):
+        self._makeRecord(logging.DEBUG, msg, args, **kwargs)
 
-    def error(self, msg):
-        self._makeRecord(msg, logging.ERROR)
+    def error(self, msg, *args, **kwargs):
+        self._makeRecord(logging.ERROR, msg, args, **kwargs)
 
-    def critical(self, msg):
-        self._makeRecord(msg, logging.CRITICAL)
+    def critical(self, msg, *args, **kwargs):
+        self._makeRecord(logging.CRITICAL, msg, args, **kwargs)
 
-    def info(self, msg):
-        self._makeRecord(msg, logging.INFO)
+    def info(self, msg, *args, **kwargs):
+        self._makeRecord(logging.INFO, msg, args, **kwargs)
 
     def __getattr__(self, attribute):
         """Forward any other attribute accesses on to our logger object"""
@@ -164,7 +164,7 @@ class SimLogFormatter(logging.Formatter):
         return string.rjust(chars)
 
     def _format(self, timeh, timel, level, record, msg):
-        simtime = "% 6d.%02dns" % ((timel / 1000), (timel % 1000) / 10)
+        simtime = "% 6d.%03dns" % ((timel / 1000), (timel % 1000))
         prefix = simtime + ' ' + level + ' ' + \
             self.ljust(record.name, _RECORD_CHARS) + \
             self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS) + \

--- a/examples/functionality/tests/test_cocotb.py
+++ b/examples/functionality/tests/test_cocotb.py
@@ -26,6 +26,7 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
+import logging
 
 """
 A set of tests that demonstrate cocotb functionality
@@ -37,7 +38,7 @@ import cocotb
 from cocotb.triggers import (Timer, Join, RisingEdge, FallingEdge, Edge,
                              ReadOnly, ReadWrite)
 from cocotb.clock import Clock
-from cocotb.result import ReturnValue, TestFailure, TestError
+from cocotb.result import ReturnValue, TestFailure, TestError, TestSuccess
 
 
 # Tests relating to providing meaningful errors if we forget to use the
@@ -446,3 +447,25 @@ def test_edge_count(dut):
     if edge_count is not edges_seen:
         raise TestFailure("Correct edge count failed saw %d wanted %d" %
                           (edges_seen, edge_count))
+
+class StrCallCounter(object):
+    def __init__(self):
+        self.str_counter = 0
+        
+    def __str__(self):
+        self.str_counter += 1
+        return "__str__ called %d time(s)" % self.str_counter
+
+@cocotb.test()
+def test_logging_with_args(dut):
+    counter = StrCallCounter()
+    dut.log.logger.setLevel(logging.INFO) #To avoid logging debug message, to make next line run without error
+    dut.log.debug("%s", counter)
+    assert counter.str_counter == 0
+    
+    dut.log.info("%s", counter)
+    assert counter.str_counter == 1
+    
+    dut.log.info("No substitution")
+    
+    yield Timer(100) #Make it do something with time


### PR DESCRIPTION
Added *args and **kwargs method to the logging functions

This is modeled after the Python logging framework, to be able to postpone
the string substitution to after it is decided that the message is going
to be logged. Only extra-keyword is supported for now.

See https://docs.python.org/2/library/logging.html#logging.Logger.debug for the inspiration.
