### PR TITLE
Resolve don't care value from std_logic ('-') to 0 in BinaryValue.

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -66,8 +66,8 @@ class BinaryValue(object):
     '*'
 
     """
-    _resolve_to_0    = "xXzZuU"  # noqa
-    _permitted_chars = "xXzZuU" + "01"  # noqa
+    _resolve_to_0    = "xXzZuU-"  # noqa
+    _permitted_chars = "xXzZuU-" + "01"  # noqa
 
     def __init__(self, value=None, bits=None, bigEndian=True,
                  binaryRepresentation=BinaryRepresentation.UNSIGNED):


### PR DESCRIPTION
Hi,

some of my VHDL components output don't care values (std_logic '-') on data signals if the corresponding valid signal is active low. Thus, the class BinaryValue should resolve the don't care values to 0 in the same way as it already handles 'X', 'Z', and 'U'.

Regards,
Martin
