### PR TITLE
replaced list with deque in monitor and driver

### DIFF
--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -186,7 +186,7 @@ class Driver(object):
             # Send in all the queued packets,
             # only synchronise on the first send
             while self._sendQ:
-                transaction, callback, event = self._sendQ.pop(0)
+                transaction, callback, event = self._sendQ.popleft()
                 self.log.debug("Sending queued packet...")
                 yield self._send(transaction, callback, event,
                                  sync=not synchronised)

--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 """
 
 import logging
+from collections import deque
 
 import cocotb
 from cocotb.decorators import coroutine
@@ -93,7 +94,7 @@ class Driver(object):
         """
         # self._busy = Lock()
         self._pending = Event(name="Driver._pending")
-        self._sendQ = []
+        self._sendQ = deque()
 
         # Subclasses may already set up logging
         if not hasattr(self, "log"):
@@ -126,7 +127,7 @@ class Driver(object):
         """
         Clear any queued transactions without sending them onto the bus
         """
-        self._sendQ = []
+        self._sendQ = deque()
 
     @coroutine
     def send(self, transaction, sync=True):
@@ -339,4 +340,3 @@ def polled_socket_attachment(driver, sock):
             driver.log.info("Remote end closed the connection")
             break
         driver.append(data)
-

--- a/cocotb/monitors/__init__.py
+++ b/cocotb/monitors/__init__.py
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 """
 
 import math
+from collections import deque
 
 import cocotb
 from cocotb.decorators import coroutine
@@ -65,7 +66,7 @@ class Monitor(object):
         """
         self._event = event
         self._wait_event = None
-        self._recvQ = []
+        self._recvQ = deque()
         self._callbacks = []
         self.stats = MonitorStatistics()
         self._wait_event = Event()


### PR DESCRIPTION
When using bus drivers/monitors, it is helpful to be able to pop off the front of the list as well as the back. Although the python `list` object supports popping at either side, `list.pop(0)` is actually an O(N) operation. The `deque` object from the standard library (short for 'double-ended queue') is more appropriate here, as it implements both FIFO and LIFO operations with O(1) complexity. It can be used transparently as a list object.