### PR TITLE
Python 2.6: use sys.version_info[0], not version_info.major

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -234,7 +234,7 @@ class coroutine(object):
         except Exception as e:
             traceback.print_exc()
             result = TestError(str(e))
-            if sys.version_info.major >= 3:
+            if sys.version_info[0] >= 3:
                 buff = StringIO()
                 traceback.print_exc(file=buff)
             else:

--- a/makefiles/Makefile.pylib.Darwin
+++ b/makefiles/Makefile.pylib.Darwin
@@ -40,8 +40,8 @@ NATIVE_ARCH=$(shell uname -m)
 ARCH?=$(NATIVE_ARCH)
 
 # We might work with other Python versions
-PYTHON_MAJOR_VERSION?=$(shell python -c "from __future__ import print_function; import sys; print(sys.version_info.major)")
-PYTHON_MINOR_VERSION?=$(shell python -c "from __future__ import print_function; import sys; print(sys.version_info.minor)")
+PYTHON_MAJOR_VERSION?=$(shell python -c "from __future__ import print_function; import sys; print(sys.version_info[0])")
+PYTHON_MINOR_VERSION?=$(shell python -c "from __future__ import print_function; import sys; print(sys.version_info[1])")
 PYTHON_VERSION?=$(shell python -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_version())')
 
 PYTHON_LIBDIR:=$(shell python -c 'from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')

--- a/makefiles/Makefile.pylib.Linux
+++ b/makefiles/Makefile.pylib.Linux
@@ -40,8 +40,8 @@ NATIVE_ARCH=$(shell uname -m)
 ARCH?=$(NATIVE_ARCH)
 
 # We might work with other Python versions
-PYTHON_MAJOR_VERSION?=$(shell $(PYTHON_BIN) -c "from __future__ import print_function; import sys; print(sys.version_info.major)")
-PYTHON_MINOR_VERSION?=$(shell $(PYTHON_BIN) -c "from __future__ import print_function; import sys; print(sys.version_info.minor)")
+PYTHON_MAJOR_VERSION?=$(shell $(PYTHON_BIN) -c "from __future__ import print_function; import sys; print(sys.version_info[0])")
+PYTHON_MINOR_VERSION?=$(shell $(PYTHON_BIN) -c "from __future__ import print_function; import sys; print(sys.version_info[1])")
 PYTHON_VERSION?=$(shell $(PYTHON_BIN) -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_version())')
 
 PYTHON_LIBDIR:=$(shell $(PYTHON_BIN) -c 'from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')


### PR DESCRIPTION
This is another Python 2.6 compatibility change, similar to #554.

The sys.version_info fields having names was introduced in Python 2.7. Thus attempting to access them by .major, .minor, etc. will cause an exception in 2.6.

The most visible place where this happens is in the raise_error function (see the snippet below) but they also get used in the pylib makefiles.

```
  0.00ns ERROR    ..3L1_basic_functionality.0x3cd4d10           result.py:51   in raise_error                     Send raised exception: 'tuple' object has no attribute 'major'
                                                                                                                   File "/tape/mitch_sim/bjr/cocotb/cocotb-1.0/cocotb/decorators.py", line 197, in send
                                                                                                                     return self._coro.send(value)
                                                                                                                   File "/home/u2/bjr/svn/hccstar/trunk/verif/unit/lcb_cocotb/lcb_cocotb.py", line 534, in test_R3L1_basic_functionality
                                                                                                                     yield setup_all_clocks(dut)
                                                                                                                   File "/tape/mitch_sim/bjr/cocotb/cocotb-1.0/cocotb/decorators.py", line 237, in __call__
                                                                                                                     if sys.version_info.major >= 3:
```