### PR TITLE
Wishbone

### DIFF
--- a/cocotb/drivers/wishbone.py
+++ b/cocotb/drivers/wishbone.py
@@ -16,8 +16,8 @@ def is_sequence(arg):
 class WBAux():
     """Wishbone Auxiliary Wrapper Class, wrap meta informations on bus transaction (internal only)
     """
-    adr   = 0
-    datwr = None     
+    adr         = 0
+    datwr       = None     
     sel         = 0xf
     waitStall   = 0
     waitIdle    = 0
@@ -52,14 +52,14 @@ class WBOp():
 class WBRes():
     """Wishbone Result Wrapper Class. What's happend on the bus plus meta information on timing
     """
-    adr   = 0
-    sel   = 0xf
-    datwr = None    
-    datrd = None
-    ack = False
-    waitstall = 0
-    waitack = 0
-    waitidle = 0
+    adr         = 0
+    sel         = 0xf
+    datwr       = None    
+    datrd       = None
+    ack         = False
+    waitstall   = 0
+    waitack     = 0
+    waitidle    = 0
     
     def __init__(self, ack, sel, adr, datrd, datwr, waitIdle, waitStall, waitAck):
         self.ack        = ack
@@ -95,16 +95,15 @@ class Wishbone(BusDriver):
         v.binstr = "1" * len(self.bus.sel)
         self.bus.sel <= v
     
-    def send_cycle(self, ops):
-        pass
+
 
 class WishboneMaster(Wishbone):
     """Wishbone master
     """
-    _acked_ops          = 0  # ack cntr. comp with opbuf len. wait for equality before releasing lock
-    _res_buf            = [] # save readdata/ack/err
-    _aux_buf            = [] # save read/write order
-    _op_cnt             = 0 # number of ops we've been issued
+    _acked_ops          = 0     # ack cntr. comp with opbuf len. wait for equality before releasing lock
+    _res_buf            = []    # save readdata/ack/err
+    _aux_buf            = []    # save read/write order
+    _op_cnt             = 0     # number of ops we've been issued
     _clk_cycle_count    = 0
     _timeout            = None
 
@@ -118,6 +117,7 @@ class WishboneMaster(Wishbone):
         self.busy_event = Event("%s_busy" % name)
         self.busy = False
         self._timeout = timeout
+
         
     @coroutine 
     def _clk_cycle_counter(self):
@@ -129,6 +129,7 @@ class WishboneMaster(Wishbone):
         while self.busy:
             yield clkedge
             self._clk_cycle_count += 1    
+
   
     @coroutine
     def _open_cycle(self):
@@ -145,6 +146,7 @@ class WishboneMaster(Wishbone):
         self._res_buf   = [] 
         self._aux_buf   = []
         self.log.debug("Opening cycle, %u Ops" % self._op_cnt)
+
         
     @coroutine    
     def _close_cycle(self):
@@ -175,7 +177,7 @@ class WishboneMaster(Wishbone):
     
     @coroutine
     def _wait_stall(self):
-        """Wait for stall to be low before continuing
+        """Wait for stall to be low before continuing (Pipelined Wishbone)
         """
         clkedge = RisingEdge(self.clock)
         count = 0
@@ -193,7 +195,7 @@ class WishboneMaster(Wishbone):
     
     @coroutine
     def _wait_ack(self):
-        """Wait for ACK on the bus before continuing
+        """Wait for ACK on the bus before continuing (Non pipelined Wishbone)
         """
         #wait for acknownledgement before continuing - Classic Wishbone without pipelining
         clkedge = RisingEdge(self.clock)
@@ -327,7 +329,7 @@ class WishboneMaster(Wishbone):
                 
             raise ReturnValue(result)
         else:
-            self.log.error("Expecting a list")
+            raise TestFailure("Sorry, argument must be a list of WBOp (Wishbone Operation) objects!")
             raise ReturnValue(None)    
     
  

--- a/cocotb/drivers/wishbone.py
+++ b/cocotb/drivers/wishbone.py
@@ -1,0 +1,333 @@
+
+
+import cocotb
+from cocotb.decorators import coroutine
+from cocotb.triggers import RisingEdge, Event
+from cocotb.drivers import BusDriver
+from cocotb.result import ReturnValue, TestFailure
+from cocotb.decorators import public    
+
+
+def is_sequence(arg):
+        return (not hasattr(arg, "strip") and
+        hasattr(arg, "__getitem__") or
+        hasattr(arg, "__iter__"))
+
+class WBAux():
+    """Wishbone Auxiliary Wrapper Class, wrap meta informations on bus transaction (internal only)
+    """
+    adr   = 0
+    datwr = None     
+    sel         = 0xf
+    waitStall   = 0
+    waitIdle    = 0
+    ts          = 0
+    
+    def __init__(self, sel, adr, datwr, waitStall, waitIdle, tsStb):
+        self.adr        = adr
+        self.datwr      = datwr        
+        self.sel        = sel
+        self.waitStall  = waitStall
+        self.ts         = tsStb
+        self.waitIdle   = waitIdle
+
+@public
+class WBOp():
+    """Wishbone Operations Wrapper Class, an attempt to wrap em tidy
+    """
+    adr     = 0
+    sel     = 0xf     
+    dat     = 0
+    idle    = 0
+    
+        
+    
+    def __init__(self, adr, dat=None, idle=0, sel=0xf):
+        self.adr    = adr        
+        self.dat    = dat
+        self.sel    = sel
+        self.idle   = idle
+
+@public
+class WBRes():
+    """Wishbone Result Wrapper Class. What's happend on the bus plus meta information on timing
+    """
+    adr   = 0
+    sel   = 0xf
+    datwr = None    
+    datrd = None
+    ack = False
+    waitstall = 0
+    waitack = 0
+    waitidle = 0
+    
+    def __init__(self, ack, sel, adr, datrd, datwr, waitIdle, waitStall, waitAck):
+        self.ack        = ack
+        self.sel        = sel
+        self.adr        = adr
+        self.datrd      = datrd
+        self.datwr      = datwr
+        self.waitStall  = waitStall
+        self.waitAck    = waitAck
+        self.waitIdle   = waitIdle
+          
+
+class Wishbone(BusDriver):
+    """Wishbone
+    """
+    _width = 32
+    
+    _signals = ["cyc", "stb", "we", "sel", "adr", "datwr", "datrd", "ack"]
+    _optional_signals = ["err", "stall", "rty"]
+
+
+    def __init__(self, entity, name, clock, width=32):
+        BusDriver.__init__(self, entity, name, clock)
+        # Drive some sensible defaults (setimmediatevalue to avoid x asserts)
+        self._width = width        
+        self.bus.cyc.setimmediatevalue(0)
+        self.bus.stb.setimmediatevalue(0)            
+        self.bus.we.setimmediatevalue(0)
+        self.bus.adr.setimmediatevalue(0)
+        self.bus.datwr.setimmediatevalue(0)
+        
+        v = self.bus.sel.value
+        v.binstr = "1" * len(self.bus.sel)
+        self.bus.sel <= v
+    
+    def send_cycle(self, ops):
+        pass
+
+class WishboneMaster(Wishbone):
+    """Wishbone master
+    """
+    _acked_ops          = 0  # ack cntr. comp with opbuf len. wait for equality before releasing lock
+    _res_buf            = [] # save readdata/ack/err
+    _aux_buf            = [] # save read/write order
+    _op_cnt             = 0 # number of ops we've been issued
+    _clk_cycle_count    = 0
+    _timeout            = None
+
+    
+    def __init__(self, entity, name, clock, timeout=None, width=32):
+        Wishbone.__init__(self, entity, name, clock, width)
+        sTo = ", no cycle timeout"        
+        if not (timeout is None):
+            sTo = ", cycle timeout is %u clockcycles" % timeout
+        self.log.info("Wishbone Master created%s" % sTo)
+        self.busy_event = Event("%s_busy" % name)
+        self.busy = False
+        self._timeout = timeout
+        
+    @coroutine 
+    def _clk_cycle_counter(self):
+        """
+            Cycle counter to time bus operations
+        """
+        clkedge = RisingEdge(self.clock)
+        self._clk_cycle_count = 0
+        while self.busy:
+            yield clkedge
+            self._clk_cycle_count += 1    
+  
+    @coroutine
+    def _open_cycle(self):
+        #Open new wishbone cycle        
+        if self.busy:
+            self.log.error("Opening Cycle, but WB Driver is already busy. Someting's wrong")
+            yield self.busy_event.wait()
+        self.busy_event.clear()
+        self.busy       = True
+        cocotb.fork(self._read())
+        cocotb.fork(self._clk_cycle_counter()) 
+        self.bus.cyc    <= 1
+        self._acked_ops = 0  
+        self._res_buf   = [] 
+        self._aux_buf   = []
+        self.log.debug("Opening cycle, %u Ops" % self._op_cnt)
+        
+    @coroutine    
+    def _close_cycle(self):
+        #Close current wishbone cycle  
+        clkedge = RisingEdge(self.clock)
+        count           = 0
+        last_acked_ops  = 0
+        #Wait for all Operations being acknowledged by the slave before lowering the cycle line
+        #This is not mandatory by the bus standard, but a crossbar might send acks to the wrong master
+        #if we don't wait. We don't want to risk that, it could hang the bus
+        while self._acked_ops < self._op_cnt:
+            if last_acked_ops != self._acked_ops:
+                self.log.debug("Waiting for missing acks: %u/%u" % (self._acked_ops, self._op_cnt) )
+            last_acked_ops = self._acked_ops    
+            #check for timeout when finishing the cycle            
+            count += 1
+            if (not (self._timeout is None)):
+                if (count > self._timeout): 
+                    raise TestFailure("Timeout of %u clock cycles reached when waiting for reply from slave" % self._timeout)                
+            yield clkedge
+            
+        self.busy = False
+        self.busy_event.set()
+        self.bus.cyc <= 0 
+        self.log.debug("Closing cycle")
+        yield clkedge        
+
+    
+    @coroutine
+    def _wait_stall(self):
+        """Wait for stall to be low before continuing
+        """
+        clkedge = RisingEdge(self.clock)
+        count = 0
+        if hasattr(self.bus, "stall"):
+            count = 0            
+            while self.bus.stall.getvalue():
+                yield clkedge
+                count += 1
+                if (not (self._timeout is None)):
+                    if (count > self._timeout): 
+                        raise TestFailure("Timeout of %u clock cycles reached when on stall from slave" % self._timeout)                
+            self.log.debug("Stalled for %u cycles" % count)
+        raise ReturnValue(count)
+    
+    
+    @coroutine
+    def _wait_ack(self):
+        """Wait for ACK on the bus before continuing
+        """
+        #wait for acknownledgement before continuing - Classic Wishbone without pipelining
+        clkedge = RisingEdge(self.clock)
+        count = 0
+        if not hasattr(self.bus, "stall"):
+            while not self._get_reply():
+                yield clkedge
+                count += 1
+            self.log.debug("Waited %u cycles for ackknowledge" % count)
+        raise ReturnValue(count)    
+    
+    
+    def _get_reply(self):
+        #helper function for slave acks
+        tmpAck = int(self.bus.ack.getvalue())
+        tmpErr = 0
+        tmpRty = 0
+        if hasattr(self.bus, "err"):        
+            tmpErr = int(self.bus.err.getvalue())
+        if hasattr(self.bus, "rty"):        
+            tmpRty = int(self.bus.rty.getvalue())
+        #check if more than one line was raised    
+        if ((tmpAck + tmpErr + tmpRty)  > 1):
+            raise TestFailure("Slave raised more than one reply line at once! ACK: %u ERR: %u RTY: %u" % (tmpAck, tmpErr, tmpRty))
+        #return 0 if no reply, 1 for ACK, 2 for ERR, 3 for RTY. use 'replyTypes' Dict for lookup
+        return (tmpAck + 2 * tmpErr + 3 * tmpRty)
+        
+    
+    @coroutine 
+    def _read(self):
+        """
+            Reader for slave replies
+        """
+        count = 0
+        clkedge = RisingEdge(self.clock)
+        while self.busy:
+            reply = self._get_reply()    
+            # valid reply?            
+            if(bool(reply)):
+                datrd = int(self.bus.datrd.getvalue())
+                #append reply and meta info to result buffer
+                tmpRes =  WBRes(ack=reply, sel=None, adr=None, datrd=datrd, datwr=None, waitIdle=None, waitStall=None, waitAck=self._clk_cycle_count)               
+                self._res_buf.append(tmpRes)
+                self._acked_ops += 1
+            yield clkedge
+            count += 1    
+
+    
+    @coroutine
+    def _drive(self, we, adr, datwr, sel, idle):
+        """
+            Drive the Wishbone Master Out Lines
+        """
+    
+        clkedge = RisingEdge(self.clock)
+        if self.busy:
+            # insert requested idle cycles            
+            if idle != None:
+                idlecnt = idle
+                while idlecnt > 0:
+                    idlecnt -= 1
+                    yield clkedge
+            # drive outputs    
+            self.bus.stb    <= 1
+            self.bus.adr    <= adr
+            self.bus.sel    <= sel
+            self.bus.datwr  <= datwr
+            self.bus.we     <= we
+            yield clkedge
+            #deal with flow control (pipelined wishbone)
+            stalled = yield self._wait_stall()
+            #append operation and meta info to auxiliary buffer
+            self._aux_buf.append(WBAux(sel, adr, datwr, stalled, idle, self._clk_cycle_count))
+            #reset strobe and write enable without advancing time
+            self.bus.stb    <= 0
+            self.bus.we     <= 0
+            # non pipelined wishbone
+            yield self._wait_ack()
+        else:
+           self.log.error("Cannot drive the Wishbone bus outside a cycle!")
+
+
+  
+    @coroutine
+    def send_cycle(self, arg):
+        """
+            The main sending routine        
+        
+        Args:
+            list(WishboneOperations)
+            
+        """
+        cnt = 0
+        clkedge = RisingEdge(self.clock)
+        yield clkedge
+        if is_sequence(arg):
+            if len(arg) < 1:
+                self.log.error("List contains no operations to carry out")
+            else:
+         
+                self._op_cnt = len(arg)
+                firstword = True
+                for op in arg:
+                    if not isinstance(op, WBOp):
+                        raise TestFailure("Sorry, argument must be a list of WBOp (Wishbone Operation) objects!")    
+                    if firstword:
+                        firstword = False
+                        result = []
+                        yield self._open_cycle()
+                        
+                    if op.dat != None:
+                        we  = 1
+                        dat = op.dat
+                    else:
+                        we  = 0
+                        dat = 0
+                    yield self._drive(we, op.adr, dat, op.sel, op.idle)
+                    self.log.debug("#%3u WE: %s ADR: 0x%08x DAT: 0x%08x SEL: 0x%1x IDLE: %3u" % (cnt, we, op.adr, dat, op.sel, op.idle))
+                    cnt += 1
+                yield self._close_cycle()
+                
+                #do pick and mix from result- and auxiliary buffer so we get all operation and meta info
+                for res, aux in zip(self._res_buf, self._aux_buf):
+                    res.datwr       = aux.datwr
+                    res.sel         = aux.sel
+                    res.adr         = aux.adr
+                    res.waitIdle    = aux.waitIdle
+                    res.waitStall   = aux.waitStall
+                    res.waitack    -= aux.ts
+                    result.append(res)
+                
+            raise ReturnValue(result)
+        else:
+            self.log.error("Expecting a list")
+            raise ReturnValue(None)    
+    
+ 

--- a/cocotb/monitors/wishbone.py
+++ b/cocotb/monitors/wishbone.py
@@ -1,0 +1,269 @@
+
+import cocotb
+from cocotb.decorators import coroutine
+from cocotb.monitors import BusMonitor
+from cocotb.triggers import RisingEdge
+from cocotb.result import TestFailure
+from cocotb.decorators import public  
+import Queue
+
+
+class WBAux():
+    """Wishbone Auxiliary Wrapper Class, wrap meta informations on bus transaction (internal only)
+    """
+    adr   = 0
+    datwr = None     
+    sel         = 0xf
+    waitStall   = 0
+    waitIdle    = 0
+    ts          = 0
+    
+    def __init__(self, sel, adr, datwr, waitStall, waitIdle, tsStb):
+        self.adr        = adr
+        self.datwr      = datwr        
+        self.sel        = sel
+        self.waitStall  = waitStall
+        self.ts         = tsStb
+        self.waitIdle   = waitIdle
+
+@public
+class WBRes():
+    """Wishbone Result Wrapper Class. What's happend on the bus plus meta information on timing
+    """
+    adr   = 0
+    sel   = 0xf
+    datwr = None    
+    datrd = None
+    ack = False
+    waitstall = 0
+    waitack = 0
+    waitidle = 0
+    
+    def __init__(self, ack, sel, adr, datrd, datwr, waitIdle, waitStall, waitAck):
+        self.ack        = ack
+        self.sel        = sel
+        self.adr        = adr
+        self.datrd      = datrd
+        self.datwr      = datwr
+        self.waitStall  = waitStall
+        self.waitAck    = waitAck
+        self.waitIdle   = waitIdle
+          
+
+class Wishbone(BusMonitor):
+    """Wishbone
+    """
+    _width = 32
+    
+    _signals = ["cyc", "stb", "we", "sel", "adr", "datwr", "datrd", "ack"]
+    _optional_signals = ["err", "stall", "rty"]
+    replyTypes = {1 : "ack", 2 : "err", 3 : "rty"}  
+
+    def __init__(self, *args, **kwargs):
+        self._width = kwargs.pop('width', 32)
+        BusMonitor.__init__(self, *args, **kwargs)
+        # Drive some sensible defaults (setimmediatevalue to avoid x asserts)
+        self.bus.ack.setimmediatevalue(0)
+        self.bus.datrd.setimmediatevalue(0)
+        if hasattr(self.bus, "err"):        
+            self.bus.err.setimmediatevalue(0)
+        if hasattr(self.bus, "stall"): 
+            self.bus.stall.setimmediatevalue(0) 
+    
+    @coroutine
+    def _respond(self):
+        pass
+    
+    @coroutine
+    def receive_cycle(self, arg):
+        pass
+            
+
+class WishboneSlave(Wishbone):
+    """Wishbone slave
+    """
+    
+    def bitSeqGen(self, tupleGen):
+        while True: 
+            [highCnt, lowCnt] = tupleGen.next()
+                #make sure there's something in here            
+            if lowCnt < 1:
+                lowCnt = 1
+            bits=[]
+            for i in range(0, highCnt):
+               bits.append(1)          
+            for i in range(0, lowCnt):
+               bits.append(0)
+            for bit in bits:
+                yield bit
+    
+    
+    def defaultTupleGen():
+        while True:        
+            yield int(0), int(1)      
+    
+    def defaultGen():
+        while True:        
+            yield int(0)
+            
+    def defaultGen1():
+        while True:        
+            yield int(1)          
+    
+    _acked_ops      = 0  # ack cntr. wait for equality with number of Ops before releasing lock
+    _reply_Q        = Queue.Queue() # save datwr, sel, idle
+    _res_buf        = [] # save readdata/ack/err/rty
+    _clk_cycle_count = 0
+    _cycle = False
+    _datGen         = defaultGen()
+    _ackGen         = defaultGen1()
+    _stallWaitGen   = defaultGen()
+    _waitAckGen   = defaultGen()
+    _lastTime       = 0
+    _stallCount     = 0
+    
+
+    def __init__(self, *args, **kwargs):
+        datGen = kwargs.pop('datgen', None)
+        ackGen = kwargs.pop('ackgen', None)
+        waitAckGen = kwargs.pop('replywaitgen', None)
+        stallWaitGen = kwargs.pop('stallwaitgen', None)
+        Wishbone.__init__(self, *args, **kwargs)
+        cocotb.fork(self._stall())
+        cocotb.fork(self._clk_cycle_counter())
+        cocotb.fork(self._ack())
+        self.log.info("Wishbone Slave created")
+        
+        if waitAckGen != None:
+            self._waitAckGen  = waitAckGen 
+        if stallWaitGen != None:
+            self._stallWaitGen  = self.bitSeqGen(stallWaitGen)
+        if ackGen != None:
+            self._ackGen        = ackGen
+        if datGen != None:
+            self._datGen        = datGen
+        
+    
+    @coroutine 
+    def _clk_cycle_counter(self):
+        """
+        """
+        clkedge = RisingEdge(self.clock)
+        self._clk_cycle_count = 0
+        while True:
+            if self._cycle:
+                self._clk_cycle_count += 1
+            else:
+                self._clk_cycle_count = 0
+            yield clkedge
+            
+
+    @coroutine
+    def _stall(self):
+        clkedge = RisingEdge(self.clock)
+        # if stall drops, keep the value for one more clock cycle
+        while True:
+            if hasattr(self.bus, "stall"):
+                tmpStall = self._stallWaitGen.next()
+                self.bus.stall <= tmpStall
+                if bool(tmpStall):                                
+                    self._stallCount += 1                    
+                    yield clkedge
+                else:
+                    yield clkedge                    
+                    self._stallCount = 0
+            
+            
+        
+    @coroutine
+    def _ack(self):
+        clkedge = RisingEdge(self.clock)         
+        while True: 
+            #set defaults
+            self.bus.ack    <= 0
+            self.bus.datrd  <= 0
+            if hasattr(self.bus, "err"):
+                self.bus.err <= 0
+            if hasattr(self.bus, "rty"):
+                self.bus.rty <= 0        
+            
+            if not self._reply_Q.empty():
+                #get next reply from queue                    
+                rep = self._reply_Q.get_nowait()
+                
+                #wait <waitAck> clock cycles before replying
+                if rep.waitAck != None:
+                    waitcnt = rep.waitAck
+                    while waitcnt > 0:
+                        waitcnt -= 1
+                        yield clkedge
+                
+                #check if the signal we want to assign exists and assign
+                if not hasattr(self.bus, self.replyTypes[rep.ack]):                
+                    raise TestFailure("Tried to assign <%s> (%u) to slave reply, but this slave does not have a <%s> line" % (self.replyTypes[rep.ack], rep.ack, self.replyTypes[rep.ack]))
+                if self.replyTypes[rep.ack]    == "ack":
+                    self.bus.ack    <= 1
+                elif self.replyTypes[rep.ack]  == "err":
+                    self.bus.err    <= 1
+                elif self.replyTypes[rep.ack]  == "rty":
+                    self.bus.rty    <= 1
+                self.bus.datrd  <= rep.datrd
+            yield clkedge
+
+
+
+    def _respond(self):
+        valid =  bool(self.bus.cyc.getvalue()) and bool(self.bus.stb.getvalue())
+        if hasattr(self.bus, "stall"):
+                valid = valid and not bool(self.bus.stall.getvalue())
+        
+        if valid:
+            #if there is a stall signal, take it into account
+            #wait before replying ?    
+            waitAck = self._waitAckGen.next()
+            #Response: rddata/don't care        
+            if (not bool(self.bus.we.getvalue())):
+                rd = self._datGen.next()
+            else:
+                rd = 0
+         
+            #Response: ack/err/rty
+            reply = self._ackGen.next()
+            if reply not in self.replyTypes:
+                raise TestFailure("Tried to assign unknown reply type (%u) to slave reply. Valid is 1-3 (ack, err, rty)" %  reply)
+            
+            wr = None
+            if bool(self.bus.we.getvalue()):
+                wr = self.bus.datwr.getvalue()
+            
+            #get the time the master idled since the last operation
+            #TODO: subtract our own stalltime or, if we're not pipelined, time since last ack    
+            idleTime = self._clk_cycle_count - self._lastTime -1    
+            res =  WBRes(ack=reply, sel=self.bus.sel.getvalue(), adr=self.bus.adr.getvalue(), datrd=rd, datwr=wr, waitIdle=idleTime, waitStall=self._stallCount, waitAck=waitAck)               
+            #print "#ADR: 0x%08x,0x%x DWR: %s DRD: %s REP: %s IDL: %3u STL: %3u RWA: %3u" % (res.adr, res.sel, res.datwr, res.datrd, replyTypes[res.ack], res.waitIdle, res.waitStall, res.waitAck)       
+            
+           #add whats going to happen to the result buffer
+            self._res_buf.append(res)
+            #add it to the reply queue for assignment. we need to process ops every cycle, so we can't do the <waitreply> delay here
+            self._reply_Q.put(res)
+            self._lastTime = self._clk_cycle_count
+            
+            
+
+    @coroutine
+    def _monitor_recv(self):
+        clkedge = RisingEdge(self.clock)
+  
+        #respong and notify the callback function  
+        while True:
+            if int(self._cycle) < int(self.bus.cyc.getvalue()):
+                self._lastTime = self._clk_cycle_count -1
+                
+            self._respond()
+            if int(self._cycle) > int(self.bus.cyc.getvalue()):
+                self._recv(self._res_buf)
+                self._reply_Q.queue.clear()
+                self._res_buf = []
+                
+            self._cycle = self.bus.cyc.getvalue()
+            yield clkedge


### PR DESCRIPTION
Hi everyone,

I implemented a Driver and Monitor for the  open [Wishbone B4 Bus Standard](cdn.opencores.org/downloads/wbspec_b4.pdf)

These are a Memory Mapped Wishbone Master and a Memory Mapped Wishbone Slave.
It supports both the 'classic' Wishbone bus mode without flow control and the pipelined version with
a Stall Line as Flow control. The controllers change their behavior based on the existence of the Stall signal. Optional Error and Retry Lines are supported.

Both master and Slave support variations in the bus timing, so one can control/randomize Idle times between operations in a Master, the delay before a reply from a slave and slave's flow control.
The slave's response (Acknowledge/Error/Retry) can be also be controlled, as well as the response data.

The master:
The master has an optional timeout parameter input. This is a convenience feature. It could also be done in the testbench itself, but I found that it non conform wishbone devices freeze the bus often enough for being useful. 

The send_cycle routine expects a list of Wishbone Operations, the WBOp class is provided in the driver.
Each List is treated as continuous Wishbone Cycle (Cycle line stays high). 
The parameters are Address, Data, Byte Select and Idle Time before Operation.
A None value in the Data parameter is treated as a Read Operation (We line is low)

The output for each cycle is a list of Wishbone Results, the WBRes class is provided in the driver.
It shows the Address, Response (Ack/Err/Rty), Read Data, Write Data, byte select, Idle time since last operation, stall time and Response time of the slave. All times are in clock cycles.

The slave:
The slave has inputs for Reply (Ack 1 /Err 2 /Rty 3), Data, Reply Delay and Stall Times. All Inputs are optional and expect a generator otherwise. The first three expect single numerals while the stall generator must yield tuples of low cycles / high cycles.

See above in the master section for the result format. 

Notes:

A master MUST hold the cycle line until ALL operations are acknowledged.
The standard does not mandate this. However, if you do not, Masters can freeze and
Switch components will get messed up big time because Acks go to the wrong recipient.

FIXME:
- Someone should maybe have a look at all my non-pythonic stuff

TODO:
- add different behavior on Retry in non pipelined Wishbone
- add the event based reply in monitor
- honor byte selects

PLANNED:
- add streaming Wishbone Source / Sink (similar to AvalonST)
- add a virtual Wishbone RAM class

All the best - Matt
