### PR TITLE
Scheduling a write during the read-only phase should cause an exception

### DIFF
--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -35,7 +35,7 @@ import random
 
 import cocotb
 from cocotb.decorators import coroutine
-from cocotb.triggers import RisingEdge, ReadOnly, Event
+from cocotb.triggers import RisingEdge, ReadOnly, NextTimeStep, Event
 from cocotb.drivers import BusDriver, ValidatedBusDriver
 from cocotb.utils import hexdump
 from cocotb.binary import BinaryValue
@@ -359,6 +359,7 @@ class AvalonMemory(BusDriver):
 
                     # toggle waitrequest
                     # TODO: configure waitrequest time with avalon properties
+                    yield NextTimeStep()  # can't write during read-only phase
                     self.bus.waitrequest <= 1
                     yield edge
                     yield edge

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -375,6 +375,8 @@ class Scheduler(object):
         del coro._join
 
     def save_write(self, handle, value):
+        if self._mode == Scheduler._MODE_READONLY:
+            raise Exception("Write to object {} was scheduled during a read-only sync phase.".format(handle._name))
         self._writes[handle] = value
 
     def _coroutine_yielded(self, coro, triggers):


### PR DESCRIPTION
Related to https://github.com/potentialventures/cocotb/issues/448.

Scheduling a write after a read-only sync is specifically forbidden by the verilog 2001 spec:

> IEEE 1394-2001, pg 703:
> 
> cbReadOnlySynch => Same as cbReadWriteSynch, except that writing values or scheduling events before the next scheduled event is not allowed.

cocotb currently allows this due to its write caching mechanism, but it will execute the write at the next timestep which may or may not be what the user wanted (in my case, it was a genuine accident and caused many hours of debugging). This pull request changes it to align with the verilog standard and PEP 20 ("Explicit is better than implicit"), in that it now throws an exception if you try to do so.

This change exposed a bug in the avalon driver, so that was also fixed.

Previous test cases were modified to account for this change, and a new test case created to check the added functionality.