### PR TITLE
Avalon.py: FallingEdge trigger was not declared

### DIFF
--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -35,7 +35,8 @@ import random
 
 import cocotb
 from cocotb.decorators import coroutine
-from cocotb.triggers import RisingEdge, ReadOnly, NextTimeStep, Event
+from cocotb.triggers import RisingEdge, FallingEdge
+from cocotb.triggers import ReadOnly, NextTimeStep, Event
 from cocotb.drivers import BusDriver, ValidatedBusDriver
 from cocotb.utils import hexdump
 from cocotb.binary import BinaryValue


### PR DESCRIPTION
FallingEdge trigger is required by function[ _writing_byte_value()](https://github.com/potentialventures/cocotb/blob/master/cocotb/drivers/avalon.py#L351)