### PR TITLE
Add utility classes for testing with numpy

### DIFF
--- a/cocotb/drivers/RdyAck/RdyAck.py
+++ b/cocotb/drivers/RdyAck/RdyAck.py
@@ -1,0 +1,204 @@
+# Copyright 2016 Yu Sheng Lin
+# This file is part of Cocotb.
+
+import cocotb
+import random
+from cocotb.decorators import coroutine
+from cocotb.triggers import RisingEdge, ReadOnly, Timer
+from cocotb.drivers import BusDriver, ValidatedBusDriver
+from cocotb.binary import BinaryValue
+from cocotb.result import ReturnValue, TestError
+from cocotb.bus import Bus
+from cocotb.monitors import BusMonitor
+from cocotb.handle import ModifiableObject
+from itertools import izip
+
+@cocotb.coroutine
+def TimeoutTimer(t):
+	yield Timer(t)
+	raise TestError("Simulation too long, abort.")
+
+class BusValue:
+	"""A collection of BinaryValue"""
+	def __init__(self, bus, signals, fill=None):
+		self.signal_and_shapes = [(signal,) + self.get_shape(getattr(bus, signal)) for signal in signals]
+		for name, shape, bitlen in self.signal_and_shapes:
+			filll = fill*bitlen if fill else None
+			signal = getattr(bus, name)
+			if len(shape) == 0:
+				binstr = filll if filll else signal.value.binstr
+				value = BinaryValue(bits=bitlen, bigEndian=False, value=binstr)
+			elif len(shape) == 1:
+				value = list()
+				for i in range(shape[0]):
+					binstr = filll if filll else signal[i].value.binstr
+					value.append(BinaryValue(bits=bitlen, bigEndian=False, value=binstr))
+			elif len(shape) == 2:
+				value = list()
+				for i in range(shape[0]):
+					valuei = list()
+					signali = signal[i]
+					for j in range(shape[1]):
+						binstr = filll if filll else signali[j].value.binstr
+						valuei.append(BinaryValue(bits=bitlen, bigEndian=False, value=binstr))
+					value.append(valuei)
+			setattr(self, name, value)
+
+	@staticmethod
+	def get_shape(signal):
+		shape = list()
+		while not isinstance(signal, ModifiableObject):
+			shape.append(len(signal))
+			signal = signal[0]
+		assert len(shape) < 3, "Sorry, 3D+ array is not supported"
+		return shape, len(signal)
+
+	@staticmethod
+	def convert_value(sig, shape):
+		if len(shape) == 0:
+			return sig.value
+		elif len(shape) == 1:
+			return [sig[i].value for i in range(shape[0])]
+		elif len(shape) == 2:
+			return [[sig[i][j].value for j in range(shape[1])] for i in range(shape[0])]
+
+	def __str__(self):
+		return str(self.value_tuple)
+
+	@property
+	def value_tuple(self):
+		return tuple(self.convert_value(getattr(self, name), shape) for name, shape, bitlen in self.signal_and_shapes)
+
+class HasBusValue:
+	def __init__(self, entity, data_name):
+		self.data_bus = Bus(entity, '', data_name)
+		self.data_name = data_name
+		self.X = self.create_data()
+		self.assign_bus(self.X)
+
+	def assign_bus(self, data):
+		for name, shape, bitlen in data.signal_and_shapes:
+			signal = getattr(self.data_bus, name)
+			value = getattr(data, name)
+			if len(shape) == 0:
+				signal <= value
+			elif len(shape) == 1:
+				for i in range(shape[0]):
+					signal[i] <= value[i]
+			elif len(shape) == 2:
+				for i in range(shape[0]):
+					signali = signal[i]
+					valuei = value[i]
+					for j in range(shape[1]):
+						signali[j] <= valuei[j]
+
+	def create_data(self):
+		return BusValue(self.data_bus, self.data_name, 'x')
+
+_rdyack_name  = ['rdy', 'ack']
+_val_name = ['dval']
+
+class RdyAckMaster(BusDriver, HasBusValue):
+	_signals = _rdyack_name
+	def __init__(self, entity, name, clock, data_name):
+		BusDriver.__init__(self, entity, name, clock)
+		HasBusValue.__init__(self, entity, data_name)
+		self.bus.rdy.setimmediatevalue(0)
+
+	@coroutine
+	def send(self, data, latency=0, sync=True):
+		"""Send a tranaction. TODO: this is not re-entryable."""
+		clk_edge = RisingEdge(self.clock)
+		if sync:
+			yield clk_edge
+		for i in range(latency):
+			yield clk_edge
+		self.bus.rdy <= 1
+		self.assign_bus(data)
+		yield self._wait_for_signal(self.bus.ack)
+		yield clk_edge
+		self.bus.rdy <= 0
+		self.assign_bus(self.X)
+
+class RdyAckSlave(BusDriver):
+	_signals = _rdyack_name
+	def __init__(self, entity, name, clock, randmax):
+		BusDriver.__init__(self, entity, name, clock)
+		self.bus.ack.setimmediatevalue(0)
+		self.randmax = randmax
+		self.coro = cocotb.fork(self.respond())
+
+	@cocotb.coroutine
+	def respond(self):
+		clk_edge = RisingEdge(self.clock)
+		while True:
+			yield clk_edge
+			if self.bus.rdy.value:
+				self.bus.ack <= 0
+				for i in range(random.randint(0, self.randmax)):
+					yield clk_edge
+				self.bus.ack <= 1
+				yield clk_edge
+				self.bus.ack <= 0
+
+class ValidMaster(BusDriver, HasBusValue):
+	_signals = _val_name
+	def __init__(self, entity, name, clock, data_name):
+		BusDriver.__init__(self, entity, name, clock)
+		HasBusValue.__init__(self, entity, data_name)
+		self.bus.dval.setimmediatevalue(0)
+
+	@coroutine
+	def send(self, data, latency=0, sync=True):
+		"""Send a tranaction. TODO: this is not re-entryable."""
+		clk_edge = RisingEdge(self.clock)
+		if sync:
+			yield clk_edge
+		for i in range(latency):
+			yield clk_edge
+		self.bus.dval <= 1
+		self.assign_bus(data)
+		yield clk_edge
+		self.bus.dval <= 0
+		self.assign_bus(self.X)
+
+class ControlledMonitor(BusMonitor, HasBusValue):
+	def __init__(self, entity, name, clock, data_name, collector, **kwargs):
+		BusMonitor.__init__(self, entity, name, clock, **kwargs)
+		HasBusValue.__init__(self, entity, data_name)
+		self.collector = collector
+
+	@cocotb.coroutine
+	def _monitor_recv(self):
+		clkedge = RisingEdge(self.clock)
+		rdonly = ReadOnly()
+		while True:
+			yield clkedge
+			yield rdonly
+			if self.bus_ok():
+				bus_value = BusValue(self.data_bus, self.data_name).value_tuple
+				if self.collector is None:
+					self._recv(bus_value)
+				else:
+					ret = self.collector(bus_value)
+					if not ret is None:
+						self._recv(ret)
+
+	def bus_ok(self):
+		return False
+
+class RdyAckMonitor(ControlledMonitor):
+	_signals = _rdyack_name
+	def __init__(self, entity, name, clock, data_name, collector=None, **kwargs):
+		ControlledMonitor.__init__(self, entity, name, clock, data_name, collector, **kwargs)
+
+	def bus_ok(self):
+		return self.bus.rdy.value and self.bus.ack.value
+
+class ValidMonitor(ControlledMonitor):
+	_signals = _val_name
+	def __init__(self, entity, name, clock, data_name, collector=None, **kwargs):
+		ControlledMonitor.__init__(self, entity, name, clock, data_name, collector, **kwargs)
+
+	def bus_ok(self):
+		return self.bus.dval.value

--- a/cocotb/drivers/RdyAck/collector.py
+++ b/cocotb/drivers/RdyAck/collector.py
@@ -1,0 +1,70 @@
+# Copyright 2016 Yu Sheng Lin
+# This file is part of Cocotb.
+
+import numpy as np
+from itertools import izip
+
+class CompareWrap(object):
+	def __init__(self, iterable, verbose=False):
+		self.iterable = iterable
+		self.verbose = verbose
+
+	def __eq__(self, rhs):
+		"""
+			Cocotb use __eq__ to check in expected_output then use __eq__ to check again
+			So currently we just return true since we don't use reorder buffer
+		"""
+		return True
+
+	def __ne__(self, rhs):
+		if len(rhs.iterable) != len(self.iterable):
+			return True
+		for l, r in izip(self.iterable, rhs.iterable):
+			if isinstance(l, np.ndarray) and isinstance(r, np.ndarray):
+				eq = np.array_equal(l, r)
+			else:
+				eq = l == r
+			if not eq:
+				if self.verbose or rhs.verbose:
+					print "Compare fail"
+					print l
+					print r
+				return True
+		return False
+
+class VectorCollector(object):
+	def __init__(self, shapes, n=0):
+		self.shapes = shapes
+		self.alloc(n)
+		self.n = n
+		self.i = 0
+
+	def __call__(self, sigs):
+		for sig_i, sig in enumerate(sigs):
+			self.v[sig_i][self.i] = sig
+		self.i += 1
+		if self.i == self.n:
+			self.i = 0
+			return CompareWrap([v[:self.n] for v in self.v])
+		return None
+
+	def update(self, n, force=False):
+		assert self.clean, "There are still {} data".format(self.i)
+		if n == self.n if force else n > self.n:
+			self.alloc(n)
+		self.n = n
+
+	def alloc(self, n):
+		if n == 0:
+			return
+		v = list()
+		for shape in self.shapes:
+			lshape = [n]
+			lshape.extend(shape)
+			v.append(np.empty(lshape, dtype='i4'))
+		self.v = v
+
+	@property
+	def clean(self):
+		return self.i == 0
+

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -32,6 +32,7 @@ export COCOTB
 
 EXAMPLES := adder/tests \
 	    endian_swapper/tests \
+	    mean_numpy/tests
 
 .PHONY: $(EXAMPLES)
 

--- a/examples/mean_numpy/hdl/mean_sv.sv
+++ b/examples/mean_numpy/hdl/mean_sv.sv
@@ -1,0 +1,34 @@
+// behaviour level
+
+module mean_sv(clk,i_dval,i_data,o_dval,o_data);
+
+parameter N = 5;
+parameter B = 10;
+localparam B_SUM = B+$clog2(N);
+
+input clk;
+input i_dval;
+input [B-1:0] i_data [N];
+output logic         o_dval;
+output logic [B-1:0] o_data;
+
+logic [B_SUM-1:0] summed;
+
+always @* begin
+	summed = 0;
+	for (int i = 0; i < N; i++) begin
+		summed += i_data[i];
+	end
+end
+
+always @(posedge clk) begin
+	o_data <= summed/N;
+	o_dval <= i_dval;
+end
+
+// initial begin
+// 	$fsdbDumpfile("mean_sv.fsdb");
+// 	$fsdbDumpvars(0, mean_sv, "+mda");
+// end
+
+endmodule

--- a/examples/mean_numpy/tests/Makefile
+++ b/examples/mean_numpy/tests/Makefile
@@ -1,0 +1,30 @@
+
+TOPLEVEL_LANG ?= verilog
+
+ifneq ($(TOPLEVEL_LANG),verilog)
+
+all:
+	@echo "Skipping example due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
+clean::
+
+else
+
+TOPLEVEL := mean_sv
+
+PWD=$(shell pwd)
+COCOTB=$(PWD)/../../..
+
+ifeq ($(OS),Msys)
+WPWD=$(shell sh -c 'pwd -W')
+else
+WPWD=$(shell pwd)
+endif
+
+VERILOG_SOURCES = $(WPWD)/../hdl/mean_sv.sv
+
+MODULE := test_mean
+
+include $(COCOTB)/makefiles/Makefile.inc
+include $(COCOTB)/makefiles/Makefile.sim
+
+endif

--- a/examples/mean_numpy/tests/test_mean.py
+++ b/examples/mean_numpy/tests/test_mean.py
@@ -1,0 +1,55 @@
+import cocotb
+from cocotb.triggers import Timer, RisingEdge, ReadOnly
+from cocotb.result import TestFailure
+from cocotb.scoreboard import Scoreboard
+from cocotb.drivers.RdyAck.RdyAck import ValidMaster, ValidMonitor
+from cocotb.drivers.RdyAck.collector import VectorCollector, CompareWrap
+import numpy as np
+
+clock_period = 100
+
+@cocotb.coroutine
+def clock_gen(signal, period=10000):
+    while True:
+        signal <= 0
+        yield Timer(period/2)
+        signal <= 1
+        yield Timer(period/2)
+
+@cocotb.test()
+def value_test(dut):
+    scb = Scoreboard(dut)
+    data_width = int(dut.B)
+    bus_width = int(dut.N)
+    n_test = 100
+    cocotb.fork(clock_gen(dut.clk, period=clock_period))
+
+    exp1 = list()
+    exp2 = list()
+    c1 = VectorCollector([[bus_width]], n_test)
+    c2 = VectorCollector([[]], n_test)
+    master = ValidMaster(dut, 'i', dut.clk, ['i_data'])
+    m1 = ValidMonitor(dut, 'i', dut.clk, ['i_data'], collector=c1)
+    m2 = ValidMonitor(dut, 'o', dut.clk, ['o_data'], collector=c2)
+    scb.add_interface(m1, exp1)
+    scb.add_interface(m2, exp2)
+
+    for i in range(10):
+        yield RisingEdge(dut.clk)
+
+    idat = np.random.randint(1<<data_width, size=(n_test,bus_width)).astype(np.int32)
+    odat = np.sum(idat, axis=1)/bus_width
+    exp1.append(CompareWrap((idat,), verbose=True))
+    # wrong answer
+    # exp2.append(CompareWrap((odat+1,), verbose=True))
+    exp2.append(CompareWrap((odat,), verbose=True))
+
+    ibus = master.create_data()
+    for n in range(n_test):
+        for i in range(bus_width):
+            ibus.i_data[i].integer = idat[n,i]
+        yield master.send(ibus, 3)
+
+    yield Timer(10)
+    assert c1.clean and c2.clean
+    raise scb.result


### PR DESCRIPTION
Cocotb is useful since it can co-simulate with existing Python libraries, and one of the most useful library is numpy. As a result, I write some classes for testing with numpy easily. Two simple interfaces, rdy/ack and valid, are provided along with the class, which are very common in module boundary such as camera stream. They are analogous to StreamBusMonitor interface and read/write/waitrequest in Avalon, respectively. 

I modify the _mean_ example to _mean\_numpy_. The input and output interfaces are still valid/data pairs, but with the collector class, the monitored signals are converted to numpy arrays automatically. Therefore, the numpy arrays are directly compared in the scoreboard, which is very convenient when developing multimedia applications.

In short, this pull request includes these classes:

* Drivers
  * RdyAck.RdyAck.RdyAckMaster
  * RdyAck.RdyAck.RdyAckSlave
  * RdyAck.RdyAck.ValidMaster
* Monitor
  * RdyAck.RdyAck.RdyAckMonitor
  * RdyAck.RdyAck.ValidMonitor
* Utilities
  * RdyAck.collector.VectorCollector
  * RdyAck.collector.CompareWrap

For more details, please refer to the test_mean.py in this pull request.