### PR TITLE
Prevent _trigger2coros change during iteration in Python3.

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -542,7 +542,7 @@ class Scheduler(object):
 
         Unprime all pending triggers and kill off any coroutines
         """
-        for trigger, waiting in self._trigger2coros.items():
+        for trigger, waiting in dict(self._trigger2coros).items():
             for coro in waiting:
                 if _debug:
                     self.log.debug("Killing %s" % str(coro))


### PR DESCRIPTION
We must iterate over copy of _trigger2coros in Scheduler.cleanup(),
because in called Scheduler.unschedule() dictionary changes.
In Python3 dict.items() return view of the dictionary instead of copy in Python2
This resolve #561 