### PR TITLE
Issue#17

### DIFF
--- a/lib/fli/FliImpl.cpp
+++ b/lib/fli/FliImpl.cpp
@@ -617,6 +617,11 @@ GpiObjHdl *FliImpl::next_handle(GpiIterator *iter)
     return NULL;
 }
 
+bool FliImpl::equal(GpiObjHdl* lhs, GpiObjHdl* rhs)
+{
+    return false;
+}
+
 
 #include <unistd.h>
 

--- a/lib/fli/FliImpl.h
+++ b/lib/fli/FliImpl.h
@@ -255,6 +255,8 @@ public:
     /* Method to provide strings from operation types */
     const char *reason_to_string(int reason);
 
+    bool equal(GpiObjHdl* lhs, GpiObjHdl* rhs);
+
 private:
     FliReadOnlyCbHdl  m_readonly_cbhdl;
     FliNextPhaseCbHdl m_nexttime_cbhdl;

--- a/lib/gpi/GpiCbHdl.cpp
+++ b/lib/gpi/GpiCbHdl.cpp
@@ -38,6 +38,11 @@ const char * GpiObjHdl::get_fullname_str(void)
     return m_fullname.c_str();
 }
 
+const std::string & GpiObjHdl::get_fullname(void)
+{
+    return m_fullname;
+}
+
 const char * GpiObjHdl::get_type_str(void)
 {
 #define CASE_OPTION(_X) \
@@ -112,10 +117,10 @@ int GpiHdl::initialise(std::string &name)
     return 0;
 }
 
-int GpiObjHdl::initialise(std::string &name)
+int GpiObjHdl::initialise(std::string &name, std::string &fq_name)
 {
     m_name = name;
-    m_fullname = "bleh2";
+    m_fullname = fq_name;
     return 0;
 }
 

--- a/lib/gpi/GpiCommon.cpp
+++ b/lib/gpi/GpiCommon.cpp
@@ -52,7 +52,8 @@ public:
             handle_map[name] = hdl;
             return hdl;
         } else {
-            LOG_WARN("Found duplicate %s", name.c_str());
+            LOG_DEBUG("Found duplicate %s", name.c_str());
+
             delete hdl;
             return it->second;
         }
@@ -254,12 +255,12 @@ gpi_sim_hdl gpi_get_handle_by_name(const char *name, gpi_sim_hdl parent)
         }
     }
 
-    LOG_DEBUG("Failed to find a hdl named %s", name);
-
     if (hdl)
         return CHECK_AND_STORE(hdl);
-    else
+    else {
+        LOG_DEBUG("Failed to find a hdl named %s", name);
         return hdl;
+    }
 }
 
 gpi_sim_hdl gpi_get_handle_by_index(gpi_sim_hdl parent, uint32_t index)

--- a/lib/gpi/Makefile
+++ b/lib/gpi/Makefile
@@ -30,7 +30,7 @@
 include $(SIM_ROOT)/makefiles/Makefile.inc
 
 INCLUDES    +=
-GXX_ARGS    += -DVPI_CHECKING -DLIB_EXT=$(LIB_EXT)
+GXX_ARGS    += -DVPI_CHECKING -DLIB_EXT=$(LIB_EXT) -DSINGLETON_HANDLES
 LIBS        := -lcocotbutils -lgpilog -lcocotb -lstdc++
 LD_PATH     := -L$(LIB_DIR)
 LIB_NAME    := libgpi

--- a/lib/gpi/gpi_priv.h
+++ b/lib/gpi/gpi_priv.h
@@ -97,9 +97,11 @@ public:
                                   m_name(name),
                                   m_fullname("unknown") { }
     GpiObjHdl(GpiImplInterface *impl) : GpiHdl(impl, NULL),
+                                        m_num_elems(0),
                                         m_fullname("unknown"),
                                         m_type(GPI_UNKNOWN) { }
     GpiObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype) : GpiHdl(impl, hdl),
+                                                                          m_num_elems(0),
                                                                           m_fullname("unknown"),
                                                                           m_type(objtype) { }
 

--- a/lib/gpi/gpi_priv.h
+++ b/lib/gpi/gpi_priv.h
@@ -61,13 +61,13 @@ inline To sim_to_hdl(gpi_sim_hdl input)
 /* Base GPI class others are derived from */
 class GpiHdl {
 public:
-    //GpiHdl() : m_impl(NULL) { }
+    GpiHdl(GpiImplInterface *impl) : m_impl(impl), m_obj_hdl(NULL) { }
     GpiHdl(GpiImplInterface *impl, void *hdl) : m_impl(impl), m_obj_hdl(hdl) { }
     virtual ~GpiHdl() { }
     virtual int initialise(std::string &name);                   // Post constructor init
 
 
-    template<typename T> T get_handle(void) {
+    template<typename T> T get_handle(void) const {
         return static_cast<T>(m_obj_hdl);
     }
 
@@ -111,14 +111,16 @@ public:
     virtual const char* get_fullname_str(void);
     virtual const char* get_type_str(void);
     virtual gpi_objtype_t get_type(void);
-    int get_num_elems(void) { 
+    int get_num_elems(void) {
         LOG_DEBUG("%s has %d elements", m_name.c_str(), m_num_elems);
-        return m_num_elems; }
+        return m_num_elems;
+    }
 
     const std::string & get_name(void);
+    const std::string & get_fullname(void);
 
     bool is_native_impl(GpiImplInterface *impl);
-    virtual int initialise(std::string &name);
+    virtual int initialise(std::string &name, std::string &full_name);
 
 protected:
     int m_num_elems;
@@ -206,10 +208,13 @@ public:
 
 class GpiIterator : public GpiHdl {
 public:
-    GpiIterator(GpiImplInterface *impl, void *hdl) : GpiHdl(impl, hdl) { }
+    GpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiHdl(impl),
+                                                          m_parent(hdl) { }
     virtual ~GpiIterator() { }
 
     virtual GpiObjHdl* next_handle() { return NULL; }
+protected:
+    GpiObjHdl *m_parent;
 };
 
 
@@ -240,6 +245,9 @@ public:
 
     /* Method to provide strings from operation types */
     virtual const char * reason_to_string(int reason) = 0;
+
+    /* Test equality of two handles */
+    virtual bool equal(const GpiObjHdl* lhs, const GpiObjHdl* rhs) = 0;
 
 private:
     std::string m_name;

--- a/lib/vhpi/VhpiImpl.h
+++ b/lib/vhpi/VhpiImpl.h
@@ -169,7 +169,7 @@ public:
 
     /* Value change callback accessor */
     GpiCbHdl *value_change_cb(unsigned int edge);
-    int initialise(std::string &name);
+    int initialise(std::string &name, std::string &fq_name);
 
 private:
     const vhpiEnumT chr2vhpi(const char value);
@@ -194,7 +194,7 @@ private:
 
 class VhpiIterator : public GpiIterator {
 public:
-    VhpiIterator(GpiImplInterface *impl, vhpiHandleT hdl);
+    VhpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl);
 
     virtual ~VhpiIterator();
 
@@ -236,7 +236,12 @@ public:
     const char * reason_to_string(int reason);
     const char * format_to_string(int format);
 
-    GpiObjHdl *create_gpi_obj_from_handle(vhpiHandleT new_hdl, std::string &name);
+    GpiObjHdl *create_gpi_obj_from_handle(vhpiHandleT new_hdl,
+                                          std::string &name,
+                                          std::string &fq_name);
+
+    bool equal(const GpiObjHdl* lhs, const GpiObjHdl* rhs);
+
 private:
     VhpiReadwriteCbHdl m_read_write;
     VhpiNextPhaseCbHdl m_next_phase;

--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -369,7 +369,6 @@ KindMappings::KindMappings()
     int32_t module_options[] = {
         //vpiModule,            // Aldec SEGV on mixed language
         //vpiModuleArray,       // Aldec SEGV on mixed language
-        vpiInternalScope,
         vpiPort,
         //vpiIODecl,            // Don't care about these
         vpiNet,
@@ -391,6 +390,7 @@ KindMappings::KindMappings()
         vpiModPath,
         vpiTchk,
         vpiAttribute,
+        vpiInternalScope,
         //vpiInterface,         // Aldec SEGV on mixed language
         //vpiInterfaceArray,    // Aldec SEGV on mixed language
         0
@@ -407,6 +407,7 @@ KindMappings::KindMappings()
         //vpiLocalDriver,
         //vpiLoad,
         //vpiLocalLoad,
+        vpiNetBit,
         0
     };
     add_to_options(vpiNet, &net_options[0]);
@@ -435,7 +436,7 @@ KindMappings::KindMappings()
 
     /* vpiPort */
     int32_t port_options[] = {
-        vpiBit,
+        vpiPortBit,
         0
     };
     add_to_options(vpiPort, &port_options[0]);
@@ -458,7 +459,7 @@ std::vector<int32_t>* KindMappings::get_options(int32_t type)
 
     if (options_map.end() == valid) {
         LOG_ERROR("VPI: Implementation does not know how to iterate over %d", type);
-        exit(1);
+        return NULL;
     } else {
         return &valid->second;
     }
@@ -472,7 +473,9 @@ VpiIterator::VpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiIterator(i
     vpiHandle iterator;
     vpiHandle vpi_hdl = m_parent->get_handle<vpiHandle>();
 
-    selected = iterate_over.get_options(vpi_get(vpiType, vpi_hdl));
+    if (NULL == (selected = iterate_over.get_options(vpi_get(vpiType, vpi_hdl))))
+        return;
+
 
     for (one2many = selected->begin();
          one2many != selected->end();
@@ -511,6 +514,9 @@ GpiObjHdl *VpiIterator::next_handle(void)
     vpiHandle obj;
     vpiHandle iter_obj = m_parent->get_handle<vpiHandle>();
     GpiObjHdl *new_obj = NULL;
+
+    if (!selected)
+        return NULL;
 
     do {
         obj = NULL;

--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -369,7 +369,6 @@ KindMappings::KindMappings()
     int32_t module_options[] = {
         //vpiModule,            // Aldec SEGV on mixed language
         //vpiModuleArray,       // Aldec SEGV on mixed language
-        vpiPort,
         //vpiIODecl,            // Don't care about these
         vpiNet,
         vpiNetArray,
@@ -390,6 +389,7 @@ KindMappings::KindMappings()
         vpiModPath,
         vpiTchk,
         vpiAttribute,
+        vpiPort,
         vpiInternalScope,
         //vpiInterface,         // Aldec SEGV on mixed language
         //vpiInterfaceArray,    // Aldec SEGV on mixed language

--- a/lib/vpi/VpiImpl.h
+++ b/lib/vpi/VpiImpl.h
@@ -204,7 +204,7 @@ public:
 
     /* Value change callback accessor */
     GpiCbHdl *value_change_cb(unsigned int edge);
-    int initialise(std::string &name);
+    int initialise(std::string &name, std::string &fq_name);
 
 private:
     VpiValueCbHdl m_rising_cb;
@@ -214,7 +214,7 @@ private:
 
 class VpiIterator : public GpiIterator {
 public:
-    VpiIterator(GpiImplInterface *impl, vpiHandle hdl);
+    VpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl);
     
     virtual ~VpiIterator();
 
@@ -252,7 +252,11 @@ public:
     GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent);
     GpiObjHdl* native_check_create(uint32_t index, GpiObjHdl *parent);
     const char * reason_to_string(int reason);
-    GpiObjHdl* create_gpi_obj_from_handle(vpiHandle new_hdl, std::string &name);
+    GpiObjHdl* create_gpi_obj_from_handle(vpiHandle new_hdl,
+                                          std::string &name,
+                                          std::string &fq_name);
+
+    bool equal(const GpiObjHdl* lhs, const GpiObjHdl* rhs);
 
 private:
     /* Singleton callbacks */

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -54,6 +54,11 @@ def recursive_discovery(dut):
     total = recursive_dump(dut, tlog)
     tlog.info("Found a total of %d things", total)
 
+    if not isinstance(dut.i_verilog.uart1.baud_gen_1.baud_freq, cocotb.handle.ModifiableObject):
+        tlog.error("Expected dut.i_verilog.uart1.baud_gen_1.baud_freq to be modifiable")
+        tlog.error("but it was %s" % dut.i_verilog.uart1.baud_gen_1.baud_freq.__class__.__name__)
+        raise TestError()
+
 
 @cocotb.test()
 def recursive_discovery_boundary(dut):


### PR DESCRIPTION
Allow the GPI layer to track the name of the handles that it has found. If the name is found again then the original handle is returned. This solves a problem where the implementation layers are free to return different handles to the same objects. Precursor to enabling a signal to reference other signals that are not in it's hierarchy for knowing load/driver information.

This is disabled for now, to enabled modify <cocotb>/lib/gpi/Makefile
with 

```
-GXX_ARGS    += -DVPI_CHECKING -DLIB_EXT=$(LIB_EXT)
+GXX_ARGS    += -DVPI_CHECKING -DLIB_EXT=$(LIB_EXT) -DSINGLETON_HANDLES
```