### PR TITLE
Add labels to all str.format calls to fix Python 2.6 build

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -311,11 +311,11 @@ class HierarchyArrayObject(RegionObject):
         # VHPI(ALDEC):        _name__X where X is the index
         # VPI:                _name[X] where X is the index
         import re
-        result = re.match("{}__(?P<index>\d+)$".format(self._name), name)
+        result = re.match("{0}__(?P<index>\d+)$".format(self._name), name)
         if not result:
-            result = re.match("{}\((?P<index>\d+)\)$".format(self._name), name)
+            result = re.match("{0}\((?P<index>\d+)\)$".format(self._name), name)
         if not result:
-            result = re.match("{}\[(?P<index>\d+)\]$".format(self._name), name)
+            result = re.match("{0}\[(?P<index>\d+)\]$".format(self._name), name)
 
         if result:
             return int(result.group("index"))

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -348,11 +348,11 @@ class RegressionManager(object):
         summary = ""
 
         summary += "*************************************************************************************\n"
-        summary += "**                                 ERRORS : {:<39}**\n".format(self.failures)
+        summary += "**                                 ERRORS : {0:<39}**\n".format(self.failures)
         summary += "*************************************************************************************\n"
-        summary += "**                               SIM TIME : {:<39}**\n".format('{:.2f} NS'.format(sim_time_ns))
-        summary += "**                              REAL TIME : {:<39}**\n".format('{:.2f} S'.format(real_time))
-        summary += "**                        SIM / REAL TIME : {:<39}**\n".format('{:.2f} NS/S'.format(ratio_time))
+        summary += "**                               SIM TIME : {0:<39}**\n".format('{0:.2f} NS'.format(sim_time_ns))
+        summary += "**                              REAL TIME : {0:<39}**\n".format('{0:.2f} S'.format(real_time))
+        summary += "**                        SIM / REAL TIME : {0:<39}**\n".format('{0:.2f} NS/S'.format(ratio_time))
         summary += "*************************************************************************************\n"
 
         self.log.info(summary)

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -376,7 +376,7 @@ class Scheduler(object):
 
     def save_write(self, handle, value):
         if self._mode == Scheduler._MODE_READONLY:
-            raise Exception("Write to object {} was scheduled during a read-only sync phase.".format(handle._name))
+            raise Exception("Write to object {0} was scheduled during a read-only sync phase.".format(handle._name))
         self._writes[handle] = value
 
     def _coroutine_yielded(self, coro, triggers):

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -127,7 +127,7 @@ def _get_log_time_scale(units):
 
     units_lwr = units.lower()
     if units_lwr not in scale:
-        raise ValueError("Invalid unit ({}) provided".format(units))
+        raise ValueError("Invalid unit ({0}) provided".format(units))
     else:
         return scale[units_lwr]
 


### PR DESCRIPTION
In Python 2.6 and below, a label (i.e. 0, 1, etc.) is necessary in calls to str.format(). That is, {} is not valid in 2.6.x; instead, it needs to be {0}. There were a handful of places in the codebase using format() without such labels. This commit adds the relevant labels.

The cocotb documentation claims Python 2.6+ is still supported. Without this change, when ran against Python 2.6, a "Called callback returned null" message will be generated at the end of simulation, when cocotb tries to print out the number of failed tests and the consumed simulation time.

In particular, RHEL/SL/CentOS 6 is sadly still using Python 2.6, so this change makes cocotb work with Python out-of-the-box on those distros.

I've been working with cocotb on a Scientific Linux 6 machine and ran into this a while ago, but I assumed it was an architecture problem with our (cadence) simulator-- especially when the 32-bit Python I built worked out of the box.-- except I chose to build 32-bit 2.7 instead of 2.6, which masked the issue. It would be great if this fix could be merged upstream.