### PR TITLE
Fix pdf documentation generation for sphinx latexpdf

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -262,8 +262,10 @@ class BinaryValue(object):
 
     def get_buff(self):
         """Attribute self.buff represents the value as a binary string buffer
-            e.g. vector "0000000100011111".buff == "\x01\x1F"
-            TODO: Doctest this!
+
+        >>> "0100000100101111".buff == "\x41\x2F"
+        True
+
         """
         bits = resolve(self._str)
         if len(bits) % 8:

--- a/documentation/source/endian_swapper.rst
+++ b/documentation/source/endian_swapper.rst
@@ -17,7 +17,7 @@ Design
 
 We have a relatively simplistic RTL block called the endian_swapper.  The DUT has three interfaces, all conforming to the Avalon standard:
 
-.. image:: diagrams/svg/endian_swapper_design.svg
+.. image:: diagrams/svg/endian_swapper_design.*
 
 The DUT will swap the endianness of packets on the Avalon-ST bus if a configuration bit is set.  For every packet arriving on the "stream_in" interface the entire packet will be endian swapped if the configuration bit is set, otherwise the entire packet will pass through unmodified.
 
@@ -46,7 +46,7 @@ To begin with we create a class to encapsulate all the common code for the testb
 
 With the above code we have created a testbench with the following structure:
 
-.. image:: diagrams/svg/endian_swapper_testbench.svg
+.. image:: diagrams/svg/endian_swapper_testbench.*
 
 If we inspect this line-by-line:
 

--- a/documentation/source/hal_cosimulation.rst
+++ b/documentation/source/hal_cosimulation.rst
@@ -60,7 +60,7 @@ coroutine (by running the function in a separate thread).  The
 to be called by a normal thread.  The call sequence looks like this:
 
 
-.. image:: diagrams/svg/hal_cosimulation.svg
+.. image:: diagrams/svg/hal_cosimulation.*
 
 
 Implementation

--- a/documentation/source/introduction.rst
+++ b/documentation/source/introduction.rst
@@ -62,7 +62,7 @@ Overview
 A typical cocotb testbench requires no additional RTL code. The Design Under Test (DUT) is instantiated as the toplevel in the simulator without any wrapper code. Cocotb drives stimulus onto the inputs to the DUT (or further down the hierarchy) and monitors the outputs directly from Python.
 
 
-.. image:: diagrams/svg/cocotb_overview.svg
+.. image:: diagrams/svg/cocotb_overview.*
 
 A test is simply a Python function.  At any given time either the simulator is advancing time or the Python code is executing.  The **yield** keyword is used to indicate when to pass control of execution back to the simulator.  A test can spawn multiple coroutines, allowing for independent flows of execution.
 

--- a/documentation/source/ping_tun_tap.rst
+++ b/documentation/source/ping_tun_tap.rst
@@ -31,7 +31,7 @@ Linux has a `TUN/TAP`_ virtual network device which we can use for this
 purpose, allowing `ping`_ to run unmodified and unaware that it is
 communicating with our simulation rather than a remote network endpoint.
 
-.. image:: diagrams/svg/ping_tun_tap.svg
+.. image:: diagrams/svg/ping_tun_tap.*
 
 
 Implementation


### PR DESCRIPTION
I had two problems to generate the pdf documentation : 
- in binary.py there was a comment with non-utf8 characters
- all svg files was not found by latex

Here a pull request to fix both.