### PR TITLE
add a space so GCC 6.1.1 won't complain

### DIFF
--- a/lib/gpi/GpiCommon.cpp
+++ b/lib/gpi/GpiCommon.cpp
@@ -133,7 +133,7 @@ void gpi_embed_event(gpi_event_t level, const char *msg)
 
 static void gpi_load_libs(std::vector<std::string> to_load)
 {
-#define DOT_LIB_EXT "."xstr(LIB_EXT)
+#define DOT_LIB_EXT "." xstr(LIB_EXT)
     std::vector<std::string>::iterator iter;
 
     for (iter = to_load.begin();


### PR DESCRIPTION
I upgraded the compiler and cocotb won't run due to a warning that gets promoted to an error.

GpiCommon.cpp:92:21: error: invalid suffix on literal; C++11 requires a space between literal and string macro [-Werror=literal-suffix]
 #define DOT_LIB_EXT "."xstr(LIB_EXT)

gcc (GCC) 6.1.1 20160621 (Red Hat 6.1.1-3)
Copyright (C) 2016 Free Software Foundation, Inc.
