### PR TITLE
Issue #17: Fix poor behaviour of handles in Python

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -381,9 +381,7 @@ class NonConstantObject(NonHierarchyObject):
         return self.value.__cmp__(other)
 
     def __int__(self):
-        print "Getting value..."
         val = self.value
-        print "Got %s (%s)" % (type(val), repr(val))
         return int(self.value)
 
     def __repr__(self):

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -264,7 +264,7 @@ class Scheduler(object):
 
             while self._writes:
                 handle, value = self._writes.popitem()
-                handle._setimmediatevalue(value)
+                handle.setimmediatevalue(value)
 
             self._readwrite.unprime()
 

--- a/include/gpi.h
+++ b/include/gpi.h
@@ -164,6 +164,9 @@ const char *gpi_get_signal_type_str(gpi_sim_hdl gpi_hdl);
 // Returns on of the types defined above e.g. gpiMemory etc.
 gpi_objtype_t gpi_get_object_type(gpi_sim_hdl gpi_hdl);
 
+// Determine whether an object value is constant (parameters / generics etc)
+int gpi_is_constant(gpi_sim_hdl gpi_hdl);
+
 
 // Functions for setting the properties of a handle
 void gpi_set_signal_value_real(gpi_sim_hdl gpi_hdl, double value);

--- a/lib/gpi/GpiCbHdl.cpp
+++ b/lib/gpi/GpiCbHdl.cpp
@@ -69,11 +69,6 @@ const char * GpiObjHdl::get_type_str(void)
     return ret;
 }
 
-gpi_objtype_e GpiObjHdl::get_type(void)
-{
-    return m_type;
-}
-
 const std::string & GpiObjHdl::get_name(void)
 {
     return m_name;

--- a/lib/gpi/GpiCommon.cpp
+++ b/lib/gpi/GpiCommon.cpp
@@ -350,6 +350,14 @@ gpi_objtype_t gpi_get_object_type(gpi_sim_hdl sig_hdl)
     return obj_hdl->get_type();
 }
 
+int gpi_is_constant(gpi_sim_hdl sig_hdl)
+{
+    GpiObjHdl *obj_hdl = sim_to_hdl<GpiObjHdl*>(sig_hdl);
+    if (obj_hdl->get_const())
+        return 1;
+    return 0;
+}
+
 void gpi_set_signal_value_long(gpi_sim_hdl sig_hdl, long value)
 {
     GpiSignalObjHdl *obj_hdl = sim_to_hdl<GpiSignalObjHdl*>(sig_hdl);

--- a/lib/gpi/gpi_priv.h
+++ b/lib/gpi/gpi_priv.h
@@ -92,25 +92,29 @@ protected:
 // that construct an object derived from GpiSignalObjHdl or GpiObjHdl
 class GpiObjHdl : public GpiHdl {
 public:
-    GpiObjHdl(std::string name) : GpiHdl(NULL, NULL),
-                                  m_num_elems(0),
-                                  m_name(name),
-                                  m_fullname("unknown") { }
     GpiObjHdl(GpiImplInterface *impl) : GpiHdl(impl, NULL),
                                         m_num_elems(0),
                                         m_fullname("unknown"),
-                                        m_type(GPI_UNKNOWN) { }
+                                        m_type(GPI_UNKNOWN),
+                                        m_const(false) { }
     GpiObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype) : GpiHdl(impl, hdl),
                                                                           m_num_elems(0),
                                                                           m_fullname("unknown"),
-                                                                          m_type(objtype) { }
-
+                                                                          m_type(objtype),
+                                                                          m_const(false) { }
+    GpiObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype, bool is_const) :
+                                                                          GpiHdl(impl, hdl),
+                                                                          m_num_elems(0),
+                                                                          m_fullname("unknown"),
+                                                                          m_type(objtype),
+                                                                          m_const(is_const) { }
     virtual ~GpiObjHdl() { }
 
     virtual const char* get_name_str(void);
     virtual const char* get_fullname_str(void);
     virtual const char* get_type_str(void);
-    virtual gpi_objtype_t get_type(void);
+    gpi_objtype_t get_type(void) { return m_type; };
+    bool get_const(void) { return m_const; };
     int get_num_elems(void) {
         LOG_DEBUG("%s has %d elements", m_name.c_str(), m_num_elems);
         return m_num_elems;
@@ -127,6 +131,7 @@ protected:
     std::string m_name;
     std::string m_fullname;
     gpi_objtype_t m_type;
+    bool m_const;
 };
 
 
@@ -136,8 +141,8 @@ protected:
 // value of the signal (which doesn't apply to non signal items in the hierarchy
 class GpiSignalObjHdl : public GpiObjHdl {
 public:
-    GpiSignalObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype) : 
-                                                         GpiObjHdl(impl, hdl, objtype),
+    GpiSignalObjHdl(GpiImplInterface *impl, void *hdl, gpi_objtype_t objtype, bool is_const) : 
+                                                         GpiObjHdl(impl, hdl, objtype, is_const),
                                                          m_length(0) { }
     virtual ~GpiSignalObjHdl() { }
     // Provide public access to the implementation (composition vs inheritance)

--- a/lib/simulator/simulatormodule.c
+++ b/lib/simulator/simulatormodule.c
@@ -776,6 +776,27 @@ static PyObject *get_type(PyObject *self, PyObject *args)
     return pyresult;
 }
 
+static PyObject *get_const(PyObject *self, PyObject *args)
+{
+    int result;
+    gpi_sim_hdl hdl;
+    PyObject *pyresult;
+
+    PyGILState_STATE gstate;
+    gstate = TAKE_GIL();
+
+    if (!PyArg_ParseTuple(args, "l", &hdl)) {
+        DROP_GIL(gstate);
+        return NULL;
+    }
+
+    result = gpi_is_constant((gpi_sim_hdl)hdl);
+    pyresult = Py_BuildValue("i", result);
+
+    DROP_GIL(gstate);
+
+    return pyresult;
+}
 
 static PyObject *get_type_string(PyObject *self, PyObject *args)
 {

--- a/lib/simulator/simulatormodule.h
+++ b/lib/simulator/simulatormodule.h
@@ -68,6 +68,7 @@ static PyObject *get_handle_by_index(PyObject *self, PyObject *args);
 static PyObject *get_root_handle(PyObject *self, PyObject *args);
 static PyObject *get_name_string(PyObject *self, PyObject *args);
 static PyObject *get_type(PyObject *self, PyObject *args);
+static PyObject *get_const(PyObject *self, PyObject *args);
 static PyObject *get_type_string(PyObject *self, PyObject *args);
 static PyObject *get_num_elems(PyObject *self, PyObject *args);
 static PyObject *register_timed_callback(PyObject *self, PyObject *args);
@@ -97,6 +98,7 @@ static PyMethodDef SimulatorMethods[] = {
     {"get_name_string", get_name_string, METH_VARARGS, "Get the name of an object as a string"},
     {"get_type_string", get_type_string, METH_VARARGS, "Get the type of an object as a string"},
     {"get_type", get_type, METH_VARARGS, "Get the type of an object, mapped to a GPI enumeration"},
+    {"get_const", get_const, METH_VARARGS, "Get a flag indicating whether the object is a constant"},
     {"get_num_elems", get_num_elems, METH_VARARGS, "Get the number of elements contained in the handle"},
     {"register_timed_callback", register_timed_callback, METH_VARARGS, "Register a timed callback"},
     {"register_value_change_callback", register_value_change_callback, METH_VARARGS, "Register a signal change callback"},

--- a/lib/vhpi/VhpiImpl.cpp
+++ b/lib/vhpi/VhpiImpl.cpp
@@ -215,11 +215,6 @@ GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl,
                 gpi_type = GPI_INTEGER;
             }
 
-            if (vhpiEnumVal == value.format) {
-                LOG_DEBUG("Detected an ENUM type %s", fq_name.c_str());
-                gpi_type = GPI_ENUM;
-            }
-
             if (vhpiRawDataVal == value.format) {
                 LOG_DEBUG("Detected a custom array type %s", fq_name.c_str());
                 gpi_type = GPI_MODULE;

--- a/lib/vhpi/VhpiImpl.cpp
+++ b/lib/vhpi/VhpiImpl.cpp
@@ -112,6 +112,17 @@ void VhpiImpl::get_sim_time(uint32_t *high, uint32_t *low)
     *low = vhpi_time_s.low;
 }
 
+// Determine whether a VHPI object type is a constant or not
+bool is_const(vhpiIntT vhpitype)
+{
+    switch (vhpitype) {
+        case vhpiConstDeclK:
+        case vhpiGenericDeclK:
+            return true;
+        default:
+            return false;
+    }
+}
 
 gpi_objtype_t to_gpi_objtype(vhpiIntT vhpitype)
 {
@@ -224,7 +235,7 @@ GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl,
                 gpi_type = GPI_ARRAY;
             }
 
-            new_obj = new VhpiSignalObjHdl(this, new_hdl, gpi_type);
+            new_obj = new VhpiSignalObjHdl(this, new_hdl, gpi_type, is_const(type));
             break;
         }
         case vhpiForGenerateK:

--- a/lib/vhpi/VhpiImpl.h
+++ b/lib/vhpi/VhpiImpl.h
@@ -151,8 +151,8 @@ public:
 
 class VhpiSignalObjHdl : public GpiSignalObjHdl {
 public:
-    VhpiSignalObjHdl(GpiImplInterface *impl, vhpiHandleT hdl, gpi_objtype_t objtype) :
-                                                                GpiSignalObjHdl(impl, hdl, objtype),
+    VhpiSignalObjHdl(GpiImplInterface *impl, vhpiHandleT hdl, gpi_objtype_t objtype, bool is_const) :
+                                                                GpiSignalObjHdl(impl, hdl, objtype, is_const),
                                                                 m_rising_cb(impl, this, GPI_RISING),
                                                                 m_falling_cb(impl, this, GPI_FALLING),
                                                                 m_either_cb(impl, this, GPI_FALLING | GPI_RISING) { }

--- a/lib/vpi/VpiImpl.cpp
+++ b/lib/vpi/VpiImpl.cpp
@@ -132,7 +132,6 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiNetBit:
         case vpiReg:
         case vpiRegBit:
-        case vpiParameter:
         case vpiRegArray:
         case vpiNetArray:
         case vpiEnumNet:
@@ -141,7 +140,10 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiIntegerVar:
         case vpiIntegerNet:
         case vpiRealVar:
-            new_obj = new VpiSignalObjHdl(this, new_hdl, to_gpi_objtype(type));
+            new_obj = new VpiSignalObjHdl(this, new_hdl, to_gpi_objtype(type), false);
+            break;
+        case vpiParameter:
+            new_obj = new VpiSignalObjHdl(this, new_hdl, to_gpi_objtype(type), true);
             break;
         case vpiStructVar:
         case vpiModule:

--- a/lib/vpi/VpiImpl.h
+++ b/lib/vpi/VpiImpl.h
@@ -187,8 +187,8 @@ private:
 
 class VpiSignalObjHdl : public GpiSignalObjHdl {
 public:
-    VpiSignalObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype_t objtype) : 
-                                                             GpiSignalObjHdl(impl, hdl, objtype),
+    VpiSignalObjHdl(GpiImplInterface *impl, vpiHandle hdl, gpi_objtype_t objtype, bool is_const) : 
+                                                             GpiSignalObjHdl(impl, hdl, objtype, is_const),
                                                              m_rising_cb(impl, this, GPI_RISING),
                                                              m_falling_cb(impl, this, GPI_FALLING),
                                                              m_either_cb(impl, this, GPI_FALLING | GPI_RISING) { }

--- a/tests/test_cases/test_iteration/test_iteration.py
+++ b/tests/test_cases/test_iteration/test_iteration.py
@@ -76,9 +76,10 @@ def dual_iteration(dut):
 
 @cocotb.test()
 def get_clock(dut):
+    dut.log.info("dut.aclk is %s" % dut.aclk.__class__.__name__)
     dut.aclk <= 0
     yield Timer(1)
     dut.aclk <= 1
     yield Timer(1)
     if int(dut.aclk) is not 1:
-        raise TestFailure("dut.aclk is not what we expected")
+        raise TestFailure("dut.aclk is not what we expected (got %d)" % int(dut.aclk))

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -30,6 +30,16 @@ from cocotb.handle import HierarchyObject, ModifiableObject, RealObject, Integer
 from cocotb.triggers import Timer
 from cocotb.result import TestError, TestFailure
 
+@cocotb.test(expect_fail=True)
+def check_enum_object(dut):
+    """
+    Enumerations currently behave as normal signals
+
+    TODO: Implement an EnumObject class and detect valid string mappings
+    """
+    yield Timer(100)
+    if not isinstance(dut.inst_ram_ctrl.write_ram_fsm, IntegerObject):
+        raise TestFailure("Expected the FSM enum to be an InterObject")
 
 @cocotb.test()
 def check_objects(dut):
@@ -59,7 +69,6 @@ def check_objects(dut):
     fails += check_instance(dut.current_active, IntegerObject)
     fails += check_instance(dut.inst_axi4s_buffer.DATA_WIDTH, ConstantObject)
     fails += check_instance(dut.inst_ram_ctrl, HierarchyObject)
-    fails += check_instance(dut.inst_ram_ctrl.write_ram_fsm, IntegerObject)
 
     if dut.inst_axi4s_buffer.DATA_WIDTH != 32:
         tlog.error("Expected dut.inst_axi4s_buffer.DATA_WIDTH to be 32 but got %d",

--- a/tests/test_cases/test_vhdl_access/test_vhdl_access.py
+++ b/tests/test_cases/test_vhdl_access/test_vhdl_access.py
@@ -75,7 +75,7 @@ def check_objects(dut):
 
     try:
         dut.inst_axi4s_buffer.DATA_WIDTH <= 42
-        tlog.error("Shouldn't be allowed to set a value on constant object")
+        tlog.error("Shouldn't be allowed to set a value on constant object using __le__")
         fails += 1
     except ValueError as e:
         pass


### PR DESCRIPTION
Various things were wrong in handle.py which have been fixed by this commit.

* Can't assign to constant objects
* Can't traverse hierarhcy of non-hierarchy objects
* Can't get/set values on hierarchy objects
* Optimise constants access - cache the value once on retrieval

Had to remove ENUM mapping to Integers as we weren't able to distinguish between normal objects and enums in VHDL.