### PR TITLE
multi-layer (hierarchical) trigger support

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -172,9 +172,9 @@ class Scheduler(object):
         if not self._terminate and self._writes:
 
             if self._mode == Scheduler._MODE_NORMAL:
-                if not self._readwrite.primed:
+                if not self._readwrite.primed_for(self.react):
                     self._readwrite.prime(self.react)
-            elif not self._next_timestep.primed:
+            elif not self._next_timestep.primed_for(self.react):
                 self._next_timestep.prime(self.react)
 
         elif self._terminate:
@@ -182,12 +182,12 @@ class Scheduler(object):
                 self.log.debug("Test terminating, scheduling Timer")
 
             for t in self._trigger2coros:
-                t.unprime()
+                t.unprime(self.react)
 
             for t in [self._readwrite, self._readonly, self._next_timestep,
                       self._timer1, self._timer0]:
-                if t.primed:
-                    t.unprime()
+                if t.primed_for(self.react):
+                    t.unprime(self.react)
 
             self._timer1.prime(self.begin_test)
             self._trigger2coros = collections.defaultdict(list)
@@ -211,7 +211,7 @@ class Scheduler(object):
 
         self._mode = Scheduler._MODE_NORMAL
         if trigger is not None:
-            trigger.unprime()
+            trigger.unprime(self.react)
 
         # Issue previous test result, if there is one
         if self._test_result is not None:
@@ -241,7 +241,6 @@ class Scheduler(object):
         # When a trigger fires it is unprimed internally
         if _debug:
             self.log.debug("Trigger fired: %s" % str(trigger))
-        # trigger.unprime()
 
         if self._mode == Scheduler._MODE_TERM:
             if _debug:
@@ -265,8 +264,6 @@ class Scheduler(object):
             while self._writes:
                 handle, value = self._writes.popitem()
                 handle.setimmediatevalue(value)
-
-            self._readwrite.unprime()
 
             if _profiling:
                 _profile.disable()
@@ -331,8 +328,8 @@ class Scheduler(object):
                 else:
                     # if pending is not trigger and pending.primed:
                     #     pending.unprime()
-                    if pending.primed:
-                        pending.unprime()
+                    if pending.primed_for(self.react):
+                        pending.unprime(self.react)
                     del self._trigger2coros[pending]
 
         for coro in scheduling:
@@ -346,8 +343,8 @@ class Scheduler(object):
                                (str(self._pending_triggers[0])))
             self.react(self._pending_triggers.pop(0), depth=depth + 1)
 
-        # We only advance for GPI triggers
-        if not depth and isinstance(trigger, GPITrigger):
+        # We only advance for GPI triggers (may be indirectly)
+        if not depth and trigger.needs_advance():
             self.advance()
 
             if _debug:
@@ -365,7 +362,7 @@ class Scheduler(object):
             if coro in self._trigger2coros[trigger]:
                 self._trigger2coros[trigger].remove(coro)
             if not self._trigger2coros[trigger]:
-                trigger.unprime()
+                trigger.unprime(self.react)
         del self._coro2triggers[coro]
 
         if coro._join in self._trigger2coros:
@@ -388,7 +385,7 @@ class Scheduler(object):
         for trigger in triggers:
 
             self._trigger2coros[trigger].append(coro)
-            if not trigger.primed:
+            if not trigger.primed_for(self.react):
                 try:
                     trigger.prime(self.react)
                 except Exception as e:

--- a/tests/designs/sample_module/sample_module.v
+++ b/tests/designs/sample_module/sample_module.v
@@ -54,11 +54,15 @@ module sample_module (
 
     input                                       stream_out_ready,
     output reg [7:0]                            stream_out_data_comb,
+    output reg                                  stream_out_valid,
     output reg [7:0]                            stream_out_data_registered,
 
     output                                      and_output
 
 );
+
+always @(posedge clk)
+    stream_out_valid <= stream_in_valid;
 
 always @(posedge clk)
     stream_out_data_registered <= stream_in_data;

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -56,6 +56,7 @@ entity sample_module is
         stream_out_data_comb            : out   std_ulogic_vector(7 downto 0);
         stream_out_data_registered      : out   std_ulogic_vector(7 downto 0);
         stream_out_data_wide            : out   std_ulogic_vector(63 downto 0);
+        stream_out_valid                : out   std_ulogic;
         stream_out_ready                : in    std_ulogic;
         stream_out_real                 : out   real;
         stream_out_int                  : out   integer;
@@ -102,6 +103,7 @@ begin
 
 process (clk) begin
     if rising_edge(clk) then
+        stream_out_valid           <= stream_in_valid;
         stream_out_data_registered <= stream_in_data;
     end if;
 end process;

--- a/tests/test_cases/issue_520/Makefile
+++ b/tests/test_cases/issue_520/Makefile
@@ -1,0 +1,31 @@
+###############################################################################
+# Copyright (c) 2015 Potential Ventures Ltd
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Potential Ventures Ltd,
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_520

--- a/tests/test_cases/issue_520/issue_520.py
+++ b/tests/test_cases/issue_520/issue_520.py
@@ -1,0 +1,117 @@
+import cocotb
+from cocotb.log import SimLog
+from cocotb.triggers import Timer, Edge, RisingEdge, FallingEdge, Join, ReadOnly
+from cocotb.triggers import ClockCycles, Sequential, RepeatNTriggers, Combine
+from cocotb.result import TestFailure, ReturnValue
+
+import sys
+
+@cocotb.coroutine
+def clock_gen(signal, per):
+    for c in range(2*100):
+        signal <= 0
+        yield Timer(per // 2)
+        signal <= 1
+        yield Timer(per // 2)
+
+class Testbench:
+    def __init__(self, dut):
+        self._dut = dut
+        cocotb.fork(clock_gen(dut.clk, 1000))
+        cocotb.fork(self.datagen(dut))
+
+    @cocotb.coroutine
+    def datagen(self, dut):
+        dut.stream_in_data <= 0
+        dut.stream_in_valid <= 0
+        dut.stream_in_func_en <= 1
+        dut.stream_out_ready <= 1
+        for c in range(2):
+            yield RisingEdge(dut.clk)
+        for d in range(128):
+            yield RisingEdge(dut.clk)
+            yield Timer(1)
+            dut.stream_in_data <= d
+            dut.stream_in_valid <= 1
+            print 'Data set to',d
+            yield RisingEdge(dut.clk)
+            yield Timer(1)
+            dut.stream_in_data <= 0
+            dut.stream_in_valid <= 0
+
+
+@cocotb.test()
+def issue_520_clockcycles(dut):
+    """ ClockCycles should work for both rising and falling edges """
+    tb = Testbench(dut)
+    yield ClockCycles(dut.clk, 10, rising=True)
+    #print 'Back from yield'
+    yield ClockCycles(dut.clk, 10, rising=False)
+    #print 'Back from yield again'
+
+@cocotb.test()
+def issue_520_sequential(dut):
+    """ Use a sequential trigger composed of 3 sub-triggers, one of which is also a layered trigger """
+    tb = Testbench(dut)
+    yield Sequential(RisingEdge(dut.stream_out_valid),
+                     ClockCycles(dut.clk, 8), ReadOnly())
+    #yield ReadOnly()
+    #print 'Back from yield', dut.stream_out_valid.value, int(dut.stream_out_data_registered)
+    if not dut.stream_out_valid.value:
+        raise TestFailure("valid should be low on even clock cycles after first valid edge")
+    if int(dut.stream_out_data_registered) != 8 // 2:
+        raise TestFailure("Data value mismatch")
+
+    yield RisingEdge(dut.clk)
+    yield ReadOnly()
+    if dut.stream_out_valid.value:
+        raise TestFailure("valid should be high on odd clock cycles after first valid edge")
+    if int(dut.stream_out_data_registered) != 0:
+        raise TestFailure("Data value mismatch")
+
+
+@cocotb.test()
+def issue_520_repeatN(dut):
+    """ Demonstrate RepeatNTriggers """
+    tb = Testbench(dut)
+    yield RisingEdge(dut.stream_out_valid)
+    yield RepeatNTriggers(ClockCycles(dut.clk, 7), 4)
+    yield ReadOnly()
+
+    if not dut.stream_out_valid.value:
+        raise TestFailure("valid should be low on odd clock cycles after first valid")
+    print 'value:', int(dut.stream_out_data_registered)
+    if int(dut.stream_out_data_registered) != 7*4 // 2:
+        raise TestFailure("Data value mismatch")
+
+    yield RisingEdge(dut.clk)
+    yield ReadOnly()
+    if dut.stream_out_valid.value:
+        raise TestFailure("valid should be high on even clock cycles after first valid")
+    if int(dut.stream_out_data_registered) != 0:
+        raise TestFailure("Data value mismatch")
+
+
+@cocotb.test()
+def issue_520_Combine(dut):
+    """ Demonstrate RepeatNTriggers """
+    tb = Testbench(dut)
+    yield RisingEdge(dut.stream_out_valid)
+    # Test Combine.  The ClockCycles will be the last element to finish, result same as RepeatN above
+    yield Combine(RisingEdge(dut.stream_out_valid), ClockCycles(dut.clk, 7*4), FallingEdge(dut.clk))
+    yield ReadOnly()
+
+    if not dut.stream_out_valid.value:
+        raise TestFailure("valid should be low on odd clock cycles after first valid")
+    print 'value:', int(dut.stream_out_data_registered)
+    if int(dut.stream_out_data_registered) != 7*4 // 2:
+        raise TestFailure("Data value mismatch")
+
+    yield RisingEdge(dut.clk)
+    yield ReadOnly()
+    if dut.stream_out_valid.value:
+        raise TestFailure("valid should be high on even clock cycles after first valid")
+    if int(dut.stream_out_data_registered) != 0:
+        raise TestFailure("Data value mismatch")
+
+

--- a/tests/test_cases/issue_520/issue_520.py
+++ b/tests/test_cases/issue_520/issue_520.py
@@ -24,7 +24,6 @@ class Testbench:
     def datagen(self, dut):
         dut.stream_in_data <= 0
         dut.stream_in_valid <= 0
-        dut.stream_in_func_en <= 1
         dut.stream_out_ready <= 1
         for c in range(2):
             yield RisingEdge(dut.clk)


### PR DESCRIPTION
Second attempt at fixing ClockCycles by adding support for layered triggers.
This is cleaner than the first attempt I made.  A simple testbench is included too.

Key changes proposed:
- Triggers now have private list of callbacks, allowing multiple externals to use the trigger (ie, the scheduler plus any layered triggers).
- One user of a trigger can unprime the trigger without impacting another user of the trigger.  This is accomplished by passing the callback with the unprime call.
- A layered trigger may or may not require advancing the simulator, depending upon whether any sub-triggers are GPITriggers.  The scheduler now calls trigger.needs_advance() to determine if advancing is required. (GPITriggers always return True.  Others return False unless dependent upon GPITriggers.)  This was the primary flaw in the first attempt made - not advancing after a layered trigger.
- The callback mechanism currently passes back the trigger that fired.  Since the callback is a member of said trigger, it should no longer be necessary to have the trigger passed up from the lower levels (simulator or C code?).  I made no attempt to alter this, though.  An assert is present to verify that the passed up trigger is in fact self.
- The trigger which fires now self-clears before calling the callbacks.  This behavior is consistent with comments that were in the scheduler (now removed).
- Minor tweak made to sample VHDL code to provide an output valid signal to fire triggers against.