### PR TITLE
Added default value for RTL_LIBRARY in Makefile.ghdl.

### DIFF
--- a/makefiles/simulators/Makefile.ghdl
+++ b/makefiles/simulators/Makefile.ghdl
@@ -50,6 +50,8 @@ else
     export GHDL_BIN_DIR
 endif
 
+RTL_LIBRARY ?= work
+
 .PHONY: analyse
 
 # Compilation phase


### PR DESCRIPTION
Hello,

this pull request fixes an issue introduced after my last pull request #467 has been merged in master. 

RTL_LIBRARY is set to "work" in Makefile.ghdl if no value was given in a project specific makefile or on the command line.

Sorry for missing that in the first place,
Martin