### PR TITLE
Fix support for ghdl.

### DIFF
--- a/makefiles/simulators/Makefile.ghdl
+++ b/makefiles/simulators/Makefile.ghdl
@@ -28,15 +28,16 @@
 
 .PHONY: analyse
 
+GHDL=ghdl
+
 # Compilation phase
 analyse: $(VHDL_SOURCES) $(SIM_BUILD)
-	cd $(SIM_BUILD) && ghdl -a $(VHDL_SOURCES)
+	cd $(SIM_BUILD) && $(GHDL) -a $(VHDL_SOURCES) && $(GHDL) -e $(TOPLEVEL)
 
-results.xml: analyse  $(COCOTB_LIBS) $(COCOTB_LIB_VPI)
-	cd $(SIM_BUILD) && LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) ghdl -e -Wl,-L$(LIB_DIR) -Wl,-lvpi $(TOPLEVEL)
+results.xml: analyse  $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
         TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
-	./$(SIM_BUILD)/$(TOPLEVEL)
+	$(GHDL) -r --workdir=$(SIM_BUILD) $(TOPLEVEL) --vpi=$(LIB_DIR)/libvpi.$(LIB_EXT)
 
 clean::
 	-@rm -rf $(SIM_BUILD)


### PR DESCRIPTION
With this patch, you can run the endian_swapper example:
If you are using the mcode version of ghdl (which is 32 bit), use the following
command:
make GHDL=install_dir/bin/ghdl SIM=ghdl GPI_IMPL=vhpi ARCH=i686

If you are using the llvm/gcc version of ghdl for x86-64, use that command:
make GHDL=install_dir/bin/ghdl SIM=ghdl GPI_IMPL=vhpi

In both case, install_dir is the ghdl installation directory.  Setting the
GHDL variable is not necessary if ghdl is in the PATH.

Note that cocotb uses VPI for interfacing with ghdl.