### PR TITLE
ClockCycles() now sets edge parameter when scheduling with simulator

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -280,16 +280,22 @@ def FallingEdge(signal):
 
 class ClockCycles(_Edge):
     """
-    Execution will resume after N rising edges
+    Execution will resume after N rising edges or N falling edges
     """
-    def __init__(self, signal, num_cycles):
+    def __init__(self, signal, num_cycles, rising=True):
         Edge.__init__(self, signal)
         self.num_cycles = num_cycles
+        if rising is True:
+            self._rising = 1
+        else:
+            self._rising = 2
 
     def prime(self, callback):
         self._callback = callback
 
         def _check(obj):
+            self.unprime()
+
             if self.signal.value:
                 self.num_cycles -= 1
 
@@ -300,6 +306,7 @@ class ClockCycles(_Edge):
             self.cbhdl = simulator.register_value_change_callback(self.signal.
                                                                   _handle,
                                                                   _check,
+                                                                  self._rising,
                                                                   self)
             if self.cbhdl is None:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
@@ -307,6 +314,7 @@ class ClockCycles(_Edge):
         self.cbhdl = simulator.register_value_change_callback(self.signal.
                                                               _handle,
                                                               _check,
+                                                              self._rising,
                                                               self)
         if self.cbhdl is None:
             raise_error(self, "Unable set up %s Trigger" % (str(self)))


### PR DESCRIPTION
Sets simulator.register_value_change_callback() edge parameter correctly (wasn't set before)
Added parameter "rising" for selecting rising (default) or falling edges
unprime() called at top of callback _check()