### PR TITLE
fix for runaway sims on ius - #463

### DIFF
--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -430,7 +430,14 @@ int VpiValueCbHdl::cleanup_callback(void)
 VpiStartupCbHdl::VpiStartupCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
                                                            VpiCbHdl(impl)
 {
+#ifndef IUS
     cb_data.reason = cbStartOfSimulation;
+#else
+    vpi_time.high = (uint32_t)(0);
+    vpi_time.low  = (uint32_t)(0);
+    vpi_time.type = vpiSimTime;
+    cb_data.reason = cbAfterDelay;
+#endif
 }
 
 int VpiStartupCbHdl::run_callback(void) {


### PR DESCRIPTION
Calling vpi_control in a callback with reason
cbStartOfSimulation doesn't stop a simulation in ius.