### PR TITLE
add support for modelsim on 64bit windows

### DIFF
--- a/lib/embed/gpi_embed.c
+++ b/lib/embed/gpi_embed.c
@@ -34,6 +34,10 @@
 #include "embed.h"
 #include "../compat/python3_compat.h"
 
+#if defined(_WIN32)
+#include <windows.h>
+#define sleep(n) Sleep(1000 * n)
+#endif
 static PyThreadState *gtstate = NULL;
 
 #if PY_MAJOR_VERSION >= 3

--- a/makefiles/Makefile.inc
+++ b/makefiles/Makefile.inc
@@ -72,6 +72,9 @@ GXX_ARGS	+= -g -DDEBUG -fpic
 GCC_ARGS	:= $(GXX_ARGS)
 else ifeq ($(OS),Msys)
 GXX_ARGS 	+= -g -DDEBUG -shared
+ifeq ($(ARCH),x86_64)
+GXX_ARGS  += -DMS_WIN64
+endif
 GCC_ARGS	:= $(GXX_ARGS)
 LIB_EXT		:= dll
 PY_EXT		:= pyd

--- a/makefiles/simulators/Makefile.modelsim
+++ b/makefiles/simulators/Makefile.modelsim
@@ -27,8 +27,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-# Modelsim is 32-bit only
-ARCH:=i686
+# Modelsim is (no longer) 32-bit only
+#ARCH:=i686
 
 # Everything else is identical to Quest
 include $(SIM_ROOT)/makefiles/simulators/Makefile.questa


### PR DESCRIPTION
also make sleep function compatible w/ all versions of windows (this
was an apparent undetected regression that broke windows support).