### PR TITLE
Fix C++11 error message

### DIFF
--- a/lib/gpi/GpiCommon.cpp
+++ b/lib/gpi/GpiCommon.cpp
@@ -133,7 +133,7 @@ void gpi_embed_event(gpi_event_t level, const char *msg)
 
 static void gpi_load_libs(std::vector<std::string> to_load)
 {
-#define DOT_LIB_EXT "."xstr(LIB_EXT)
+#define DOT_LIB_EXT "." xstr(LIB_EXT)
     std::vector<std::string>::iterator iter;
 
     for (iter = to_load.begin();


### PR DESCRIPTION
When building on Fedora 25 gcc complains with the following message:
```
GpiCommon.cpp:136:21: erreur : suffixe de chaîne invalide ; C++11 requière un espace entre une chaîne et une macro de chaîne [-Werror=literal-suffix]
 #define DOT_LIB_EXT "."xstr(LIB_EXT)
```