### PR TITLE
Add stderr flush to see Python traceback

### DIFF
--- a/lib/embed/gpi_embed.c
+++ b/lib/embed/gpi_embed.c
@@ -62,9 +62,7 @@ static PyObject *pEventFn = NULL;
  */
 void print_traceback(void) {
   PyErr_Print();
-#if defined(_WIN32)
   PyRun_SimpleString("import sys; sys.stderr.flush()");
-#endif
 }
 
 /**


### PR DESCRIPTION
On Windows, the traceback is not shown because
the stderr is not flushed which makes debugging hard.