### PR TITLE
Issue#17

### DIFF
--- a/lib/fli/FliImpl.cpp
+++ b/lib/fli/FliImpl.cpp
@@ -107,6 +107,13 @@ void FliImpl::sim_end(void)
     mti_Cmd(stop);
 }
 
+GpiObjHdl* FliImpl::native_check_create(void *raw_hdl, GpiObjHdl *parent)
+{
+    LOG_WARN("%s implementation can not create from raw handle",
+             m_name.c_str());
+    return NULL;
+}
+
 /**
  * @name    Native Check Create
  * @brief   Determine whether a simulation object is native to FLI and create

--- a/lib/fli/FliImpl.h
+++ b/lib/fli/FliImpl.h
@@ -241,6 +241,7 @@ public:
     /* Hierachy related */
     GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent);
     GpiObjHdl* native_check_create(uint32_t index, GpiObjHdl *parent);
+    GpiObjHdl* native_check_create(void *raw_hdl, GpiObjHdl *paret);
     GpiObjHdl *get_root_handle(const char *name);
     GpiIterator *iterate_handle(GpiObjHdl *obj_hdl, gpi_iterator_sel_t type);
 

--- a/lib/gpi/gpi_priv.h
+++ b/lib/gpi/gpi_priv.h
@@ -215,14 +215,18 @@ public:
 class GpiIterator : public GpiHdl {
 public:
     enum Status {
-        VALID, VALID_NO_NAME, INVALID, END
+        NATIVE,             // Fully resolved object was created
+        NATIVE_NO_NAME,     // Native object was found but unable to fully create
+        NOT_NATIVE,         // Mon native object was found but we did get a name
+        NOT_NATIVE_NO_NAME, // Mon native object was found without a name
+        END
     };
 
     GpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiHdl(impl),
                                                           m_parent(hdl) { }
     virtual ~GpiIterator() { }
 
-    virtual int next_handle(std::string &name, GpiObjHdl **hdl) {
+    virtual Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl) {
         name = "";
         *hdl = NULL;
         return GpiIterator::END;
@@ -251,6 +255,7 @@ public:
     /* Hierachy related */
     virtual GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent) = 0;
     virtual GpiObjHdl* native_check_create(uint32_t index, GpiObjHdl *parent) = 0;
+    virtual GpiObjHdl* native_check_create(void *raw_hdl, GpiObjHdl *parent) = 0;
     virtual GpiObjHdl *get_root_handle(const char *name) = 0;
     virtual GpiIterator *iterate_handle(GpiObjHdl *obj_hdl, gpi_iterator_sel_t type) = 0;
 

--- a/lib/vhpi/VhpiCbHdl.cpp
+++ b/lib/vhpi/VhpiCbHdl.cpp
@@ -712,6 +712,8 @@ VhpiIterator::~VhpiIterator()
         vhpi_release_handle(m_iterator);
 }
 
+#define VHPI_TYPE_MIN (1000)
+
 GpiIterator::Status VhpiIterator::next_handle(std::string &name,
                                               GpiObjHdl **hdl,
                                               void **raw_hdl)
@@ -769,7 +771,7 @@ GpiIterator::Status VhpiIterator::next_handle(std::string &name,
         int type = vhpi_get(vhpiKindP, obj);
         LOG_WARN("Unable to get the name for this object of type %d", type);
 
-        if (type < 1000) {
+        if (type < VHPI_TYPE_MIN) {
             *raw_hdl = (void*)obj;
             return GpiIterator::NOT_NATIVE_NO_NAME;
         }

--- a/lib/vhpi/VhpiImpl.cpp
+++ b/lib/vhpi/VhpiImpl.cpp
@@ -272,6 +272,37 @@ GpiObjHdl *VhpiImpl::create_gpi_obj_from_handle(vhpiHandleT new_hdl,
     return new_obj;
 }
 
+GpiObjHdl *VhpiImpl::native_check_create(void *raw_hdl, GpiObjHdl *parent)
+{
+    LOG_DEBUG("Trying to convert raw to VHPI handle");
+
+    vhpiHandleT new_hdl = (vhpiHandleT)raw_hdl;
+
+    std::string fq_name = parent->get_fullname();
+    const char *c_name = vhpi_get_str(vhpiNameP, new_hdl);
+    if (!c_name) {
+        LOG_DEBUG("Unable to query name of passed in handle");
+        return NULL;
+    }
+
+    std::string name = c_name;
+
+    if (fq_name == ":") {
+        fq_name += name;
+    } else {
+        fq_name += "." + name;
+    }
+
+    GpiObjHdl* new_obj = create_gpi_obj_from_handle(new_hdl, name, fq_name);
+    if (new_obj == NULL) {
+        vhpi_release_handle(new_hdl);
+        LOG_DEBUG("Unable to fetch object %s", fq_name.c_str());
+        return NULL;
+    }
+
+    return new_obj;
+}
+
 GpiObjHdl *VhpiImpl::native_check_create(std::string &name, GpiObjHdl *parent)
 {
     vhpiHandleT new_hdl;

--- a/lib/vhpi/VhpiImpl.h
+++ b/lib/vhpi/VhpiImpl.h
@@ -198,7 +198,7 @@ public:
 
     virtual ~VhpiIterator();
 
-    int next_handle(std::string &name, GpiObjHdl **hdl);
+    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl);
 
 private:
     vhpiHandleT m_iterator;
@@ -231,6 +231,7 @@ public:
     int deregister_callback(GpiCbHdl *obj_hdl);
     GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent);
     GpiObjHdl* native_check_create(uint32_t index, GpiObjHdl *parent);
+    GpiObjHdl* native_check_create(void *raw_hdl, GpiObjHdl *parent);
 
     const char * reason_to_string(int reason);
     const char * format_to_string(int format);

--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -68,13 +68,11 @@ int VpiCbHdl::arm_callback(void) {
     }
 
     vpiHandle new_hdl = vpi_register_cb(&cb_data);
-    check_vpi_error();
-    
-    int ret = 0;
 
     if (!new_hdl) {
         LOG_ERROR("VPI: Unable to register a callback handle for VPI type %s(%d)",
-                     m_impl->reason_to_string(cb_data.reason), cb_data.reason);
+                  m_impl->reason_to_string(cb_data.reason), cb_data.reason);
+        check_vpi_error();
         return -1;
 
     } else {
@@ -83,7 +81,7 @@ int VpiCbHdl::arm_callback(void) {
     
     m_obj_hdl = new_hdl;
 
-    return ret;
+    return 0;
 }
 
 int VpiCbHdl::cleanup_callback(void)
@@ -164,6 +162,11 @@ long VpiSignalObjHdl::get_signal_value_long(void)
 int VpiSignalObjHdl::set_signal_value(long value)
 {
     FENTER
+
+    LOG_WARN("Writing %ld to %s",
+         value,
+         m_name.c_str());
+
     s_vpi_value value_s;
 
     value_s.value.integer = value;

--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -547,6 +547,8 @@ GpiIterator::Status VpiSingleIterator::next_handle(std::string &name,
         return GpiIterator::NOT_NATIVE;
 }
 
+#define VPI_TYPE_MAX (1000)
+
 GpiIterator::Status VpiIterator::next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl)
 {
     GpiObjHdl *new_obj;
@@ -600,7 +602,7 @@ GpiIterator::Status VpiIterator::next_handle(std::string &name, GpiObjHdl **hdl,
         int type = vpi_get(vpiType, obj);
         LOG_WARN("Unable to get the name for this object of type %d", type);
 
-        if (type >= 1000) {
+        if (type >= VPI_TYPE_MAX) {
             *raw_hdl = (void*)obj;
             return GpiIterator::NOT_NATIVE_NO_NAME;
         }

--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -475,7 +475,7 @@ VpiIterator::VpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiIterator(i
 
     int type = vpi_get(vpiType, vpi_hdl);
     if (NULL == (selected = iterate_over.get_options(type))) {
-        LOG_ERROR("VPI: Implementation does not know how to iterate over %s(%d)",
+        LOG_WARN("VPI: Implementation does not know how to iterate over %s(%d)",
                   vpi_get_str(vpiType, vpi_hdl), type);
         return;
     }

--- a/lib/vpi/VpiImpl.cpp
+++ b/lib/vpi/VpiImpl.cpp
@@ -184,6 +184,30 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
     return new_obj;
 }
 
+GpiObjHdl* VpiImpl::native_check_create(void *raw_hdl, GpiObjHdl *parent)
+{
+    LOG_DEBUG("Trying to convert raw to VPI handle");
+
+    vpiHandle new_hdl = (vpiHandle)raw_hdl;
+
+    const char *c_name = vpi_get_str(vpiName, new_hdl);
+    if (!c_name) {
+        LOG_DEBUG("Unable to query name of passed in handle");
+        return NULL;
+    }
+
+    std::string name = c_name;
+    std::string fq_name = parent->get_fullname() + "." + name;
+
+    GpiObjHdl* new_obj = create_gpi_obj_from_handle(new_hdl, name, fq_name);
+    if (new_obj == NULL) {
+        vpi_free_object(new_hdl);
+        LOG_ERROR("Unable to fetch object %s", fq_name.c_str());
+        return NULL;
+    }
+    return new_obj;
+}
+
 GpiObjHdl* VpiImpl::native_check_create(std::string &name, GpiObjHdl *parent)
 {
     vpiHandle new_hdl;

--- a/lib/vpi/VpiImpl.h
+++ b/lib/vpi/VpiImpl.h
@@ -219,7 +219,7 @@ public:
 
     virtual ~VpiIterator();
 
-    int next_handle(std::string &name, GpiObjHdl **hdl);
+    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl);
 
 private:
     vpiHandle m_iterator;
@@ -246,7 +246,7 @@ public:
     }
 
     virtual ~VpiSingleIterator() { }
-    int next_handle(std::string &name, GpiObjHdl **hdl);
+    Status next_handle(std::string &name, GpiObjHdl **hdl, void **raw_hdl);
 
 protected:
     vpiHandle m_iterator;
@@ -277,6 +277,7 @@ public:
     int deregister_callback(GpiCbHdl *obj_hdl);
     GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent);
     GpiObjHdl* native_check_create(uint32_t index, GpiObjHdl *parent);
+    GpiObjHdl* native_check_create(void *raw_hdl, GpiObjHdl *parent);
     const char * reason_to_string(int reason);
     GpiObjHdl* create_gpi_obj_from_handle(vpiHandle new_hdl,
                                           std::string &name,

--- a/makefiles/simulators/Makefile.ius
+++ b/makefiles/simulators/Makefile.ius
@@ -37,7 +37,7 @@ ifeq ($(shell ncbits),64)
 $(error "The 64bit version of IUS is on your PATH, please use the 32bit version for now")
 endif
 
-EXTRA_ARGS += -nclibdirname $(SIM_BUILD)
+EXTRA_ARGS += -nclibdirname $(SIM_BUILD) -plinowarn
 
 ifeq ($(GUI),1)
     EXTRA_ARGS += -gui

--- a/tests/designs/uart2bus/Makefile
+++ b/tests/designs/uart2bus/Makefile
@@ -34,7 +34,7 @@ ifeq ($(SIM),ius)
 endif
 
 else
-	$(error "Only verilog toplevel supported at the moment")
+$(error "Only verilog toplevel supported at the moment")
 endif
 
 ifneq ($(GPI_EXTRA),)

--- a/tests/test_cases/test_iteration_mixedlang/test_iteration.py
+++ b/tests/test_cases/test_iteration_mixedlang/test_iteration.py
@@ -65,10 +65,22 @@ def recursive_discovery(dut):
     """
     Recursively discover every single object in the design
     """
+    if cocotb.SIM_NAME in ["ncsim(64)",
+                           "ncsim"]:
+        # vpiAlways = 31 and vpiStructVar = 2 do not show up in IUS
+        # But vhpiSimpleSigAssignStmtK objects do, and ther are 2. 
+        pass_total = 883
+    else:
+        pass_total = 916
+
     tlog = logging.getLogger("cocotb.test")
     yield Timer(100)
     total = recursive_dump(dut, tlog)
-    tlog.info("Found a total of %d things", total)
+
+    if pass_total != total:
+        raise TestFailure("Expected %d but found %d" % (pass_total, total))
+    else:
+        tlog.info("Found a total of %d things", total)
 
     if not isinstance(dut.i_verilog.uart1.baud_gen_1.baud_freq, cocotb.handle.ModifiableObject):
         tlog.error("Expected dut.i_verilog.uart1.baud_gen_1.baud_freq to be modifiable")
@@ -84,10 +96,17 @@ def recursive_discovery_boundary(dut):
     However if we manually delve through the language boundary we
     should then be able to iterate to discover objects
     """
+    if cocotb.SIM_NAME in ["ncsim(64)",
+                           "ncsim"]:
+        # # But vhpiSimpleSigAssignStmtK objects only show up on IUS, and ther are 2
+        pass_total = 428
+    else:
+        pass_total = 426
+
     tlog = logging.getLogger("cocotb.test")
     yield Timer(100)
     total = recursive_dump(dut.i_vhdl, tlog)
     tlog.info("Found a total of %d things", total)
-    if total != 426:
-        raise TestFailure("Expected 426 objects but found %d" % total)
+    if total != pass_total:
+        raise TestFailure("Expected %d objects but found %d" % (pass_total, total))
 


### PR DESCRIPTION
Transparent traversal of a language boundary now works on IUS and Aldec. 

If an object can be created via the implementation of the parent doing the iteration then it will.
If only the name can be obtained then it passed up and the GPI code will try other implementations.
If nothing can be determined apart from the type and this indicates it is non native then pass up the raw handle and allow the GPI layer to ask implementations to convert. 