### PR TITLE
Support for Riviera-Pro 32bit on 64bit host

### DIFF
--- a/lib/simulator/simulatormodule.c
+++ b/lib/simulator/simulatormodule.c
@@ -952,7 +952,25 @@ static PyObject *deregister_callback(PyObject *self, PyObject *args)
     gstate = TAKE_GIL();
 
     pSihHdl = PyTuple_GetItem(args, 0);
-    hdl = (gpi_sim_hdl)PyLong_AsUnsignedLong(pSihHdl);
+
+
+    // In python 2.x pSohHdl is PyLong on 64bit systems, Pyint on 32bit systems
+#if PY_VERSION_HEX < 0x03000000
+        if (PyLong_Check(pSihHdl)) {
+            hdl = (gpi_sim_hdl)PyLong_AsUnsignedLong(pSihHdl);
+        }
+        else if (PyInt_Check(pSihHdl)) {
+            hdl = (gpi_sim_hdl)PyInt_AsLong(pSihHdl);
+        }
+        else {
+            PyErr_SetString(PyExc_RuntimeError, "Failed to deregister callback!");
+            return NULL;
+        }
+        
+#else  // In python3.x all integers are PyLong
+        hdl = (gpi_sim_hdl)PyLong_AsVoidPtr(pSihHdl);
+#endif
+        
 
     gpi_deregister_callback(hdl);
 

--- a/makefiles/simulators/Makefile.aldec
+++ b/makefiles/simulators/Makefile.aldec
@@ -133,7 +133,12 @@ LIB_LOAD := PATH=$(MINGW_BIN_DIR):$(OLD_PATH):$(LIB_DIR)
 NEW_PYTHONPATH := $(shell echo "$(PYTHONPATH)" | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):\//\/\1\//g' -e 's/;/:/g')
 else
 EXTRA_LIBS = -laldecpli
+# If running 32 bit version of Riviera, use the 32 bit library path
+ifeq ($(ARCH),i686)
+EXTRA_LIBDIRS = -L$(ALDEC_BIN_DIR)/Linux
+else
 EXTRA_LIBDIRS = -L$(ALDEC_BIN_DIR)/Linux64
+endif
 LIB_LOAD := LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)
 NEW_PYTHONPATH := $(PYTHONPATH)
 endif


### PR DESCRIPTION
These changes allow cocotb to be used with Riviera-Pro 32bit version running on a 64bit host. 

I don't think the changes will break support for other simulators, but I am not able to test it.
