### PR TITLE
Multi layer triggers

### DIFF
--- a/makefiles/simulators/Makefile.ghdl
+++ b/makefiles/simulators/Makefile.ghdl
@@ -51,12 +51,13 @@ else
 endif
 
 RTL_LIBRARY ?= work
+EXTRA_ARGS=--std=08
 
 .PHONY: analyse
 
 # Compilation phase
 analyse: $(VHDL_SOURCES) $(SIM_BUILD)
-	cd $(SIM_BUILD) && $(CMD) -a --work=$(RTL_LIBRARY) $(VHDL_SOURCES) && $(CMD) -e --work=$(RTL_LIBRARY) $(TOPLEVEL)
+	cd $(SIM_BUILD) && $(CMD) -a $(EXTRA_ARGS) --work=$(RTL_LIBRARY) $(VHDL_SOURCES) && $(CMD) -e $(EXTRA_ARGS) --work=$(RTL_LIBRARY) $(TOPLEVEL)
 
 results.xml: analyse  $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
 	cd $(SIM_BUILD); \


### PR DESCRIPTION
Addresses the issue noted in issue #520.  There are problems with a trigger attempting to prime/unprime other triggers, which is required for triggers such as ClockCycles - specifically related to modifying the callback of an already primed trigger or being unable to set a different (specialized) callback because the trigger is already primed.  This patch addresses the issue by creating the concept of helper functions which are registered with the scheduler along with a list of triggers which should activate the helper function.  This is analogous to coroutines providing a list of triggers.  I refer to these helper-based triggers as multi-layer triggers because they rely upon other (sub) triggers.

The multi-layer triggers allow for more than just ClockCycles.  For example, it is possible to specify a Sequential trigger as 
yield Sequential(ClockCycles(clk, 5), RisingEdge(valid), FallingEdge(valid), ClockCyles(12))
which would trigger only after each of the sub triggers has occurred in turn.