### PR TITLE
AvalonMM adding cs signal, do some correction for burst in AvalonMemory

### DIFF
--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -54,7 +54,8 @@ class AvalonMM(BusDriver):
     """
     _signals = ["address"]
     _optional_signals = ["readdata", "read", "write", "waitrequest",
-                         "writedata", "readdatavalid", "byteenable"]
+                         "writedata", "readdatavalid", "byteenable",
+                         "cs"]
 
 
     def __init__(self, entity, name, clock):
@@ -76,6 +77,9 @@ class AvalonMM(BusDriver):
 
         if hasattr(self.bus, "byteenable"):
             self.bus.byteenable.setimmediatevalue(0)
+
+        if hasattr(self.bus, "cs"):
+            self.bus.cs.setimmediatevalue(0)
 
         self.bus.address.setimmediatevalue(0)
 
@@ -130,6 +134,8 @@ class AvalonMaster(AvalonMM):
         self.bus.read <= 1
         if hasattr(self.bus, "byteenable"):
             self.bus.byteenable <= int("1"*len(self.bus.byteenable), 2)
+        if hasattr(self.bus, "cs"):
+            self.bus.cs <= 1
 
         # Wait for waitrequest to be low
         if hasattr(self.bus, "waitrequest"):
@@ -150,6 +156,8 @@ class AvalonMaster(AvalonMM):
         self.bus.read <= 0
         if hasattr(self.bus, "byteenable"):
             self.bus.byteenable <= 0
+        if hasattr(self.bus, "cs"):
+            self.bus.cs <= 0
 
         self._release_lock()
         raise ReturnValue(data)
@@ -174,6 +182,8 @@ class AvalonMaster(AvalonMM):
         self.bus.write <= 1
         if hasattr(self.bus, "byteenable"):
             self.bus.byteenable <= int("1"*len(self.bus.byteenable), 2)
+        if hasattr(self.bus, "cs"):
+            self.bus.cs <= 1
 
         # Wait for waitrequest to be low
         if hasattr(self.bus, "waitrequest"):
@@ -184,6 +194,8 @@ class AvalonMaster(AvalonMM):
         self.bus.write <= 0
         if hasattr(self.bus, "byteenable"):
             self.bus.byteenable <= 0
+        if hasattr(self.bus, "cs"):
+            self.bus.cs <= 0
 
         v = self.bus.writedata.value
         v.binstr = "x" * len(self.bus.writedata)

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -317,7 +317,9 @@ class AvalonMemory(BusDriver):
                 else:
                     addr = self.bus.address.value.integer
                     if addr % (self._width/8) != 0:
-                        self.log.error("Address must be aligned to data width")
+                        self.log.error("Address must be aligned to data width" +
+                                       "(addr = " + hex(addr) +
+                                       ", width = " + str(self._width))
                     addr = addr / (self._width/8)
                     burstcount = self.bus.burstcount.value.integer
                     byteenable = self.bus.byteenable.value


### PR DESCRIPTION
Some Avalon component use a chipselect signal named 'cs'. I added it in AvalonMM class.

I also added some little correction in read-bursting capabilities in AvalonMemory class.