### PR TITLE
Issue #536: Fix memory leak in Scheduler._trigger2coros

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -366,6 +366,7 @@ class Scheduler(object):
                 self._trigger2coros[trigger].remove(coro)
             if not self._trigger2coros[trigger]:
                 trigger.unprime()
+                del self._trigger2coros[trigger]
         del self._coro2triggers[coro]
 
         if coro._join in self._trigger2coros:


### PR DESCRIPTION
After coroutine was unscheduled remove from self._trigger2coros unprimed triggers.
I've checked patch resolves #536 