### PR TITLE
Moves __len__() function in handle.py to the Base class.  Fixes issue #371

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -65,7 +65,7 @@ class SimHandleBase(object):
 
     # For backwards compatibility we support a mapping of old member names
     # which may alias with the simulator hierarchy.  In these cases the
-    # simulator takes priority, only falling back 
+    # simulator takes priority, only falling back
     _compat_mapping = {
         "log"               :       "_log",
         "fullname"          :       "_fullname",
@@ -92,6 +92,14 @@ class SimHandleBase(object):
     def __hash__(self):
         return self._handle
 
+    def __len__(self):
+        """Returns the 'length' of the underlying object.
+
+        For vectors this is the number of bits.
+        """
+        if self._len is None:
+            self._len = simulator.get_num_elems(self._handle)
+        return self._len
 
     def __eq__(self, other):
 
@@ -380,17 +388,6 @@ class NonConstantObject(NonHierarchyObject):
 
     def _get_value_str(self):
         return simulator.get_signal_val_binstr(self._handle)
-
-    def __len__(self):
-        """Returns the 'length' of the underlying object.
-
-        For vectors this is the number of bits.
-
-        TODO: Handle other types (loops, generate etc)
-        """
-        if self._len is None:
-            self._len = simulator.get_num_elems(self._handle)
-        return self._len
 
     def __eq__(self, other):
         if isinstance(other, SimHandleBase):


### PR DESCRIPTION
By moving the __len__() function to the base handle class all handles will support len(handle).  The GPI Object already supports this as well and it will move support for different getting the length of different types of handles to the FLI, VHPI and VPI.  The GPI object will return 0 if not overridden in a sub-class.