### PR TITLE
Fli win64

### DIFF
--- a/lib/fli/FliObjHdl.cpp
+++ b/lib/fli/FliObjHdl.cpp
@@ -312,9 +312,9 @@ int FliLogicObjHdl::set_signal_value(const long value)
         }
 
         if (m_is_var) {
-            mti_SetVarValue(get_handle<mtiVariableIdT>(), (long)m_mti_buff);
+            mti_SetVarValue(get_handle<mtiVariableIdT>(), (mtiLongT)m_mti_buff);
         } else {
-            mti_SetSignalValue(get_handle<mtiSignalIdT>(), (long)m_mti_buff);
+            mti_SetSignalValue(get_handle<mtiSignalIdT>(), (mtiLongT)m_mti_buff);
         }
     }
 
@@ -350,9 +350,9 @@ int FliLogicObjHdl::set_signal_value(std::string &value)
         }
 
         if (m_is_var) {
-            mti_SetVarValue(get_handle<mtiVariableIdT>(), (long)m_mti_buff);
+            mti_SetVarValue(get_handle<mtiVariableIdT>(), (mtiLongT)m_mti_buff);
         } else {
-            mti_SetSignalValue(get_handle<mtiSignalIdT>(), (long)m_mti_buff);
+            mti_SetSignalValue(get_handle<mtiSignalIdT>(), (mtiLongT)m_mti_buff);
         }
     }
 
@@ -446,9 +446,9 @@ int FliRealObjHdl::set_signal_value(const double value)
     m_mti_buff[0] = value;
 
     if (m_is_var) {
-        mti_SetVarValue(get_handle<mtiVariableIdT>(), (long)m_mti_buff);
+        mti_SetVarValue(get_handle<mtiVariableIdT>(), (mtiLongT)m_mti_buff);
     } else {
-        mti_SetSignalValue(get_handle<mtiSignalIdT>(), (long)m_mti_buff);
+        mti_SetSignalValue(get_handle<mtiSignalIdT>(), (mtiLongT)m_mti_buff);
     }
 
     return 0;
@@ -497,9 +497,9 @@ int FliStringObjHdl::set_signal_value(std::string &value)
     strncpy(m_mti_buff, value.c_str(), m_num_elems);
 
     if (m_is_var) {
-        mti_SetVarValue(get_handle<mtiVariableIdT>(), (long)m_mti_buff);
+        mti_SetVarValue(get_handle<mtiVariableIdT>(), (mtiLongT)m_mti_buff);
     } else {
-        mti_SetSignalValue(get_handle<mtiSignalIdT>(), (long)m_mti_buff);
+        mti_SetSignalValue(get_handle<mtiSignalIdT>(), (mtiLongT)m_mti_buff);
     }
 
     return 0;

--- a/tests/designs/array_module/Makefile
+++ b/tests/designs/array_module/Makefile
@@ -31,14 +31,13 @@ TOPLEVEL_LANG ?= verilog
 
 TOPLEVEL := array_module
 
-PWD=$(shell pwd)
-COCOTB?=$(PWD)/../../..
-
 ifeq ($(OS),Msys)
 WPWD=$(shell sh -c 'pwd -W')
 else
 WPWD=$(shell pwd)
 endif
+
+COCOTB?=$(WPWD)/../../..
 
 ifeq ($(TOPLEVEL_LANG),verilog)
     VERILOG_SOURCES = $(COCOTB)/tests/designs/array_module/array_module.v


### PR DESCRIPTION
Fixes compile errors for modelsim FLI under windows 64 bit as detailed in #428.