### PR TITLE
use built-in Clock() instead of separate clock_gen() function

### DIFF
--- a/documentation/source/endian_swapper.rst
+++ b/documentation/source/endian_swapper.rst
@@ -120,7 +120,7 @@ We want to run different variations of tests but they will all have a very simil
     @cocotb.coroutine
     def run_test(dut, data_in=None, config_coroutine=None, idle_inserter=None, backpressure_inserter=None):
         
-        cocotb.fork(clock_gen(dut.clk))
+        cocotb.fork(Clock(dut.clk, 5000).start())
         tb = EndianSwapperTB(dut)
         
         yield tb.reset()

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -112,20 +112,10 @@ class EndianSwapperTB(object):
 
 
 @cocotb.coroutine
-def clock_gen(signal):
-    while True:
-        signal <= 0
-        yield Timer(5000)
-        signal <= 1
-        yield Timer(5000)
-
-
-@cocotb.coroutine
 def run_test(dut, data_in=None, config_coroutine=None, idle_inserter=None,
              backpressure_inserter=None):
 
-    cocotb.fork(clock_gen(dut.clk))
-    yield RisingEdge(dut.clk)
+    cocotb.fork(Clock(dut.clk, 5000).start())
     tb = EndianSwapperTB(dut)
 
     yield tb.reset()


### PR DESCRIPTION
also makes it match the version on edaplayground.com