### PR TITLE
Issue #17: Some fix-ups for VHPI discovery and sizing (in progress)

### DIFF
--- a/include/vpi_user.h
+++ b/include/vpi_user.h
@@ -82,6 +82,7 @@ typedef uint32_t *vpiHandle;
 #define vpiType                 1   /* type of object */
 #define vpiName                 2   /* local name of object */
 #define vpiFullName             3   /* full hierarchical name */
+#define vpiSize                 4   /* size of gate, net, port, etc. */
 
 #define vpiNoDelay              1
 #define vpiInertialDelay        2

--- a/lib/gpi/GpiCbHdl.cpp
+++ b/lib/gpi/GpiCbHdl.cpp
@@ -74,12 +74,6 @@ const std::string & GpiObjHdl::get_name(void)
     return m_name;
 }
 
-int GpiObjHdl::get_num_elems(void)
-{
-    LOG_WARN("Generic get_num_elems, doubtful this is correct");
-    return 0;
-}
-
 /* Genertic base clss implementations */
 char *GpiHdl::gpi_copy_name(const char *name)
 {

--- a/lib/gpi/gpi_priv.h
+++ b/lib/gpi/gpi_priv.h
@@ -93,6 +93,7 @@ protected:
 class GpiObjHdl : public GpiHdl {
 public:
     GpiObjHdl(std::string name) : GpiHdl(NULL, NULL),
+                                  m_num_elems(0),
                                   m_name(name),
                                   m_fullname("unknown") { }
     GpiObjHdl(GpiImplInterface *impl) : GpiHdl(impl, NULL),
@@ -108,7 +109,9 @@ public:
     virtual const char* get_fullname_str(void);
     virtual const char* get_type_str(void);
     virtual gpi_objtype_t get_type(void);
-    virtual int get_num_elems(void);
+    int get_num_elems(void) { 
+        LOG_DEBUG("%s has %d elements", m_name.c_str(), m_num_elems);
+        return m_num_elems; }
 
     const std::string & get_name(void);
 
@@ -116,6 +119,7 @@ public:
     virtual int initialise(std::string &name);
 
 protected:
+    int m_num_elems;
     std::string m_name;
     std::string m_fullname;
     gpi_objtype_t m_type;

--- a/lib/vhpi/VhpiImpl.cpp
+++ b/lib/vhpi/VhpiImpl.cpp
@@ -211,7 +211,7 @@ GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl, std::string
                 vhpiPhysVecVal == value.format ||
                 vhpiTimeVecVal == value.format) {
                 LOG_DEBUG("Detected a vector type", name.c_str());
-                gpi_type = GPI_MODULE;
+                gpi_type = GPI_ARRAY;
             }
 
             new_obj = new VhpiSignalObjHdl(this, new_hdl, gpi_type);

--- a/lib/vhpi/VhpiImpl.h
+++ b/lib/vhpi/VhpiImpl.h
@@ -153,7 +153,6 @@ class VhpiSignalObjHdl : public GpiSignalObjHdl {
 public:
     VhpiSignalObjHdl(GpiImplInterface *impl, vhpiHandleT hdl, gpi_objtype_t objtype) :
                                                                 GpiSignalObjHdl(impl, hdl, objtype),
-                                                                m_size(0),
                                                                 m_rising_cb(impl, this, GPI_RISING),
                                                                 m_falling_cb(impl, this, GPI_FALLING),
                                                                 m_either_cb(impl, this, GPI_FALLING | GPI_RISING) { }
@@ -172,11 +171,8 @@ public:
     GpiCbHdl *value_change_cb(unsigned int edge);
     int initialise(std::string &name);
 
-    int get_num_elems(void);
-
 private:
     const vhpiEnumT chr2vhpi(const char value);
-    unsigned int m_size;
     vhpiValueT m_value;
     vhpiValueT m_binvalue;
     VhpiValueCbHdl m_rising_cb;

--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -123,6 +123,12 @@ int VpiCbHdl::cleanup_callback(void)
     return 0;
 }
 
+int VpiSignalObjHdl::initialise(std::string &name) {
+    m_num_elems = vpi_get(vpiSize, GpiObjHdl::get_handle<vpiHandle>());
+    LOG_DEBUG("VPI: %s initialised with %d elements", name.c_str(), m_num_elems);
+    return GpiObjHdl::initialise(name);
+}
+
 const char* VpiSignalObjHdl::get_signal_value_binstr(void)
 {
     FENTER
@@ -216,11 +222,6 @@ int VpiSignalObjHdl::set_signal_value(std::string &value)
 
     FEXIT
     return 0;
-}
-
-int VpiSignalObjHdl::get_num_elems(void)
-{
-    return 1;
 }
 
 GpiCbHdl * VpiSignalObjHdl::value_change_cb(unsigned int edge)

--- a/lib/vpi/VpiImpl.cpp
+++ b/lib/vpi/VpiImpl.cpp
@@ -112,7 +112,6 @@ gpi_objtype_t to_gpi_objtype(int32_t vpitype)
     }
 }
 
-
 GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl, std::string &name)
 {
     int32_t type;

--- a/lib/vpi/VpiImpl.h
+++ b/lib/vpi/VpiImpl.h
@@ -188,10 +188,10 @@ public:
     int set_signal_value(const long value);
     int set_signal_value(const double value);
     int set_signal_value(std::string &value);
-    int get_num_elems(void);
 
     /* Value change callback accessor */
     GpiCbHdl *value_change_cb(unsigned int edge);
+    int initialise(std::string &name);
 
 private:
     VpiValueCbHdl m_rising_cb;


### PR DESCRIPTION
* Added a load of debug in handle.py (can be removed before merge but may as well leave in for now)
* Reduced get_num_elems to return m_num_elems
* Fix VHPI size calculation for vhpiRawDataVal
* Fix returning a simulator.MODULE type for arrays
* Make generate detection happy with non-contiguous indexes (seems to happen in example design)

Still doesn't work but gets much further on Aldec than previously.