### PR TITLE
Enum vs Integer in GPI, tidy-up, more tests

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -510,7 +510,8 @@ def SimHandle(handle):
         simulator.REG:         ModifiableObject,
         simulator.NETARRAY:    ModifiableObject,
         simulator.REAL:        RealObject,
-        simulator.ENUM:        IntegerObject
+        simulator.INTEGER:     IntegerObject,
+        simulator.ENUM:        IntegerObject,
     }
 
     t = simulator.get_type(handle)

--- a/include/gpi.h
+++ b/include/gpi.h
@@ -134,7 +134,8 @@ typedef enum gpi_objtype_e {
     GPI_ARRAY = 6,
     GPI_ENUM = 7,
     GPI_STRUCTURE = 8,
-    GPI_REAL = 9
+    GPI_REAL = 9,
+    GPI_INTEGER = 10
 } gpi_objtype_t;
 
 // Functions for iterating over entries of a handle

--- a/lib/simulator/simulatormodule.c
+++ b/lib/simulator/simulatormodule.c
@@ -874,6 +874,25 @@ static PyObject *deregister_callback(PyObject *self, PyObject *args)
     return value;
 }
 
+static void add_module_constants(PyObject* simulator)
+{
+    // Make the GPI constants accessible from the C world
+    int rc = 0;
+    rc |= PyModule_AddIntConstant(simulator, "UNKNOWN",       GPI_UNKNOWN);
+    rc |= PyModule_AddIntConstant(simulator, "MEMORY",        GPI_MEMORY);
+    rc |= PyModule_AddIntConstant(simulator, "MODULE",        GPI_MODULE);
+    rc |= PyModule_AddIntConstant(simulator, "NET",           GPI_NET);
+    rc |= PyModule_AddIntConstant(simulator, "PARAMETER",     GPI_PARAMETER);
+    rc |= PyModule_AddIntConstant(simulator, "REG",           GPI_REGISTER);
+    rc |= PyModule_AddIntConstant(simulator, "NETARRAY",      GPI_ARRAY);
+    rc |= PyModule_AddIntConstant(simulator, "ENUM",          GPI_ENUM);
+    rc |= PyModule_AddIntConstant(simulator, "STRUCTURE",     GPI_STRUCTURE);
+    rc |= PyModule_AddIntConstant(simulator, "REAL",          GPI_REAL);
+    rc |= PyModule_AddIntConstant(simulator, "INTEGER",       GPI_INTEGER);
+    if (rc != 0)
+        fprintf(stderr, "Failed to add module constants!\n");
+}
+
 #if PY_MAJOR_VERSION >= 3
 #include "simulatormodule_python3.c"
 #else

--- a/lib/simulator/simulatormodule_python2.c
+++ b/lib/simulator/simulatormodule_python2.c
@@ -26,18 +26,5 @@ MODULE_ENTRY_POINT(void)
         INITERROR;
     }
 
-    // Make the GPI constants accessible from the C world
-    int rc = 0;
-    rc |= PyModule_AddIntConstant(simulator, "UNKNOWN",       GPI_UNKNOWN);
-    rc |= PyModule_AddIntConstant(simulator, "MEMORY",        GPI_MEMORY);
-    rc |= PyModule_AddIntConstant(simulator, "MODULE",        GPI_MODULE);
-    rc |= PyModule_AddIntConstant(simulator, "NET",           GPI_NET);
-    rc |= PyModule_AddIntConstant(simulator, "PARAMETER",     GPI_PARAMETER);
-    rc |= PyModule_AddIntConstant(simulator, "REG",           GPI_REGISTER);
-    rc |= PyModule_AddIntConstant(simulator, "NETARRAY",      GPI_ARRAY);
-    rc |= PyModule_AddIntConstant(simulator, "ENUM",          GPI_ENUM);
-    rc |= PyModule_AddIntConstant(simulator, "STRUCTURE",     GPI_STRUCTURE);
-    rc |= PyModule_AddIntConstant(simulator, "REAL",          GPI_REAL);
-    if (rc != 0)
-        fprintf(stderr, "Failed to add module constants!\n");
+    add_module_constants(simulator);
 }

--- a/lib/simulator/simulatormodule_python3.c
+++ b/lib/simulator/simulatormodule_python3.c
@@ -45,21 +45,7 @@ MODULE_ENTRY_POINT(void)
         INITERROR;
     }
 
-    // Make the GPI constants accessible from the C world
-    int rc = 0;
-    rc |= PyModule_AddIntConstant(simulator, "UNKNOWN",       GPI_UNKNOWN);
-    rc |= PyModule_AddIntConstant(simulator, "MEMORY",        GPI_MEMORY);
-    rc |= PyModule_AddIntConstant(simulator, "MODULE",        GPI_MODULE);
-    rc |= PyModule_AddIntConstant(simulator, "NET",           GPI_NET);
-    rc |= PyModule_AddIntConstant(simulator, "PARAMETER",     GPI_PARAMETER);
-    rc |= PyModule_AddIntConstant(simulator, "REG",           GPI_REGISTER);
-    rc |= PyModule_AddIntConstant(simulator, "NETARRAY",      GPI_ARRAY);
-    rc |= PyModule_AddIntConstant(simulator, "ENUM",          GPI_ENUM);
-    rc |= PyModule_AddIntConstant(simulator, "STRUCTURE",     GPI_STRUCTURE);
-    rc |= PyModule_AddIntConstant(simulator, "REAL",          GPI_REAL);
-    if (rc != 0)
-        fprintf(stderr, "Failed to add module constants!\n");
-
+    add_module_constants(simulator);
     return simulator;
 }
 

--- a/lib/vhpi/VhpiImpl.cpp
+++ b/lib/vhpi/VhpiImpl.cpp
@@ -196,9 +196,14 @@ GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl, std::string
 
             if (vhpiIntVal == value.format) {
                 LOG_DEBUG("Detected an INT type %s", name.c_str());
-                gpi_type = GPI_ENUM;
-
+                gpi_type = GPI_INTEGER;
             }
+
+            if (vhpiEnumVal == value.format) {
+                LOG_DEBUG("Detected an ENUM type %s", name.c_str());
+                gpi_type = GPI_ENUM;
+            }
+
             if (vhpiRawDataVal == value.format) {
                 LOG_DEBUG("Detected a custom array type %s", name.c_str());
                 gpi_type = GPI_MODULE;

--- a/lib/vpi/VpiImpl.cpp
+++ b/lib/vpi/VpiImpl.cpp
@@ -89,10 +89,12 @@ gpi_objtype_t to_gpi_objtype(int32_t vpitype)
 
         case vpiEnumNet:
         case vpiEnumVar:
+            return GPI_ENUM;
+
         case vpiIntVar:
         case vpiIntegerVar:
         case vpiIntegerNet:
-            return GPI_ENUM;
+            return GPI_INTEGER;
 
         case vpiParameter:
             return GPI_PARAMETER;

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -31,8 +31,6 @@ from cocotb.triggers import Timer
 from cocotb.result import TestError, TestFailure
 
 
-
-
 @cocotb.test()
 def check_objects(dut):
     """
@@ -56,15 +54,31 @@ def check_objects(dut):
     fails += check_instance(dut.gen_branch_distance[0].inst_branch_distance, HierarchyObject)
     fails += check_instance(dut.gen_acs[0].inbranch_tdata_low, ModifiableObject)
     fails += check_instance(dut.gen_acs[0].inbranch_tdata_low[0], ModifiableObject)
-
     fails += check_instance(dut.aclk, ModifiableObject)
     fails += check_instance(dut.s_axis_input_tdata, ModifiableObject)
-
     fails += check_instance(dut.current_active, IntegerObject)
-
     fails += check_instance(dut.inst_axi4s_buffer.DATA_WIDTH, ConstantObject)
+    fails += check_instance(dut.inst_ram_ctrl, HierarchyObject)
+    fails += check_instance(dut.inst_ram_ctrl.write_ram_fsm, IntegerObject)
+
+    if dut.inst_axi4s_buffer.DATA_WIDTH != 32:
+        tlog.error("Expected dut.inst_axi4s_buffer.DATA_WIDTH to be 32 but got %d",
+                   dut.inst_axi4s_buffer.DATA_WIDTH)
+        fails += 1
+
+    try:
+        dut.inst_axi4s_buffer.DATA_WIDTH = 42
+        tlog.error("Shouldn't be allowed to set a value on constant object")
+        fails += 1
+    except ValueError as e:
+        pass
+
+    try:
+        dut.inst_axi4s_buffer.DATA_WIDTH <= 42
+        tlog.error("Shouldn't be allowed to set a value on constant object")
+        fails += 1
+    except ValueError as e:
+        pass
 
     if fails:
-        raise TestFailure("%d objects were not of the expected type" % fails)
-
-
+        raise TestFailure("%d Failures during the test" % fails)


### PR DESCRIPTION
* Additional tests that check whether we can assign to constants (fails)
* Tidy up duplicated code in simulatormodule_python[2|3].c
* Differentiate between enumerations and integers in GPI

Note don't do anything with this information in Python yet