### PR TITLE
Improved WaveDrom header/footer handling, added config handler

### DIFF
--- a/cocotb/wavedrom.py
+++ b/cocotb/wavedrom.py
@@ -200,9 +200,15 @@ class trace(object):
         for sig in self._signals:
             trace["signal"].extend(sig.get(add_clock=False))
         if header:
-            trace["head"] = header
+            if isinstance(header, dict):
+                trace["head"] = header
+            else:
+                trace["head"] = {"text": header}
         if footer:
-            trace["foot"] = footer
+            if isinstance(footer, dict):
+                trace["foot"] = footer
+            else:
+                trace["foot"] = {"text": footer}
         if config:
             trace["config"] = config
         return json.dumps(trace, indent=4, sort_keys=False)

--- a/cocotb/wavedrom.py
+++ b/cocotb/wavedrom.py
@@ -193,14 +193,16 @@ class trace(object):
         with open(filename, "w") as f:
             f.write(self.dumpj(**kwargs))
 
-    def dumpj(self, header="", footer=""):
+    def dumpj(self, header="", footer="", config=""):
         trace = {"signal": []}
         trace["signal"].append(
             {"name": "clock", "wave": "p" + "."*(self._clocks-1)})
         for sig in self._signals:
             trace["signal"].extend(sig.get(add_clock=False))
         if header:
-            trace["head"] = {"text": header}
+            trace["head"] = header
         if footer:
-            trace["foot"] = {"text": footer}
+            trace["foot"] = footer
+        if config:
+            trace["config"] = config
         return json.dumps(trace, indent=4, sort_keys=False)

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -190,7 +190,7 @@ import cocotb.wavedrom
 @cocotb.test()
 def wavedrom_test(dut):
     """
-    Generate a JSON wavedrom diagram of a trace
+    Generate a JSON wavedrom diagram of a trace and save it to wavedrom.json
     """
     cocotb.fork(clock_gen(dut.clk))
     yield RisingEdge(dut.clk)
@@ -202,4 +202,5 @@ def wavedrom_test(dut):
         yield tb.csr.read(0)
         yield RisingEdge(dut.clk)
         yield RisingEdge(dut.clk)
-        dut._log.info(waves.dumpj())
+        dut._log.info(waves.dumpj(header = {'text':'WaveDrom example', 'tick':0}))
+        waves.write('wavedrom.json', header = {'tick':0}, config = {'hscale':3})


### PR DESCRIPTION
Previous method did not have full compatibility with WaveDrom standard.

All header or footer arguments were passed as an an object in the "text" field.

See:
http://wavedrom.com/tutorial.html

That would work fine in (most of) the last example of Step 8, for example, but would be incomplete in the immediately preceding example, where there are arguments outside "text"

This method allows more control on the user side, e.g.:

```

log.info(waves.dumpj(header = {'text':'WaveDrom example', 'tick':0}))
waves.write('wavedrom.json', header = {'tick':0}, config = {'hscale':3})

```
