### PR TITLE
Issue #382 : introducing simulator time precision into cocotb

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -162,8 +162,9 @@ class SimLogFormatter(logging.Formatter):
             return ".." + string[(chars - 2) * -1:]
         return string.rjust(chars)
 
-    def _format(self, timeh, timel, level, record, msg):
-        simtime = "% 6d.%02dns" % ((timel / 1000), (timel % 1000) / 10)
+    def _format(self, timeh, timel, precision, level, record, msg):
+        time_ns = (timeh << 32 | timel) * (10.0**precision) / 1e-9
+        simtime = "%6.2fns" % (time_ns)
         prefix = simtime + ' ' + level + ' ' + \
             self.ljust(record.name, _RECORD_CHARS) + \
             self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS) + \
@@ -182,9 +183,9 @@ class SimLogFormatter(logging.Formatter):
 
         msg = str(msg)
         level = record.levelname.ljust(_LEVEL_CHARS)
-        timeh, timel = simulator.get_sim_time()
+        timeh, timel, precision = simulator.get_sim_time()
 
-        return self._format(timeh, timel, level, record, msg)
+        return self._format(timeh, timel, precision, level, record, msg)
 
 
 class SimColourLogFormatter(SimLogFormatter):
@@ -210,5 +211,5 @@ class SimColourLogFormatter(SimLogFormatter):
         level = (SimColourLogFormatter.loglevel2colour[record.levelno] %
                  record.levelname.ljust(_LEVEL_CHARS))
 
-        timeh, timel = simulator.get_sim_time()
-        return self._format(timeh, timel, level, record, msg)
+        timeh, timel, precision = simulator.get_sim_time()
+        return self._format(timeh, timel, precision, level, record, msg)

--- a/include/gpi.h
+++ b/include/gpi.h
@@ -110,7 +110,7 @@ void gpi_sim_end(void);
 
 
 // Returns simulation time as a float. Units are default sim units
-void gpi_get_sim_time(uint32_t *high, uint32_t *low);
+void gpi_get_sim_time(uint32_t *high, uint32_t *low, int32_t *precision);
 
 
 // Functions for extracting a gpi_sim_hdl to an object

--- a/include/vpi_user.h
+++ b/include/vpi_user.h
@@ -290,6 +290,8 @@ typedef struct t_vpi_value
 
 #define vpiUnknown            3
 
+#define vpiTimePrecision         12   /* module time precision */
+
 /* normal callback structure */
 typedef struct t_cb_data
 {

--- a/lib/fli/FliImpl.cpp
+++ b/lib/fli/FliImpl.cpp
@@ -376,10 +376,11 @@ const char *FliImpl::reason_to_string(int reason)
  *
  * NB units depend on the simulation configuration
  */
-void FliImpl::get_sim_time(uint32_t *high, uint32_t *low)
+void FliImpl::get_sim_time(uint32_t *high, uint32_t *low, int32_t *precision)
 {
     *high = mti_NowUpper();
     *low = mti_Now();
+    *precision = 0;
 }
 
 /**

--- a/lib/fli/FliImpl.h
+++ b/lib/fli/FliImpl.h
@@ -403,7 +403,7 @@ public:
 
      /* Sim related */
     void sim_end(void);
-    void get_sim_time(uint32_t *high, uint32_t *low);
+    void get_sim_time(uint32_t *high, uint32_t *low, int32_t *precision);
 
     /* Hierachy related */
     GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent);

--- a/lib/gpi/GpiCommon.cpp
+++ b/lib/gpi/GpiCommon.cpp
@@ -196,9 +196,9 @@ void gpi_load_extra_libs(void)
     gpi_print_registered_impl();
 }
 
-void gpi_get_sim_time(uint32_t *high, uint32_t *low)
+void gpi_get_sim_time(uint32_t *high, uint32_t *low, int32_t *precision)
 {
-    registered_impls[0]->get_sim_time(high, low);
+    registered_impls[0]->get_sim_time(high, low, precision);
 }
 
 gpi_sim_hdl gpi_get_root_handle(const char *name)

--- a/lib/gpi/gpi_priv.h
+++ b/lib/gpi/gpi_priv.h
@@ -287,7 +287,7 @@ public:
 
     /* Sim related */
     virtual void sim_end(void) = 0;
-    virtual void get_sim_time(uint32_t *high, uint32_t *low) = 0;
+    virtual void get_sim_time(uint32_t *high, uint32_t *low, int32_t *precision) = 0;
 
     /* Hierachy related */
     virtual GpiObjHdl* native_check_create(std::string &name, GpiObjHdl *parent) = 0;

--- a/lib/simulator/simulatormodule.c
+++ b/lib/simulator/simulatormodule.c
@@ -848,22 +848,24 @@ static PyObject *get_type_string(PyObject *self, PyObject *args)
 }
 
 
-// Returns a high, low tuple of simulator time
+// Returns a high, low, precision tuple of simulator time
 // Note we can never log from this function since the logging mechanism calls this to annotate
 // log messages with the current simulation time
 static PyObject *get_sim_time(PyObject *self, PyObject *args)
 {
 
     uint32_t high, low;
+    int32_t precision;
 
     PyGILState_STATE gstate;
     gstate = TAKE_GIL();
 
-    gpi_get_sim_time(&high, &low);
+    gpi_get_sim_time(&high, &low, &precision);
 
-    PyObject *pTuple = PyTuple_New(2);
+    PyObject *pTuple = PyTuple_New(3);
     PyTuple_SetItem(pTuple, 0, PyLong_FromUnsignedLong(high));       // Note: This function “steals” a reference to o.
     PyTuple_SetItem(pTuple, 1, PyLong_FromUnsignedLong(low));       // Note: This function “steals” a reference to o.
+    PyTuple_SetItem(pTuple, 2, PyLong_FromLong(precision));       // Note: This function “steals” a reference to o.
 
     DROP_GIL(gstate);
 

--- a/lib/vhpi/VhpiImpl.cpp
+++ b/lib/vhpi/VhpiImpl.cpp
@@ -103,13 +103,14 @@ const char *VhpiImpl::reason_to_string(int reason)
     }
 }
 
-void VhpiImpl::get_sim_time(uint32_t *high, uint32_t *low)
+void VhpiImpl::get_sim_time(uint32_t *high, uint32_t *low, int32_t *precision)
 {
     vhpiTimeT vhpi_time_s;
     vhpi_get_time(&vhpi_time_s, NULL);
     check_vhpi_error();
     *high = vhpi_time_s.high;
     *low = vhpi_time_s.low;
+    *precision = 0;
 }
 
 // Determine whether a VHPI object type is a constant or not

--- a/lib/vhpi/VhpiImpl.h
+++ b/lib/vhpi/VhpiImpl.h
@@ -221,7 +221,7 @@ public:
 
      /* Sim related */
     void sim_end(void);
-    void get_sim_time(uint32_t *high, uint32_t *low);
+    void get_sim_time(uint32_t *high, uint32_t *low, int32_t *precision);
 
     /* Hierachy related */
     GpiObjHdl *get_root_handle(const char *name);

--- a/lib/vpi/VpiImpl.cpp
+++ b/lib/vpi/VpiImpl.cpp
@@ -59,7 +59,7 @@ const char *VpiImpl::reason_to_string(int reason)
     }
 }
 
-void VpiImpl::get_sim_time(uint32_t *high, uint32_t *low)
+void VpiImpl::get_sim_time(uint32_t *high, uint32_t *low, int32_t *precision)
 {
     s_vpi_time vpi_time_s;
     vpi_time_s.type = vpiSimTime;       //vpiSimTime;
@@ -67,6 +67,7 @@ void VpiImpl::get_sim_time(uint32_t *high, uint32_t *low)
     check_vpi_error();
     *high = vpi_time_s.high;
     *low = vpi_time_s.low;
+    *precision = vpi_get(vpiTimePrecision, NULL);
 }
 
 gpi_objtype_t to_gpi_objtype(int32_t vpitype)

--- a/lib/vpi/VpiImpl.h
+++ b/lib/vpi/VpiImpl.h
@@ -251,7 +251,7 @@ public:
 
      /* Sim related */
     void sim_end(void);
-    void get_sim_time(uint32_t *high, uint32_t *low);
+    void get_sim_time(uint32_t *high, uint32_t *low, int32_t *precision);
 
     /* Hierachy related */
     GpiObjHdl *get_root_handle(const char *name);


### PR DESCRIPTION
Currently only works with VPI.
Need to work out the equivalent of:

vpi_get(vpiTimePrecision, NULL);

for VHPI