### PR TITLE
Added AXI Lite Slave Test

### DIFF
--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -36,7 +36,7 @@ import binascii
 import array
 
 
-class AXIReadError(Exception):
+class AXIProtocolError(Exception):
     pass
 
 
@@ -141,7 +141,7 @@ class AXI4LiteMaster(BusDriver):
         yield RisingEdge(self.clock)
 
         if int(result):
-            raise AXIReadError("Write to address 0x%08x failed with BRESP: %d"
+            raise AXIProtocolError("Write to address 0x%08x failed with BRESP: %d"
                                % (address, int(result)))
 
         raise ReturnValue(result)
@@ -175,7 +175,7 @@ class AXI4LiteMaster(BusDriver):
             yield RisingEdge(self.clock)
 
         if int(result):
-            raise AXIReadError("Read address 0x%08x failed with RRESP: %d" %
+            raise AXIProtocolError("Read address 0x%08x failed with RRESP: %d" %
                                (address, int(result)))
 
         raise ReturnValue(data)

--- a/examples/axi_lite_slave/README.md
+++ b/examples/axi_lite_slave/README.md
@@ -1,0 +1,27 @@
+# AXI Lite Demo
+
+Description: In order to simplify AXI Lite Transactions we use an module that
+translates AXI Lite Slave transactions to a simple register read/write.
+
+There are other projects that translate AXI Slave signals to wishbone.
+
+
+## Source Files
+
+* tb\_axi\_lite\_slave: Testbench interface, primarily used to translate
+    the cocotb AXI Lite bus signals to the signals within axi_lite_demo core
+
+* axi\_lite\_demo: demonstration module, anyone who wishes to interact
+    with an AXI Lite slave core can use this as a template.
+
+* axi\_lite\_slave: Performs all the low level AXI Translactions.
+    * Addresses and data sent from the master are decoded from the AXI Bus and
+        sent to the user with a simple 'ready', 'acknowledge' handshake.
+    * Address and data are read from the slave using a simple
+        'request', 'ready' handshake.
+
+## NOTE: Test ID
+
+If you use a logic analyzer wave viewer it's hard to determine which test is
+currently running so I added a value called 'test\_id' in the test bench
+so when viewing the waveforms the individual tests can easily be identified

--- a/examples/axi_lite_slave/hdl/axi_defines.v
+++ b/examples/axi_lite_slave/hdl/axi_defines.v
@@ -1,0 +1,68 @@
+`ifndef __AXI_DEFINES__
+`define __AXI_DEFINES__
+
+//AXI Defines
+
+//--Burst
+`define AXI_BURST_FIXED         2'b00
+`define AXI_BURST_INCR          2'b01
+`define AXI_BURST_WRAP          2'b10
+
+//--Burst Size
+`define AXI_BURST_SIZE_8BIT     3'b000
+`define AXI_BURST_SIZE_16BIT    3'b001
+`define AXI_BURST_SIZE_32BIT    3'b010
+`define AXI_BURST_SIZE_64BIT    3'b011
+`define AXI_BURST_SIZE_128BIT   3'b100
+`define AXI_BURST_SIZE_256BIT   3'b101
+`define AXI_BURST_SIZE_512BIT   3'b110
+`define AXI_BURST_SIZE_1024BIT  3'b111
+
+//--Response
+`define AXI_RESP_OKAY           2'b00
+`define AXI_RESP_EXOKAY         2'b01
+`define AXI_RESP_SLVERR         2'b10
+`define AXI_RESP_DECERR         2'b11
+
+//--Lock
+`define AXI_LOCK_NORMAL         2'b00
+`define AXI_LOCK_EXCLUSIVE      2'b01
+`define AXI_LOCK_LOCKED         2'b10
+
+//--cache
+//----Bufferable
+`define AXI_CACHE_NON_BUF       1'b0
+`define AXI_CACHE_BUF           1'b1
+//----Cachable
+`define AXI_CACHE_NON_CACHE     1'b0
+`define AXI_CACHE_CACHE         1'b1
+//----Read Allocate
+`define AXI_CACHE_NON_RA        1'b0
+`define AXI_CACHE_RA            1'b1
+//----Write Allocate
+`define AXI_CACHE_NON_WA        1'b0
+`define AXI_CACHE_WA            1'b1
+//----Unused
+`define AXI_CACHE_UNUSED        4'b0000
+
+//--Protection
+//----ARPROT[0]
+`define AXI_PROT_NORMAL         1'b0
+`define AXI_PROT_PRIVLEDGE      1'b1
+
+//----ARPROT[1]
+`define AXI_PROT_SECURE         1'b0
+`define AXI_PROT_NON_SECURE     1'b1
+
+//----ARPROT[2]
+`define AXI_PROT_DATA           1'b0
+`define AXI_PROT_INST           1'b1
+
+//----Unused:
+`define AXI_PROT_UNUSED         {`AXI_PROT_NORMAL, `AXI_PROT_NON_SECURE, `AXI_PROT_DATA}
+
+//--Low Power Mode
+`define AXI_POWER_LOW           1'b0
+`define AXI_POWER_NORMAL        1'b1
+
+`endif //__AXI_DEFINES__

--- a/examples/axi_lite_slave/hdl/axi_lite_demo.v
+++ b/examples/axi_lite_slave/hdl/axi_lite_demo.v
@@ -1,0 +1,210 @@
+/*
+Distributed under the MIT license.
+Copyright (c) 2016 Dave McCoy (dave.mccoy@cospandesign.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+ * Author:
+ * Description:
+ *
+ * Changes:
+ */
+
+`timescale 1ps / 1ps
+
+module axi_lite_demo #(
+  parameter ADDR_WIDTH          = 32,
+  parameter DATA_WIDTH          = 32,
+  parameter STROBE_WIDTH        = (DATA_WIDTH / 8)
+)(
+  input                               clk,
+  input                               rst,
+
+  //Write Address Channel
+  input                               i_awvalid,
+  input       [ADDR_WIDTH - 1: 0]     i_awaddr,
+  output                              o_awready,
+
+  //Write Data Channel
+  input                               i_wvalid,
+  output                              o_wready,
+  input       [STROBE_WIDTH - 1:0]    i_wstrb,
+  input       [DATA_WIDTH - 1: 0]     i_wdata,
+
+  //Write Response Channel
+  output                              o_bvalid,
+  input                               i_bready,
+  output      [1:0]                   o_bresp,
+
+  //Read Address Channel
+  input                               i_arvalid,
+  output                              o_arready,
+  input       [ADDR_WIDTH - 1: 0]     i_araddr,
+
+  //Read Data Channel
+  output                              o_rvalid,
+  input                               i_rready,
+  output      [1:0]                   o_rresp,
+  output      [DATA_WIDTH - 1: 0]     o_rdata
+);
+//local parameters
+
+//Address Map
+localparam  ADDR_0      = 0;
+localparam  ADDR_1      = 1;
+
+localparam  MAX_ADDR = ADDR_1;
+
+//registes/wires
+
+//User Interface
+wire [ADDR_WIDTH - 1: 0]    w_reg_address;
+reg                         r_reg_invalid_addr;
+
+wire                        w_reg_in_rdy;
+reg                         r_reg_in_ack_stb;
+wire [DATA_WIDTH - 1: 0]    w_reg_in_data;
+
+wire                        w_reg_out_req;
+reg                         r_reg_out_rdy_stb;
+reg [DATA_WIDTH - 1: 0]     r_reg_out_data;
+
+
+//TEMP DATA, JUST FOR THE DEMO
+reg [DATA_WIDTH - 1: 0]     r_temp_0;
+reg [DATA_WIDTH - 1: 0]     r_temp_1;
+
+//submodules
+
+//Convert AXI Slave bus to a simple register/address strobe
+axi_lite_slave #(
+  .ADDR_WIDTH         (ADDR_WIDTH           ),
+  .DATA_WIDTH         (DATA_WIDTH           )
+
+) axi_lite_reg_interface (
+  .clk                (clk                  ),
+  .rst                (rst                  ),
+
+
+  .i_awvalid          (i_awvalid            ),
+  .i_awaddr           (i_awaddr             ),
+  .o_awready          (o_awready            ),
+
+  .i_wvalid           (i_wvalid             ),
+  .o_wready           (o_wready             ),
+  .i_wstrb            (i_wstrb              ),
+  .i_wdata            (i_wdata              ),
+
+  .o_bvalid           (o_bvalid             ),
+  .i_bready           (i_bready             ),
+  .o_bresp            (o_bresp              ),
+
+  .i_arvalid          (i_arvalid            ),
+  .o_arready          (o_arready            ),
+  .i_araddr           (i_araddr             ),
+
+  .o_rvalid           (o_rvalid             ),
+  .i_rready           (i_rready             ),
+  .o_rresp            (o_rresp              ),
+  .o_rdata            (o_rdata              ),
+
+
+  //Simple Register Interface
+  .o_reg_address      (w_reg_address        ),
+  .i_reg_invalid_addr (r_reg_invalid_addr   ),
+
+  //Ingress Path (From Master)
+  .o_reg_in_rdy       (w_reg_in_rdy         ),
+  .i_reg_in_ack_stb   (r_reg_in_ack_stb     ),
+  .o_reg_in_data      (w_reg_in_data        ),
+
+  //Egress Path (To Master)
+  .o_reg_out_req      (w_reg_out_req        ),
+  .i_reg_out_rdy_stb  (r_reg_out_rdy_stb    ),
+  .i_reg_out_data     (r_reg_out_data       )
+);
+
+//asynchronous logic
+
+//synchronous logic
+always @ (posedge clk) begin
+  //De-assert Strobes
+  r_reg_in_ack_stb                        <=  0;
+  r_reg_out_rdy_stb                       <=  0;
+  r_reg_invalid_addr                      <=  0;
+
+  if (rst) begin
+    r_reg_out_data                        <=  0;
+
+    //Reset the temporary Data
+    r_temp_0                              <=  0;
+    r_temp_1                              <=  0;
+  end
+  else begin
+
+    if (w_reg_in_rdy) begin
+      //From master
+      case (w_reg_address)
+        ADDR_0: begin
+          //$display("Incomming data on address: 0x%h: 0x%h", w_reg_address, w_reg_in_data);
+          r_temp_0                        <=  w_reg_in_data;
+        end
+        ADDR_1: begin
+          //$display("Incomming data on address: 0x%h: 0x%h", w_reg_address, w_reg_in_data);
+          r_temp_1                        <=  w_reg_in_data;
+        end
+        default: begin
+          $display ("Unknown address: 0x%h", w_reg_address);
+        end
+      endcase
+      if (w_reg_address > MAX_ADDR) begin
+        //Tell the host they wrote to an invalid address
+        r_reg_invalid_addr                <= 1;
+      end
+      //Tell the AXI Slave Control we're done with the data
+      r_reg_in_ack_stb                    <= 1;
+    end
+    else if (w_reg_out_req) begin
+      //To master
+      //$display("User is reading from address 0x%0h", w_reg_address);
+      case (w_reg_address)
+        ADDR_0: begin
+          r_reg_out_data                  <= r_temp_0;
+        end
+        ADDR_1: begin
+          r_reg_out_data                  <= r_temp_1;
+        end
+        default: begin
+          //Unknown address
+          r_reg_out_data                  <= 32'h00;
+        end
+      endcase
+      if (w_reg_address > MAX_ADDR) begin
+        //Tell the host they are reading from an invalid address
+        r_reg_invalid_addr                <= 1;
+      end
+      //Tell the AXI Slave to send back this packet
+      r_reg_out_rdy_stb                   <= 1;
+    end
+  end
+end
+
+endmodule

--- a/examples/axi_lite_slave/hdl/axi_lite_slave.v
+++ b/examples/axi_lite_slave/hdl/axi_lite_slave.v
@@ -1,0 +1,218 @@
+/*
+Distributed under the MIT license.
+Copyright (c) 2017 Dave McCoy (dave.mccoy@cospandesign.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+ * Author: David McCoy (dave.mccoy@cospandesign.com)
+ * Description: An AXI Lite Slave interface that simplifies register access
+ *  XXX: Currently there is no strobe level access
+ *
+ * Changes:
+ *  3/24/2017: Initial Commit
+ */
+
+`timescale 1ps / 1ps
+
+`include "axi_defines.v"
+
+module axi_lite_slave #(
+  parameter ADDR_WIDTH          = 32,
+  parameter DATA_WIDTH          = 32,
+  parameter STROBE_WIDTH        = (DATA_WIDTH / 8)
+
+)(
+
+  input                               clk,
+  input                               rst,
+
+  //Write Address Channel
+  input                               i_awvalid,
+  input       [ADDR_WIDTH - 1: 0]     i_awaddr,
+  output  reg                         o_awready,
+
+  //Write Data Channel
+  input                               i_wvalid,
+  output  reg                         o_wready,
+  input       [STROBE_WIDTH - 1:0]    i_wstrb,
+  input       [DATA_WIDTH - 1: 0]     i_wdata,
+
+  //Write Response Channel
+  output  reg                         o_bvalid,
+  input                               i_bready,
+  output  reg [1:0]                   o_bresp,
+
+  //Read Address Channel
+  input                               i_arvalid,
+  output  reg                         o_arready,
+  input       [ADDR_WIDTH - 1: 0]     i_araddr,
+
+  //Read Data Channel
+  output  reg                         o_rvalid,
+  input                               i_rready,
+  output  reg [1:0]                   o_rresp,
+  output  reg [DATA_WIDTH - 1: 0]     o_rdata,
+
+
+
+  //Simple User Interface
+  output  reg                         o_reg_in_rdy,
+  input                               i_reg_in_ack_stb,
+  output  reg [ADDR_WIDTH - 1: 0]     o_reg_address,
+  output  reg [DATA_WIDTH - 1: 0]     o_reg_in_data,
+
+  output  reg                         o_reg_out_req,
+  input                               i_reg_out_rdy_stb,
+  input       [DATA_WIDTH - 1: 0]     i_reg_out_data,
+  input                               i_reg_invalid_addr
+
+);
+
+
+
+//local parameters
+localparam      IDLE                = 4'h0;
+localparam      RECEIVE_WRITE_DATA  = 4'h1;
+localparam      WRITE_WAIT_FOR_USER = 4'h2;
+localparam      SEND_WRITE_RESP     = 4'h3;
+localparam      READ_WAIT_FOR_USER  = 4'h4;
+localparam      SEND_READ_DATA      = 4'h5;
+
+//registes/wires
+reg   [3:0]                           state;
+
+//submodules
+//asynchronous logic
+//synchronous logic
+
+always @ (posedge clk) begin
+  //Deassert Strobes
+  if (rst) begin
+    o_reg_address       <=  0;
+    o_arready           <=  0;
+    o_awready           <=  0;
+    o_wready            <=  0;
+
+    o_rvalid            <=  0;
+    o_rdata             <=  0;
+    o_bresp             <=  0;
+    o_rresp             <=  0;
+    o_bvalid            <=  0;
+
+    //Demo values
+    state               <= IDLE;
+    o_reg_in_rdy        <=  0;
+    o_reg_in_data       <=  0;
+    o_reg_out_req       <=  0;
+  end
+  else begin
+    case (state)
+      IDLE: begin
+        o_reg_in_rdy    <=  0;
+        o_reg_address   <=  0;
+        o_awready       <=  1;
+        o_arready       <=  1;
+        o_rvalid        <=  0;
+        o_bresp         <=  0;
+        o_rresp         <=  0;
+        o_bvalid        <=  0;
+        o_reg_out_req   <=  0;
+        o_wready        <=  0;
+
+        //Only handle read or write at one time, not both
+        if (i_awvalid && o_awready) begin
+          o_reg_address <=  i_awaddr;
+          o_wready      <=  1;
+          o_arready     <=  0;
+          state         <=  RECEIVE_WRITE_DATA;
+        end
+        else if (i_arvalid && o_arready) begin
+          o_reg_address <=  i_araddr;
+          o_awready     <=  0;
+          o_reg_out_req <=  1;
+          state         <=  READ_WAIT_FOR_USER;
+        end
+      end
+      RECEIVE_WRITE_DATA: begin
+        o_awready       <=  0;
+
+        if (i_wvalid) begin
+          //Assume everything is okay unless the o_reg_address is wrong,
+          //We don't want to clutter our states with this statement over and over again
+          o_reg_in_data   <=  i_wdata;
+          state           <=  WRITE_WAIT_FOR_USER;
+          o_reg_in_rdy    <=  1;
+        end
+      end
+      WRITE_WAIT_FOR_USER: begin
+        //Wait for the user to ackknowledge the new info, user can introduce a delay
+        if (i_reg_in_ack_stb) begin
+          state           <=  SEND_WRITE_RESP;
+          o_reg_in_rdy    <=  0;
+          o_bvalid        <=  1;
+          if (i_reg_invalid_addr) begin
+            o_bresp       <=  `AXI_RESP_DECERR;
+          end
+          else begin
+            o_bresp       <=  `AXI_RESP_OKAY;
+          end
+        end
+      end
+      SEND_WRITE_RESP: begin
+        if (i_bready && o_bvalid) begin
+          o_bvalid      <=  0;
+          state         <=  IDLE;
+        end
+      end
+
+      //Read Path
+      READ_WAIT_FOR_USER: begin
+        o_arready       <=  0;
+        if (i_reg_out_rdy_stb) begin
+          //The data in i_reg_out_data should be valid now
+          o_rdata       <=  i_reg_out_data;
+          if (i_reg_invalid_addr) begin
+            o_rresp     <=  `AXI_RESP_DECERR;
+          end
+          else begin
+            o_rresp     <=  `AXI_RESP_OKAY;
+          end
+          o_rvalid      <=  1;
+          state         <=  SEND_READ_DATA;
+        end
+      end
+      SEND_READ_DATA: begin
+        //If more time is needed for a response another state should be added here
+        if (i_rready && o_rvalid) begin
+          o_rvalid      <=  0;
+          state         <=  IDLE;
+        end
+      end
+      default: begin
+        $display("AXI Lite Slave: Shouldn't have gotten here!");
+      end
+    endcase
+  end
+end
+
+
+
+endmodule

--- a/examples/axi_lite_slave/hdl/tb_axi_lite_slave.v
+++ b/examples/axi_lite_slave/hdl/tb_axi_lite_slave.v
@@ -1,0 +1,98 @@
+`timescale 1ns/1ps
+
+
+module tb_axi_lite_slave #(
+  parameter ADDR_WIDTH          = 32,
+  parameter DATA_WIDTH          = 32,
+  parameter STROBE_WIDTH        = (DATA_WIDTH / 8)
+)(
+
+input                               clk,
+input                               rst,
+
+//Write Address Channel
+input                               AXIML_AWVALID,
+input       [ADDR_WIDTH - 1: 0]     AXIML_AWADDR,
+output                              AXIML_AWREADY,
+
+//Write Data Channel
+input                               AXIML_WVALID,
+output                              AXIML_WREADY,
+input       [STROBE_WIDTH - 1:0]    AXIML_WSTRB,
+input       [DATA_WIDTH - 1: 0]     AXIML_WDATA,
+
+//Write Response Channel
+output                              AXIML_BVALID,
+input                               AXIML_BREADY,
+output      [1:0]                   AXIML_BRESP,
+
+//Read Address Channel
+input                               AXIML_ARVALID,
+output                              AXIML_ARREADY,
+input       [ADDR_WIDTH - 1: 0]     AXIML_ARADDR,
+
+//Read Data Channel
+output                              AXIML_RVALID,
+input                               AXIML_RREADY,
+output      [1:0]                   AXIML_RRESP,
+output      [DATA_WIDTH - 1: 0]     AXIML_RDATA
+
+);
+
+
+//Local Parameters
+//Registers
+
+reg               r_rst;
+reg               test_id         = 0;
+
+//Workaround for weird icarus simulator bug
+always @ (*)      r_rst           = rst;
+
+//submodules
+axi_lite_demo #(
+  .ADDR_WIDTH   (ADDR_WIDTH     ),
+  .DATA_WIDTH   (DATA_WIDTH     )
+) dut (
+  .clk          (clk            ),
+  .rst          (r_rst          ),
+
+
+  .i_awvalid    (AXIML_AWVALID  ),
+  .i_awaddr     (AXIML_AWADDR   ),
+  .o_awready    (AXIML_AWREADY  ),
+
+
+  .i_wvalid     (AXIML_WVALID   ),
+  .o_wready     (AXIML_WREADY   ),
+  .i_wstrb      (AXIML_WSTRB    ),
+  .i_wdata      (AXIML_WDATA    ),
+
+
+  .o_bvalid     (AXIML_BVALID   ),
+  .i_bready     (AXIML_BREADY   ),
+  .o_bresp      (AXIML_BRESP    ),
+
+
+  .i_arvalid    (AXIML_ARVALID  ),
+  .o_arready    (AXIML_ARREADY  ),
+  .i_araddr     (AXIML_ARADDR   ),
+
+
+  .o_rvalid     (AXIML_RVALID   ),
+  .i_rready     (AXIML_RREADY   ),
+  .o_rresp      (AXIML_RRESP    ),
+  .o_rdata      (AXIML_RDATA    )
+
+);
+
+//asynchronus logic
+//synchronous logic
+
+initial begin
+  $dumpfile ("design.vcd");
+  $dumpvars(0, tb_axi_lite_slave);
+end
+
+
+endmodule

--- a/examples/axi_lite_slave/tests/Makefile
+++ b/examples/axi_lite_slave/tests/Makefile
@@ -1,0 +1,29 @@
+
+TOPLEVEL_LANG ?= verilog
+PWD=$(shell pwd)
+TOPDIR=$(PWD)/..
+COCOTB=$(PWD)/../../..
+PYTHONPATH := ./model:$(PYTHONPATH)
+
+export PYTHONPATH
+export PYTHONHOME=$(shell python -c "from distutils.sysconfig import get_config_var; print(get_config_var('prefix'))")
+
+EXTRA_ARGS+=-I$(TOPDIR)/hdl/
+
+#DUT
+VERILOG_SOURCES = $(TOPDIR)/hdl/axi_lite_slave.v
+VERILOG_SOURCES += $(TOPDIR)/hdl/axi_lite_demo.v
+
+#Test Bench
+VERILOG_SOURCES += $(TOPDIR)/hdl/tb_axi_lite_slave.v
+
+TOPLEVEL = tb_axi_lite_slave
+
+GPI_IMPL := vpi
+
+export TOPLEVEL_LANG
+MODULE=test_axi_lite_slave
+
+include $(COCOTB)/makefiles/Makefile.inc
+include $(COCOTB)/makefiles/Makefile.sim
+

--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -1,0 +1,208 @@
+import os
+import sys
+import cocotb
+import logging
+from cocotb.result import TestFailure
+from cocotb.result import TestSuccess
+from cocotb.clock import Clock
+import time
+from array import array as Array
+from cocotb.triggers import Timer
+from cocotb.drivers.amba import AXI4LiteMaster
+from cocotb.drivers.amba import AXIProtocolError
+
+CLK_PERIOD = 10
+
+MODULE_PATH = os.path.join(os.path.dirname(__file__), os.pardir, "hdl")
+MODULE_PATH = os.path.abspath(MODULE_PATH)
+
+def setup_dut(dut):
+    cocotb.fork(Clock(dut.clk, CLK_PERIOD).start())
+
+#Write to address 0 and verify that value got through
+@cocotb.test(skip = False)
+def write_address_0(dut):
+    """
+    Description:
+        Write to the register at address 0
+        verify the value has changed
+
+    Test ID: 0
+
+    Expected Results:
+        The value read directly from the register is the same as the
+        value written
+    """
+
+    #Reset
+    dut.rst <=  1
+    dut.test_id <= 0
+    axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
+    setup_dut(dut)
+    yield Timer(CLK_PERIOD * 10)
+    dut.rst <= 0
+
+    ADDRESS = 0x00
+    DATA = 0xAB
+
+    yield axim.write(ADDRESS, DATA)
+    yield Timer(CLK_PERIOD * 10)
+
+    value = dut.dut.r_temp_0
+    if value != DATA:
+        #Fail
+        raise TestFailure("Register at address 0x%08X should have been: \
+                           0x%08X but was 0x%08X" % (ADDRESS, DATA, value))
+
+    dut.log.info("Write 0x%08X to addres 0x%08X" % (value, ADDRESS))
+
+
+#Read back a value at address 0x01
+@cocotb.test(skip = False)
+def read_address_1(dut):
+    """
+    Description
+        Use cocotb to set the value of the register at address 0x01
+        Use AXIML to read the contents of that register and
+        compare the values
+
+    Test ID: 1
+
+    Expected Results:
+        The value read from the register is the same as the value written
+    """
+    #Reset
+    dut.rst <=  1
+    dut.test_id <= 0
+    axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
+    setup_dut(dut)
+    yield Timer(CLK_PERIOD * 10)
+    dut.rst <= 0
+
+    ADDRESS = 0x01
+    DATA = 0xCD
+
+    dut.dut.r_temp_1 <= DATA
+    yield Timer(CLK_PERIOD * 10)
+
+    value = yield axim.read(ADDRESS)
+    yield Timer(CLK_PERIOD * 10)
+
+    if value != DATA:
+        #Fail
+        raise TestFailure("Register at address 0x%08X should have been: \
+                           0x%08X but was 0x%08X" % (ADDRESS, DATA, value))
+
+    dut.log.info("Read: 0x%08X From Address: 0x%08X" % (value, ADDRESS))
+
+
+
+@cocotb.test(skip = False)
+def write_and_read(dut):
+    """
+    Description:
+        Write to the register at address 0
+        read back from that register and verify the value is the same
+
+    Test ID: 2
+
+    Expected Results:
+        The contents of the register is the same as the value written
+    """
+
+    #Reset
+    dut.rst <=  1
+    dut.test_id <= 2
+    axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
+    setup_dut(dut)
+    yield Timer(CLK_PERIOD * 10)
+    dut.rst <= 0
+
+    ADDRESS = 0x00
+    DATA = 0xAB
+
+    #Write to the register
+    yield axim.write(ADDRESS, DATA)
+    yield Timer(CLK_PERIOD * 10)
+
+    #Read back the value
+    value = yield axim.read(ADDRESS)
+    yield Timer(CLK_PERIOD * 10)
+
+    value = dut.dut.r_temp_0
+    if value != DATA:
+        #Fail
+        raise TestFailure("Register at address 0x%08X should have been: \
+                           0x%08X but was 0x%08X" % (ADDRESS, DATA, value))
+
+    dut.log.info("Write 0x%08X to addres 0x%08X" % (value, ADDRESS))
+
+@cocotb.test(skip = False, expect_error=True)
+def write_fail(dut):
+    """
+    Description:
+        Attemp to write data to an address that doesn't exist. This test
+        should fail
+
+    Test ID: 3
+
+    Expected Results:
+        The AXIML bus should throw an exception because the user attempted
+        to write to an invalid address
+    """
+    #Reset
+    dut.rst <=  1
+    dut.test_id <= 3
+    axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
+    setup_dut(dut)
+    yield Timer(CLK_PERIOD * 10)
+    dut.rst <= 0
+
+    ADDRESS = 0x02
+    DATA = 0xAB
+
+    try:
+        yield axim.write(ADDRESS, DATA)
+        yield Timer(CLK_PERIOD * 10)
+    except AXIProtocolError as e:
+        print "Exception: %s" % str(e)
+        dut.log.info("Bus Successfully Raised an Error")
+        raise TestSuccess()
+    raise TestFailure("AXI Bus Should have raised an ERROR when writing to \
+                        the wrong bus")
+
+@cocotb.test(skip = False, expect_error=True)
+def read_fail(dut):
+    """
+    Description:
+        Attemp to write data to an address that doesn't exist. This test
+        should fail
+
+    Test ID: 4
+
+    Expected Results:
+        The AXIML bus should throw an exception because the user attempted
+        to write to an invalid address
+    """
+    #Reset
+    dut.rst <=  1
+    dut.test_id <= 4
+    axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
+    setup_dut(dut)
+    yield Timer(CLK_PERIOD * 10)
+    dut.rst <= 0
+
+    ADDRESS = 0x02
+    DATA = 0xAB
+
+    try:
+        yield axim.read(ADDRESS, DATA)
+        yield Timer(CLK_PERIOD * 10)
+    except AXIProtocolError as e:
+        print "Exception: %s" % str(e)
+        dut.log.info("Bus Successfully Raised an Error")
+        raise TestSuccess()
+    raise TestFailure("AXI Bus Should have raised an ERROR when writing to \
+                        the wrong bus")
+
+


### PR DESCRIPTION
Created a test for AXI Lite Slaves.

Included is a core that can interact with the AXI Lite master.
The core will extract the address and data send from the master
and interact with the demo module with a very simple handshake
that the axi_lite_demo module can interface without
a state machine.

The master can read data from axi_lite_demo through the
axi_lite_slave using a simple handshake. The axi_lite_slave
will wrap up a response from the core in an AXI Lite Transaction.

The testbench can be run by navigating to the following directory:

<Cocotb Base>/examples/axi_lite_slave/tests

and running 'make'

Two of the tests fail on purpose, they attempt to read/write
from/to an illegal address.



I did make a change within the directory

<Cocotb Base>/cocotb/drivers/amba.py

where I modified the Exception to be:

AXIProtocolError instead of AXIReadError

Because that exception was raised during writes
and reads