### PR TITLE
Makefile clean-up.  

### DIFF
--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -127,11 +127,11 @@ To run a test using a different simulator:
 Running a VHDL example
 ----------------------
 
-The endian swapper example includes both a VHDL and Verilog RTL implementation.  The Cocotb testbench can execute against either implementation using VPI for Verilog and VHPI for VHDL.  To run the test suite against the VHDL implementation use the following command (a VHPI capable simulator must be used):
+The endian swapper example includes both a VHDL and Verilog RTL implementation.  The Cocotb testbench can execute against either implementation using VPI for Verilog and VHPI/FLI for VHDL.  To run the test suite against the VHDL implementation use the following command (a VHPI or FLI capable simulator must be used):
 
 .. code-block:: bash
 
-    $> make SIM=aldec GPI_IMPL=vhpi
+    $> make SIM=aldec TOPLEVEL_LANG=vhdl
 
 
 

--- a/examples/adder/tests/Makefile
+++ b/examples/adder/tests/Makefile
@@ -27,9 +27,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-
-TOPLEVEL := adder
 TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping example due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
 
 PWD=$(shell pwd)
 COCOTB=$(PWD)/../../..
@@ -41,14 +47,13 @@ else
 WPWD=$(shell pwd)
 PYTHONPATH := $(WPWD)/../model:$(PYTHONPATH)
 endif
-export PYTHONPATH
 
 VERILOG_SOURCES = $(WPWD)/../hdl/adder.v
-GPI_IMPL := vpi
 
-export TOPLEVEL_LANG
-
-MODULE ?= test_adder
+TOPLEVEL := adder
+MODULE   := test_adder
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim
+
+endif

--- a/examples/endian_swapper/tests/Makefile
+++ b/examples/endian_swapper/tests/Makefile
@@ -41,18 +41,15 @@ else
 WPWD=$(shell pwd)
 PYTHONPATH := $(PWD)/../cosim:$(PYTHONPATH)
 endif
-export PYTHONPATH
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(WPWD)/../hdl/endian_swapper.sv
     TOPLEVEL = endian_swapper_sv
-    GPI_IMPL=vpi
-endif
-
-ifeq ($(TOPLEVEL_LANG),vhdl)
+else ifeq ($(TOPLEVEL_LANG),vhdl)
     VHDL_SOURCES = $(WPWD)/../hdl/endian_swapper.vhdl
     TOPLEVEL = endian_swapper_vhdl
-    GPI_IMPL=vhpi
+else
+    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
 MODULE=test_endian_swapper
@@ -60,7 +57,6 @@ MODULE=test_endian_swapper
 CUSTOM_COMPILE_DEPS = hal
 
 LD_LIBRARY_PATH := $(PWD)/../cosim:$(LD_LIBRARY_PATH)
-export LD_LIBRARY_PATH
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim

--- a/examples/mean/tests/Makefile
+++ b/examples/mean/tests/Makefile
@@ -1,6 +1,15 @@
 
-TOPLEVEL := mean_sv
 TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping example due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
+
+TOPLEVEL := mean_sv
 
 PWD=$(shell pwd)
 COCOTB=$(PWD)/../../..
@@ -15,17 +24,14 @@ VHDL_SOURCES = $(WPWD)/../hdl/mean_pkg.vhd
 VHDL_SOURCES += $(WPWD)/../hdl/mean.vhd
 
 VCOM_ARGS = -mixedsvvh
-export VCOM_ARGS
 
 GENERICS = "BUS_WIDTH=2"
-export GENERICS
 
 VERILOG_SOURCES = $(WPWD)/../hdl/mean_sv.sv
-GPI_IMPL := vpi
 
-export TOPLEVEL_LANG
-
-MODULE ?= test_mean
+MODULE := test_mean
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim
+
+endif

--- a/examples/mixed_language/tests/Makefile
+++ b/examples/mixed_language/tests/Makefile
@@ -1,5 +1,5 @@
 # Override this variable to use a VHDL toplevel instead of SystemVerilog
-TOPLEVEL_LANG ?= sv
+TOPLEVEL_LANG ?= verilog
 
 # At the moment the only simulator supporting mixed language VHPI/VPI is Aldec
 SIM?=aldec
@@ -18,25 +18,13 @@ endif
 VERILOG_SOURCES = $(WPWD)/../../endian_swapper/hdl/endian_swapper.sv
 VHDL_SOURCES    = $(WPWD)/../../endian_swapper/hdl/endian_swapper.vhdl
 
-ifeq ($(TOPLEVEL_LANG),sv)
+ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES += $(WPWD)/../hdl/toplevel.sv
-    GPI_IMPL=vpi
-    GPI_EXTRA=vhpi
-ifeq ($(SIM),modelsim)
-    GPI_EXTRA=fli
-endif
-endif
-
-ifeq ($(TOPLEVEL_LANG),vhdl)
+else ifeq ($(TOPLEVEL_LANG),vhdl)
     $(error "VHDL toplevel not yet implemented")
     VHDL_SOURCES += $(WPWD)/../hdl/toplevel.vhdl
-ifeq ($(SIM),aldec)
-    GPI_IMPL=vhpi
-endif
-ifeq ($(SIM),modelsim)
-    GPI_IMPL=fli
-endif
-    GPI_EXTRA=vpi
+else
+    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
 

--- a/examples/ping_tun_tap/tests/Makefile
+++ b/examples/ping_tun_tap/tests/Makefile
@@ -26,6 +26,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping example due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
 
 TOPLEVEL = icmp_reply
 
@@ -43,3 +52,5 @@ MODULE=test_icmp_reply
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim
+
+endif

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -29,13 +29,6 @@
 
 include $(SIM_ROOT)/makefiles/Makefile.inc
 
-# Default to VPI layer for now, override this for VHPI
-GPI_IMPL ?= vpi
-
-ifndef GPI_IMPL
-   $(error "Unable to determine appropriate GPI layer to use")
-endif
-
 
 # FIXME it's a bit nasty to have the source files listed here as dependencies
 # but better than re-building the libraries every time.

--- a/makefiles/Makefile.inc
+++ b/makefiles/Makefile.inc
@@ -57,7 +57,6 @@ include $(SIM_ROOT)/makefiles/Makefile.pylib
 export LIB_DIR=$(BUILD_DIR)/libs/$(ARCH)
 export LIB_OBJ_DIR:= $(BUILD_DIR)/obj/$(ARCH)
 export INCLUDES := -I$(SIM_ROOT)/include -I$(PYTHON_INCLUDEDIR)
-export GPI_EXTRA
 
 LIB_EXT     := so
 PY_EXT	    := so

--- a/makefiles/simulators/Makefile.aldec
+++ b/makefiles/simulators/Makefile.aldec
@@ -44,20 +44,29 @@ ifeq ($(COVERAGE),1)
     ALOG_ARGS += -coverage sb
 endif
 
-ifeq ($(GPI_IMPL),vpi)
+GPI_EXTRA:=
+ifeq ($(TOPLEVEL_LANG),verilog)
+
     GPI_ARGS = -pli libvpi
+ifneq ($(VHDL_SOURCES),)
+    GPI_EXTRA = vhpi
 endif
-ifeq ($(GPI_IMPL),vhpi)
+
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+
 ifeq ($(OS),Msys)
     VHPI_LIB = $(shell sh -c 'cd $(LIB_DIR) && pwd -W')/libvhpi
 else
     VHPI_LIB = $(LIB_DIR)/libvhpi
 endif
+
     GPI_ARGS = -loadvhpi $(VHPI_LIB):vhpi_startup_routines_bootstrap
+ifneq ($(VERILOG_SOURCES),)
+    GPI_EXTRA = vpi 
 endif
 
-ifndef GPI_ARGS
-   $(error "Unable to determine appropriate GPI layer to use as main entry point")
+else
+   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
 
@@ -65,10 +74,10 @@ endif
 $(SIM_BUILD)/runsim.tcl : $(VERILOG_SOURCES) $(VHDL_SOURCES) $(SIM_BUILD)
 	echo "alib $(RTL_LIBRARY)" > $@
 	echo "set worklib $(RTL_LIBRARY)" >> $@
-ifdef VHDL_SOURCES
+ifneq ($(VHDL_SOURCES),)
 	echo "acom $(ACOM_ARGS) $(VHDL_SOURCES)" >> $@
 endif
-ifdef VERILOG_SOURCES
+ifneq ($(VERILOG_SOURCES),)
 	echo "alog $(ALOG_ARGS) $(VERILOG_SOURCES)" >> $@
 endif
 ifdef SCRIPT_FILE
@@ -121,7 +130,7 @@ endif
 # Note it's the redirection of the output rather than the 'do' command
 # that turns on batch mode (i.e. exit on completion/error)
 results.xml: $(SIM_BUILD)/runsim.tcl $(COCOTB_LIBS) $(COCOTB_VHPI_LIB) $(COCOTB_VPI_LIB) $(CUSTOM_SIM_DEPS)
-	cd $(SIM_BUILD) && PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(NEW_PYTHONPATH) \
+	cd $(SIM_BUILD) && PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(NEW_PYTHONPATH) GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) $(CMD) -do runsim.tcl | tee sim.log
 
 clean::

--- a/makefiles/simulators/Makefile.cvc
+++ b/makefiles/simulators/Makefile.cvc
@@ -25,6 +25,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+ifneq ($(VHDL_SOURCES),)
+
+results.xml:
+	@echo "Skipping simulation as VHDL is not supported on simulator=$(SIM)"
+debug: results.xml
+clean::
+
+else
+
 #only interpreted mode works for the moment
 CVC_ITERP ?= 1
 
@@ -35,7 +44,7 @@ endif
 # Compilation phase
 $(SIM_BUILD)/sim.vvp: $(SIM_BUILD) $(VERILOG_SOURCES) $(CUSTOM_COMPILE_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
-	TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+	TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         cvc64 $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=libvpi:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 
 # Execution phase
@@ -44,7 +53,7 @@ ifeq ($(CVC_ITERP),1)
 else
     results.xml: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
-        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 endif
 
@@ -52,16 +61,16 @@ endif
 ifeq ($(CVC_ITERP),1)
     debug:  $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
-        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         gdb --args cvc64 $(CVC_ARGS) +acc+2 -o $(SIM_BUILD)/sim.vvp +define+COCOTB_SIM=1 +loadvpi=libvpi:vlog_startup_routines_bootstrap $(COMPILE_ARGS) $(EXTRA_ARGS) $(VERILOG_SOURCES)
 else
     debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
-        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         gdb --args $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 endif
 
 
 clean::
 	-@rm -rf $(SIM_BUILD)
-
+endif

--- a/makefiles/simulators/Makefile.ghdl
+++ b/makefiles/simulators/Makefile.ghdl
@@ -26,6 +26,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+ifneq ($(VERILOG_SOURCES),)
+
+results.xml:
+	@echo "Skipping simulation as Verilog is not supported on simulator=$(SIM)"
+clean::
+
+else
+
 .PHONY: analyse
 
 GHDL=ghdl
@@ -36,8 +44,9 @@ analyse: $(VHDL_SOURCES) $(SIM_BUILD)
 
 results.xml: analyse  $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
-        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	$(GHDL) -r --workdir=$(SIM_BUILD) $(TOPLEVEL) --vpi=$(LIB_DIR)/libvpi.$(LIB_EXT)
 
 clean::
 	-@rm -rf $(SIM_BUILD)
+endif

--- a/makefiles/simulators/Makefile.icarus
+++ b/makefiles/simulators/Makefile.icarus
@@ -27,6 +27,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+ifneq ($(VHDL_SOURCES),)
+
+results.xml:
+	@echo "Skipping simulation as VHDL is not supported on simulator=$(SIM)"
+debug: results.xml
+clean::
+
+else
+
 BUILD_VPI=1
 
 # Compilation phase
@@ -58,13 +67,14 @@ endif
 
 results.xml: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
-        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         vvp -M $(LIB_DIR) -m gpivpi $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 
 debug: $(SIM_BUILD)/sim.vvp $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS)
 	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(NEW_PYTHONPATH) $(LIB_LOAD) MODULE=$(MODULE) \
-        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+        TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         gdb --args vvp -M $(LIB_DIR) -m gpivpi $(SIM_BUILD)/sim.vvp $(SIM_ARGS) $(EXTRA_ARGS) $(PLUSARGS)
 
 clean::
 	-@rm -rf $(SIM_BUILD)
+endif

--- a/makefiles/simulators/Makefile.ius
+++ b/makefiles/simulators/Makefile.ius
@@ -45,19 +45,27 @@ endif
 # Which does not play nice with out multi language. So we supply vhpi
 # GPI_EXTRA if needed.
 
-ifeq ($(GPI_IMPL),vpi)
+GPI_EXTRA:=
+ifeq ($(TOPLEVEL_LANG),verilog)
     GPI_ARGS = -loadvpi $(LIB_DIR)/libvpi
     EXTRA_ARGS += -sv -v93
-    HDL_SOURCES = $(VERILOG_SOURCES) $(VHDL_SOURCES)
+    HDL_SOURCES = $(VERILOG_SOURCES)
     ROOT_LEVEL = $(TOPLEVEL)
+ifneq ($(VHDL_SOURCES),)
+    HDL_SOURCES += $(VHDL_SOURCES)
+    GPI_EXTRA = vhpi 
 endif
-
-ifeq ($(GPI_IMPL),vhpi)
+else ifeq ($(TOPLEVEL_LANG),vhdl)
     GPI_EXTRA = vhpi
     EXTRA_ARGS += -v93
     EXTRA_ARGS += -top $(TOPLEVEL)
     MAKE_LIB = -makelib $(TOPLEVEL)
     HDL_SOURCES = $(VHDL_SOURCES)
+ifneq ($(VHDL_SOURCES),)
+    HDL_SOURCES += $(VERILOG_SOURCES)
+endif
+else
+   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
 GPI_LIB = $(COCOTB_VPI_LIB) $(COCOTB_VHPI_LIB)
@@ -65,6 +73,7 @@ GPI_LIB = $(COCOTB_VPI_LIB) $(COCOTB_VHPI_LIB)
 results.xml: $(SIM_BUILD) $(HDL_SOURCES) $(CUSTOM_COMPILE_DEPS) $(CUSTOM_SIM_DEPS) $(COCOTB_LIBS) $(GPI_LIB)
 	LD_RUN_PATH=$(PYTHON_LIBDIR):$(LD_RUN_PATH) PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) \
 	LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 	irun $(EXTRA_ARGS) $(GPI_ARGS) +access+rwc $(MAKE_LIB) $(HDL_SOURCES) $(PLUSARGS)
 
 clean::

--- a/makefiles/simulators/Makefile.nvc
+++ b/makefiles/simulators/Makefile.nvc
@@ -1,5 +1,13 @@
 # -*- mode: makefile-gmake -*-
 
+ifneq ($(VERILOG_SOURCES),)
+
+results.xml:
+	@echo "Skipping simulation as Verilog is not supported on simulator=$(SIM)"
+clean::
+
+else
+
 RTL_LIBRARY ?= work
 
 .PHONY: analyse
@@ -13,9 +21,10 @@ results.xml: analyse $(COCOTB_LIBS) $(COCOTB_VHPI_LIB)
 		nvc --work=$(RTL_LIBRARY) -e $(TOPLEVEL)
 	cd $(SIM_BUILD) && PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) \
 		LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) \
-		TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+		TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
 		LD_LIBRARY_PATH=$(LIB_DIR) \
 		nvc --work=$(RTL_LIBRARY) -r --load $(COCOTB_VHPI_LIB) $(TOPLEVEL)
 
 clean::
 	-@rm -rf $(SIM_BUILD)
+endif

--- a/makefiles/simulators/Makefile.questa
+++ b/makefiles/simulators/Makefile.questa
@@ -45,10 +45,21 @@ SIM_CMD = vsim -c
 VSIM_ARGS += -onfinish exit
 endif
 
-ifeq ($(GPI_IMPL),vhpi)
-VSIM_ARGS += -foreign \"cocotb_init libfli.so\"
+GPI_EXTRA:=
+ifeq ($(TOPLEVEL_LANG),vhdl)
+    VSIM_ARGS += -foreign \"cocotb_init libfli.so\"
+ifneq ($(VERILOG_SOURCES),)
+    GPI_EXTRA = vpi 
+endif
+
+else ifeq ($(TOPLEVEL_LANG),verilog)
+    VSIM_ARGS += -pli libvpi.$(LIB_EXT)
+ifneq ($(VHDL_SOURCES),)
+    GPI_EXTRA = fli 
+endif
+
 else
-VSIM_ARGS += -pli libvpi.$(LIB_EXT)
+   $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 
 ifneq ($(GENERICS),)
@@ -110,7 +121,7 @@ endif
 # Append or remove values to INT_LIBS depenending on your license
 results.xml: $(SIM_BUILD)/runsim.do $(COCOTB_LIBS) $(INT_LIBS)
 	cd $(SIM_BUILD) && $(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
-	PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(NEW_PYTHONPATH) \
+	GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(NEW_PYTHONPATH) \
 	$(SIM_CMD) -do runsim.do 2>&1 | tee sim.log
 
 clean::

--- a/makefiles/simulators/Makefile.vcs
+++ b/makefiles/simulators/Makefile.vcs
@@ -27,6 +27,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+ifneq ($(VHDL_SOURCES),)
+
+results.xml:
+	@echo "Skipping simulation as VHDL is not supported on simulator=$(SIM)"
+clean::
+
+else
+
 ifeq ($(ARCH),x86_64)
 EXTRA_ARGS += -full64
 endif
@@ -48,6 +56,7 @@ $(SIM_BUILD)/simv: $(SIM_BUILD) $(VERILOG_SOURCES) $(SIM_BUILD)/pli.tab $(COCOTB
 # Execution phase
 results.xml: $(SIM_BUILD)/simv $(PYTHON_FILES) $(CUSTOM_SIM_DEPS)
 	-PYTHONPATH=$(LIB_DIR):$(SIM_ROOT):$(PWD):$(PYTHONPATH) LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) \
+		TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
         $(SIM_BUILD)/simv +define+COCOTB_SIM=1 $(SIM_ARGS) $(EXTRA_ARGS)
 
 
@@ -58,4 +67,4 @@ clean::
 	-@rm -rf cm.log
 	-@rm -rf results.xml
 	-@rm -rf ucli.key
-
+endif

--- a/tests/designs/avalon_module/Makefile
+++ b/tests/designs/avalon_module/Makefile
@@ -27,9 +27,17 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
 
 TOPLEVEL := burst_read_master
-TOPLEVEL_LANG ?= verilog
 
 PWD=$(shell pwd)
 COCOTB=$(PWD)/../../..
@@ -41,9 +49,8 @@ WPWD=$(shell pwd)
 endif
 
 VERILOG_SOURCES = $(COCOTB)/tests/designs/avalon_module/burst_read_master.v
-GPI_IMPL := vpi
-
-export TOPLEVEL_LANG
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim
+
+endif

--- a/tests/designs/close_module/Makefile
+++ b/tests/designs/close_module/Makefile
@@ -27,6 +27,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
 
 TOPLEVEL = close_module
 
@@ -48,3 +57,4 @@ all:
 	@echo "Skipping test as system call overrides seqfault VCS"
 endif
 
+endif

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -27,6 +27,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
 
 TOPLEVEL = tb_top
 
@@ -44,3 +53,4 @@ VERILOG_SOURCES = $(COCOTB)/tests/designs/plusargs_module/tb_top.v
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim
 
+endif

--- a/tests/designs/sample_module/Makefile
+++ b/tests/designs/sample_module/Makefile
@@ -27,9 +27,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+TOPLEVEL_LANG ?= verilog
 
 TOPLEVEL := sample_module
-TOPLEVEL_LANG ?= verilog
 
 PWD=$(shell pwd)
 COCOTB?=$(PWD)/../../..
@@ -40,16 +40,13 @@ else
 WPWD=$(shell pwd)
 endif
 
-ifeq ($(TOPLEVEL_LANG),vhdl)
-    VHDL_SOURCES =  $(COCOTB)/tests/designs/sample_module/sample_module_1.vhdl $(COCOTB)/tests/designs/sample_module/sample_module.vhdl
-    TOPLEVEL := $(TOPLEVEL)
-    GPI_IMPL := vhpi
-else
+ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/sample_module/sample_module.v
-    GPI_IMPL := vpi
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+    VHDL_SOURCES =  $(COCOTB)/tests/designs/sample_module/sample_module_1.vhdl $(COCOTB)/tests/designs/sample_module/sample_module.vhdl
+else
+    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
-
-export TOPLEVEL_LANG
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim

--- a/tests/designs/uart2bus/Makefile
+++ b/tests/designs/uart2bus/Makefile
@@ -1,6 +1,15 @@
-SRC_BASE = $(COCOTB)/tests/designs/uart2bus
-
 TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
+
+
+SRC_BASE = $(COCOTB)/tests/designs/uart2bus
 
 VHDL_SOURCES =      $(SRC_BASE)/vhdl/uart2BusTop_pkg.vhd \
                     $(SRC_BASE)/vhdl/baudGen.vhd \
@@ -17,35 +26,10 @@ VERILOG_SOURCES =   $(SRC_BASE)/verilog/baud_gen.v \
                     $(SRC_BASE)/verilog/uart_top.v \
                     $(SRC_BASE)/verilog/uart2bus_top.v
 
-GPI_EXTRA:=
-ifeq ($(TOPLEVEL_LANG),verilog)
-    VERILOG_SOURCES += $(SRC_BASE)/top/verilog_toplevel.v
-    TOPLEVEL = verilog_toplevel
-    GPI_IMPL=vpi
+VERILOG_SOURCES += $(SRC_BASE)/top/verilog_toplevel.v
+TOPLEVEL = verilog_toplevel
 
-ifeq ($(SIM),aldec)
-    GPI_EXTRA=vhpi
-endif
-ifeq ($(SIM),modelsim)
-    GPI_EXTRA=vhpi
-endif
-ifeq ($(SIM),questa)
-    GPI_EXTRA=vhpi
-endif
-ifeq ($(SIM),ius)
-    GPI_EXTRA=vhpi
-endif
+include $(COCOTB)/makefiles/Makefile.inc
+include $(COCOTB)/makefiles/Makefile.sim
 
-else
-$(error "Only verilog toplevel supported at the moment")
 endif
-
-ifneq ($(GPI_EXTRA),)
-	include $(COCOTB)/makefiles/Makefile.inc
-	include $(COCOTB)/makefiles/Makefile.sim
-else
-all:
-	@echo "Skipping test as VHDL not supported on simulator=$(SIM)"
-clean::
-endif
-

--- a/tests/designs/vhdl_configurations/Makefile
+++ b/tests/designs/vhdl_configurations/Makefile
@@ -1,23 +1,17 @@
+TOPLEVEL_LANG ?= verilog
+
 TOPLEVEL = testbench
 
 VHDL_SOURCES = $(COCOTB)/tests/designs/vhdl_configurations/dut.vhd
-ifeq ($(TOPLEVEL_LANG),vhdl)
+ifeq ($(TOPLEVEL_LANG),verilog)
+    VERILOG_SOURCES = $(COCOTB)/tests/designs/vhdl_configurations/testbench.sv
+else ifeq ($(TOPLEVEL_LANG),vhdl)
    	VHDL_SOURCES += $(COCOTB)/tests/designs/vhdl_configurations/testbench.vhd
-    GPI_IMPL := vhpi
+else
+    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
 endif
 VHDL_SOURCES += $(COCOTB)/tests/designs/vhdl_configurations/configurations.vhd
 
-ifeq ($(TOPLEVEL_LANG),verilog)
-    VERILOG_SOURCES = $(COCOTB)/tests/designs/vhdl_configurations/testbench.sv
-    GPI_IMPL := vpi
-endif
-
-ifneq ($(SIM),)
-	include $(COCOTB)/makefiles/Makefile.inc
-	include $(COCOTB)/makefiles/Makefile.sim
-else
-all:
-	@echo "Skipping test as VHDL not supported on Icarus"
-clean::
-endif
+include $(COCOTB)/makefiles/Makefile.inc
+include $(COCOTB)/makefiles/Makefile.sim
 

--- a/tests/designs/viterbi_decoder_axi4s/Makefile
+++ b/tests/designs/viterbi_decoder_axi4s/Makefile
@@ -25,7 +25,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-TOPLEVEL_LANG = vhdl
+TOPLEVEL_LANG ?= vhdl
+
+ifneq ($(TOPLEVEL_LANG),vhdl)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being vhdl"
+clean::
+
+else
 
 TOPLEVEL = dec_viterbi
 
@@ -52,25 +60,7 @@ VHDL_SOURCES = $(SRC_BASE)/packages/pkg_helper.vhd \
 	       $(SRC_BASE)/src/recursion.vhd \
 	       $(SRC_BASE)/src/dec_viterbi.vhd \
 
-GPI_IMPL:=
-ifeq ($(SIM),aldec)
-    GPI_IMPL=vhpi
-endif
-ifeq ($(SIM),modelsim)
-    GPI_IMPL=vhpi
-endif
-ifeq ($(SIM),questa)
-    GPI_IMPL=vhpi
-endif
-ifeq ($(SIM),ius)
-    GPI_IMPL=vhpi
-endif
-
-ifneq ($(GPI_IMPL),)
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim
-else
-all:
-	@echo "Skipping test as VHDL not supported on simulator=$(SIM)"
-clean::
+
 endif

--- a/tests/test_cases/test_configuration/Makefile
+++ b/tests/test_cases/test_configuration/Makefile
@@ -25,9 +25,5 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-PWD := $(shell pwd)
-COCOTB := $(PWD)/../../..
-TOPLEVEL_LANG?=vhdl
-
 include ../../designs/vhdl_configurations/Makefile
 MODULE = test_configurations

--- a/tests/test_cases/test_iteration_mixedlang/Makefile
+++ b/tests/test_cases/test_iteration_mixedlang/Makefile
@@ -25,8 +25,5 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-PWD := $(shell pwd)
-COCOTB := $(PWD)/../../..
-
 include ../../designs/uart2bus/Makefile
 MODULE = test_iteration

--- a/tests/test_cases/test_iteration_verilog/Makefile
+++ b/tests/test_cases/test_iteration_verilog/Makefile
@@ -25,10 +25,18 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
+
 PWD := $(shell pwd)
 COCOTB := $(PWD)/../../..
-
-TOPLEVEL_LANG = verilog
 
 VERILOG_SOURCES = $(COCOTB)/examples/endian_swapper/hdl/endian_swapper.sv
 TOPLEVEL = endian_swapper_sv
@@ -42,4 +50,6 @@ clean::
 else
 	include $(COCOTB)/makefiles/Makefile.inc
 	include $(COCOTB)/makefiles/Makefile.sim
+endif
+
 endif

--- a/tests/test_cases/test_iteration_vhdl/Makefile
+++ b/tests/test_cases/test_iteration_vhdl/Makefile
@@ -25,9 +25,5 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-PWD := $(shell pwd)
-COCOTB := $(PWD)/../../..
-
 include ../../designs/viterbi_decoder_axi4s/Makefile
-#GPI_EXTRA=vhpi
 MODULE = test_iteration

--- a/tests/test_cases/test_verilog_access/Makefile
+++ b/tests/test_cases/test_verilog_access/Makefile
@@ -25,8 +25,5 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-PWD := $(shell pwd)
-COCOTB := $(PWD)/../../..
-
 include ../../designs/uart2bus/Makefile
 MODULE = test_verilog_access

--- a/tests/test_cases/test_vhdl_access/Makefile
+++ b/tests/test_cases/test_vhdl_access/Makefile
@@ -25,8 +25,5 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-PWD := $(shell pwd)
-COCOTB := $(PWD)/../../..
-
 include ../../designs/viterbi_decoder_axi4s/Makefile
 MODULE = test_vhdl_access


### PR DESCRIPTION
No longer need for user to specify GPI_IMPL or GPI_EXTRA.  Addresses issues #232 and #372.

@stuarthodgson There may be more that you wanted to do, but this cleaned up a lot.