### PR TITLE
python3 compatibility fix - print as a keyword replaced with print() …

### DIFF
--- a/makefiles/Makefile.pylib.Msys
+++ b/makefiles/Makefile.pylib.Msys
@@ -42,14 +42,14 @@ endif
 PYTHON_BIN=$(PYTHON_DIR)/python.exe
 
 # We might work with other Python versions
-LOCAL_PYTHON_VERSION?=$(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print distutils.sysconfig.get_python_version()')
-PYTHON_DYNLIBDIR:=$(shell $(PYTHON_BIN) -c 'from distutils import sysconfig; print sysconfig.get_config_var("DESTSHARED")')
+LOCAL_PYTHON_VERSION?=$(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print( distutils.sysconfig.get_python_version() )')
+PYTHON_DYNLIBDIR:=$(shell $(PYTHON_BIN) -c 'from distutils import sysconfig; print( sysconfig.get_config_var("DESTSHARED") )')
 PYTHON_LIBDIR=$(PYTHON_DIR)/libs
 
 period := .
 empty := 
 PYTHON_VERSION=$(subst $(period),$(empty),$(LOCAL_PYTHON_VERSION))
-PYTHON_INCLUDEDIR := $(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print distutils.sysconfig.get_python_inc()')
+PYTHON_INCLUDEDIR := $(shell $(PYTHON_BIN) -c 'import distutils.sysconfig; print( distutils.sysconfig.get_python_inc() )')
 
 PYLIBS = -lPython$(PYTHON_VERSION)
 PYTHON_DYN_LIB = Python$(PYTHON_VERSION).dll


### PR DESCRIPTION
python3 compatibility fix
