### PR TITLE
New simple D-FF example demonstrating the use of monitors, drivers, and the scoreboard

### DIFF
--- a/examples/dff/hdl/dff.v
+++ b/examples/dff/hdl/dff.v
@@ -1,0 +1,17 @@
+// Copyright (c) 2016 Technische Universitaet Dresden, Germany
+// Chair for VLSI-Design, Diagnostic and Architecture
+// Author: Martin Zabel
+// All rights reserved.
+//
+// A simple D flip-flop
+
+module dff (c,d,q);
+   input wire c, d;
+   output reg q = 1'b0;
+
+   always @(posedge c)
+     begin
+	q <= #1 d;
+     end
+   
+endmodule // dff

--- a/examples/dff/hdl/dff.v
+++ b/examples/dff/hdl/dff.v
@@ -1,9 +1,29 @@
-// Copyright (c) 2016 Technische Universitaet Dresden, Germany
-// Chair for VLSI-Design, Diagnostic and Architecture
-// Author: Martin Zabel
-// All rights reserved.
+// =============================================================================
+// Authors:		Martin Zabel
+// 
+// Module:              A simple D-FF
+// 
+// Description:
+// ------------------------------------
+// A simple D-FF with an initial state of '0'.
 //
-// A simple D flip-flop
+// License:
+// =============================================================================
+// Copyright 2016 Technische Universitaet Dresden - Germany
+//		  Chair for VLSI-Design, Diagnostics and Architecture
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//		http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
 
 module dff (c,d,q);
    input wire c, d;
@@ -11,7 +31,9 @@ module dff (c,d,q);
 
    always @(posedge c)
      begin
-	q <= #1 d;
+	// It is also possible to add an delay of less than one clock period 
+	// here.
+	q <= d;
      end
    
 endmodule // dff

--- a/examples/dff/hdl/dff.vhdl
+++ b/examples/dff/hdl/dff.vhdl
@@ -1,9 +1,29 @@
--- Copyright (c) 2016 Technische Universitaet Dresden, Germany
--- Chair for VLSI-Design, Diagnostic and Architecture
--- Author: Martin Zabel
--- All rights reserved.
+-- =============================================================================
+-- Authors:		Martin Zabel
+-- 
+-- Module:              A simple D-FF
+-- 
+-- Description:
+-- ------------------------------------
+-- A simple D-FF with an initial state of '0'.
 --
--- A simple D flip-flop
+-- License:
+-- =============================================================================
+-- Copyright 2016 Technische Universitaet Dresden - Germany
+--		  Chair for VLSI-Design, Diagnostics and Architecture
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--		http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- =============================================================================
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -17,5 +37,6 @@ end entity dff;
 
 architecture rtl of dff is
 begin
+  -- It is also possible to add an delay of less than one clock period here.
   q <= d when rising_edge(c);
 end architecture rtl;

--- a/examples/dff/hdl/dff.vhdl
+++ b/examples/dff/hdl/dff.vhdl
@@ -1,0 +1,21 @@
+-- Copyright (c) 2016 Technische Universitaet Dresden, Germany
+-- Chair for VLSI-Design, Diagnostic and Architecture
+-- Author: Martin Zabel
+-- All rights reserved.
+--
+-- A simple D flip-flop
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity dff is
+  port (
+    c : in  std_logic;
+    d : in  std_logic;
+    q : out std_logic := '0');
+end entity dff;
+
+architecture rtl of dff is
+begin
+  q <= d when rising_edge(c);
+end architecture rtl;

--- a/examples/dff/tests/Makefile
+++ b/examples/dff/tests/Makefile
@@ -1,0 +1,30 @@
+# Copyright (c) 2016 Technische Universitaet Dresden, Germany
+# Chair for VLSI-Design, Diagnostic and Architecture
+# Author: Martin Zabel
+# All rights reserved.
+
+CWD=$(shell pwd)
+COCOTB=$(CWD)/../../..
+
+TOPLEVEL_LANG ?=verilog
+
+ifeq ($(TOPLEVEL_LANG),verilog)
+  VERILOG_SOURCES =$(CWD)/../hdl/dff.v
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+  VHDL_SOURCES =$(CWD)/../hdl/dff.vhdl
+else
+  $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+endif
+
+TOPLEVEL=dff
+MODULE=$(TOPLEVEL)_cocotb
+
+CUSTOM_SIM_DEPS=$(CWD)/Makefile
+
+VSIM_ARGS=-t 1ps
+
+include $(COCOTB)/makefiles/Makefile.inc
+include $(COCOTB)/makefiles/Makefile.sim
+
+# list all required Python files here
+sim: $(MODULE).py

--- a/examples/dff/tests/dff_cocotb.py
+++ b/examples/dff/tests/dff_cocotb.py
@@ -1,12 +1,30 @@
-'''Copyright (c) 2016 Technische Universitaet Dresden, Germany
-Chair for VLSI-Design, Diagnostic and Architecture
-Author: Martin Zabel
-All rights reserved.
+# ==============================================================================
+# Authors:		Martin Zabel
+# 
+# Cocotb Testbench:	For D-FF
+# 
+# Description:
+# ------------------------------------
+# Automated testbench for simple D-FF.
+#
+# License:
+# ==============================================================================
+# Copyright 2016 Technische Universitaet Dresden - Germany
+#		 Chair for VLSI-Design, Diagnostics and Architecture
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#		http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
-Structure of this testbench is based on Endian Swapper Example delivered with
-Cocotb.'''
-
-#import traceback
 import random
 
 import cocotb
@@ -19,31 +37,46 @@ from cocotb.regression import TestFactory
 from cocotb.scoreboard import Scoreboard
 from cocotb.result import TestFailure, TestSuccess
 
+# ==============================================================================
 class BitMonitor(Monitor):
-    '''Observes single input or output of DUT.'''
-    def __init__(self, name, signal, clk, callback=None, event=None):
+    """Observes single input or output of DUT."""
+    def __init__(self, name, signal, clock, callback=None, event=None):
         self.name = name
         self.signal = signal
-        self.clk = clk
+        self.clock = clock
         Monitor.__init__(self, callback, event)
         
     @coroutine
     def _monitor_recv(self):
-        clkedge = RisingEdge(self.clk)
+        clkedge = RisingEdge(self.clock)
 
         while True:
+            # Capture signal at rising edge of clock
             yield clkedge
             vec = self.signal.value
             self._recv(vec)
 
+# ==============================================================================
 def input_gen():
+    """Generator for input data applied by BitDriver"""
     while True:
         yield random.randint(1,5), random.randint(1,5)
         
+# ==============================================================================
 class DFF_TB(object):
     def __init__(self, dut, init_val):
+        """
+        Setup testbench.
+
+        init_val signifies the BinaryValue which must be captured by the
+        output monitor with the first risign edge. This is actually the initial 
+        state of the flip-flop.
+        """
+        # Some internal state
         self.dut = dut
         self.stopped = False
+
+        # Create input driver and output monitor
         self.input_drv = BitDriver(dut.d, dut.c, input_gen())
         self.output_mon = BitMonitor("output", dut.q, dut.c)
         
@@ -58,39 +91,58 @@ class DFF_TB(object):
                                     callback=self.model)
 
     def model(self, transaction):
-        '''Model the DUT based on the input transaction.'''
+        """Model the DUT based on the input transaction."""
+        # Do not append an output transaction for the last clock cycle of the
+        # simulation, that is, after stop() has been called.
         if not self.stopped:
             self.expected_output.append(transaction)
 
     def start(self):
+        """Start generation of input data."""
         self.input_drv.start()
 
     def stop(self):
+        """
+        Stop generation of input data. 
+        Also stop generation of expected output transactions.
+        One more clock cycle must be executed afterwards, so that, output of
+        D-FF can be checked.
+        """
         self.input_drv.stop()
         self.stopped = True
 
+# ==============================================================================
 @cocotb.coroutine
 def clock_gen(signal):
+    """Generate the clock signal."""
     while True:
         signal <= 0
         yield Timer(5000) # ps
         signal <= 1
         yield Timer(5000) # ps
 
+# ==============================================================================
 @cocotb.coroutine
 def run_test(dut):
+    """Setup testbench and run a test."""
     cocotb.fork(clock_gen(dut.c))
     tb = DFF_TB(dut, BinaryValue(0,1))
     clkedge = RisingEdge(dut.c)
-    
+
+    # Apply random input data by input_gen via BitDriver for 100 clock cycle.
     tb.start()
     for i in range(100):
         yield clkedge
-        
+
+    # Stop generation of input data. One more clock cycle is needed to capture
+    # the resulting output of the DUT.
     tb.stop()
     yield clkedge
-    
+
+    # Print result of scoreboard.
     raise tb.scoreboard.result
 
+# ==============================================================================
+# Register test.
 factory = TestFactory(run_test)
 factory.generate_tests()

--- a/examples/dff/tests/dff_cocotb.py
+++ b/examples/dff/tests/dff_cocotb.py
@@ -1,0 +1,96 @@
+'''Copyright (c) 2016 Technische Universitaet Dresden, Germany
+Chair for VLSI-Design, Diagnostic and Architecture
+Author: Martin Zabel
+All rights reserved.
+
+Structure of this testbench is based on Endian Swapper Example delivered with
+Cocotb.'''
+
+#import traceback
+import random
+
+import cocotb
+from cocotb.decorators import coroutine
+from cocotb.triggers import Timer, RisingEdge, ReadOnly
+from cocotb.monitors import Monitor
+from cocotb.drivers import BitDriver
+from cocotb.binary import BinaryValue
+from cocotb.regression import TestFactory
+from cocotb.scoreboard import Scoreboard
+from cocotb.result import TestFailure, TestSuccess
+
+class BitMonitor(Monitor):
+    '''Observes single input or output of DUT.'''
+    def __init__(self, name, signal, clk, callback=None, event=None):
+        self.name = name
+        self.signal = signal
+        self.clk = clk
+        Monitor.__init__(self, callback, event)
+        
+    @coroutine
+    def _monitor_recv(self):
+        clkedge = RisingEdge(self.clk)
+
+        while True:
+            yield clkedge
+            vec = self.signal.value
+            self._recv(vec)
+
+def input_gen():
+    while True:
+        yield random.randint(1,5), random.randint(1,5)
+        
+class DFF_TB(object):
+    def __init__(self, dut, init_val):
+        self.dut = dut
+        self.stopped = False
+        self.input_drv = BitDriver(dut.d, dut.c, input_gen())
+        self.output_mon = BitMonitor("output", dut.q, dut.c)
+        
+        # Create a scoreboard on the outputs
+        self.expected_output = [ init_val ]
+        self.scoreboard = Scoreboard(dut)
+        self.scoreboard.add_interface(self.output_mon, self.expected_output)
+
+        # Reconstruct the input transactions from the pins
+        # and send them to our 'model'
+        self.input_mon = BitMonitor("input", dut.d, dut.c,
+                                    callback=self.model)
+
+    def model(self, transaction):
+        '''Model the DUT based on the input transaction.'''
+        if not self.stopped:
+            self.expected_output.append(transaction)
+
+    def start(self):
+        self.input_drv.start()
+
+    def stop(self):
+        self.input_drv.stop()
+        self.stopped = True
+
+@cocotb.coroutine
+def clock_gen(signal):
+    while True:
+        signal <= 0
+        yield Timer(5000) # ps
+        signal <= 1
+        yield Timer(5000) # ps
+
+@cocotb.coroutine
+def run_test(dut):
+    cocotb.fork(clock_gen(dut.c))
+    tb = DFF_TB(dut, BinaryValue(0,1))
+    clkedge = RisingEdge(dut.c)
+    
+    tb.start()
+    for i in range(100):
+        yield clkedge
+        
+    tb.stop()
+    yield clkedge
+    
+    raise tb.scoreboard.result
+
+factory = TestFactory(run_test)
+factory.generate_tests()


### PR DESCRIPTION
Hi,

it would be nice to have a simpler example then the Endian Swapper which shows the usage of monitors, drivers, and the scoreboard. It should especially demonstrate when to capture the input and output signals. The proposed example is much shorter and hopefully easier to understand.

This pull requests contains:

* a simple D-FF with in an initial state written in Verilog and VDHL.
* a Cocotb testbench checking the initial state first, and then applying random data to the data input. The flip-flop output is captured at sub-sequent rising-edges and compared to the applied input data using a scoreboard.

Regards,
Martin