### PR TITLE
Pass RTL_LIBRARY to GHDL analyse and elaborate.

### DIFF
--- a/makefiles/simulators/Makefile.ghdl
+++ b/makefiles/simulators/Makefile.ghdl
@@ -54,7 +54,7 @@ endif
 
 # Compilation phase
 analyse: $(VHDL_SOURCES) $(SIM_BUILD)
-	cd $(SIM_BUILD) && $(CMD) -a $(VHDL_SOURCES) && $(CMD) -e $(TOPLEVEL)
+	cd $(SIM_BUILD) && $(CMD) -a --work=$(RTL_LIBRARY) $(VHDL_SOURCES) && $(CMD) -e --work=$(RTL_LIBRARY) $(TOPLEVEL)
 
 results.xml: analyse  $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
 	cd $(SIM_BUILD); \


### PR DESCRIPTION
Hello,

Makefile variable RTL_LIBRARY must be passed to GHDL analyse and elaborate calls. Required if RTL_LIBRARY differs from "work".

Thanks.