### PR TITLE
AXI Lite Demo 32-bit Address

### DIFF
--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -42,7 +42,8 @@ def write_address_0(dut):
     yield Timer(CLK_PERIOD * 10)
     dut.rst <= 0
 
-    ADDRESS = 0x00
+    #Shift the adress up by 2 in order to make the addresses 32-bit aligned
+    ADDRESS = 0x00 << 2
     DATA = 0xAB
 
     yield axim.write(ADDRESS, DATA)
@@ -79,7 +80,8 @@ def read_address_1(dut):
     yield Timer(CLK_PERIOD * 10)
     dut.rst <= 0
 
-    ADDRESS = 0x01
+    #Shift the adress up by 2 in order to make the addresses 32-bit aligned
+    ADDRESS = 0x01 << 2
     DATA = 0xCD
 
     dut.dut.r_temp_1 <= DATA
@@ -118,7 +120,8 @@ def write_and_read(dut):
     yield Timer(CLK_PERIOD * 10)
     dut.rst <= 0
 
-    ADDRESS = 0x00
+    #Shift the adress up by 2 in order to make the addresses 32-bit aligned
+    ADDRESS = 0x00 << 2
     DATA = 0xAB
 
     #Write to the register
@@ -158,7 +161,8 @@ def write_fail(dut):
     yield Timer(CLK_PERIOD * 10)
     dut.rst <= 0
 
-    ADDRESS = 0x02
+    #Shift the adress up by 2 in order to make the addresses 32-bit aligned
+    ADDRESS = 0x02 << 2
     DATA = 0xAB
 
     try:
@@ -192,11 +196,12 @@ def read_fail(dut):
     yield Timer(CLK_PERIOD * 10)
     dut.rst <= 0
 
-    ADDRESS = 0x02
+    #Shift the adress up by 2 in order to make the addresses 32-bit aligned
+    ADDRESS = 0x02 << 2
     DATA = 0xAB
 
     try:
-        yield axim.read(ADDRESS, DATA)
+        yield axim.read(ADDRESS)
         yield Timer(CLK_PERIOD * 10)
     except AXIProtocolError as e:
         print "Exception: %s" % str(e)


### PR DESCRIPTION
Small change to the AXI Lite Demo.

I found out when creating an IP core for Xilinx's Vivado Block Diagram that the core worked well until I tried to access an address > 0.

I mistakenly thought that the addresses presented to the core would by 32-bit aligned
0x01 would equal 32-bit address 1

but instead should have been
0x01 << 2 or 0x04 equals 32-bit address 1

I've changed the 'axi_lite_demo.v' and the test bench 'test_axi_lite_slave.py' to reflect this.

With these changes I've created multiple IP cores that work with Xilinx Vivado block diagram.