### PR TITLE
Print python exception in simulatormodule instead of just aborting

### DIFF
--- a/lib/simulator/simulatormodule.c
+++ b/lib/simulator/simulatormodule.c
@@ -110,7 +110,8 @@ int handle_gpi_callback(void *user_data)
     if (pValue == NULL)
     {
         fprintf(stderr, "ERROR: called callback function returned NULL\n");
-        fprintf(stderr, "Failed to execute callback\n");
+        fprintf(stderr, "Failed to execute callback due to internal python exception:\n");
+        PyErr_Print();
         gpi_sim_end();
         return 0;
     }


### PR DESCRIPTION
If a Python exception occurs in lib/simulator/simulatormodule.c, the message "called callback returned NULL" gets printed out and the simulator just exits. This makes it very hard to actually debug these issues.

This commit adds a call to PyErr_Print(), which prints a standard Python traceback to standard error.

I ran into trouble as a result of this debugging #554 without modifying the C source code; this commit is a direct result of my attempt to solve that issue.