### PR TITLE
Add coverage generation to Makefile.ius

### DIFF
--- a/makefiles/simulators/Makefile.ius
+++ b/makefiles/simulators/Makefile.ius
@@ -70,7 +70,7 @@ ifeq ($(TOPLEVEL_LANG),verilog)
     ROOT_LEVEL = $(TOPLEVEL)
 ifneq ($(VHDL_SOURCES),)
     HDL_SOURCES += $(VHDL_SOURCES)
-    GPI_EXTRA = vhpi 
+    GPI_EXTRA = vhpi
 endif
 else ifeq ($(TOPLEVEL_LANG),vhdl)
     GPI_EXTRA = vhpi
@@ -83,6 +83,12 @@ ifneq ($(VERILOG_SOURCES),)
 endif
 else
    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+endif
+
+# Tell IUS to generate coverage data if COVERAGE=1 set.
+# This is in analogy to the functionality in Makefile.aldec.
+ifeq ($(COVERAGE),1)
+    EXTRA_ARGS += -coverage ALL -covoverwrite
 endif
 
 GPI_LIB = $(COCOTB_VPI_LIB) $(COCOTB_VHPI_LIB)


### PR DESCRIPTION
This adds the following arguments to EXTRA_ARGS in Makefile.ius when ```COVERAGE=1``` is set.

* ```-coverage ALL```: generate all types of code coverage data.
* ```-covoverwrite```: overwrite coverage data from previous runs.

Currently it looks like setting COVERAGE=1 in Makefile.aldec will generate coverage data. This commit adds similar functionality for Cadence users.