### PR TITLE
Fixed crash on test cleanup: coroutines kill dict changed during iter…

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -542,7 +542,10 @@ class Scheduler(object):
 
         Unprime all pending triggers and kill off any coroutines
         """
-        for trigger, waiting in self._trigger2coros.items():
+        # Iterate over a copy of the coroutines dict, as the collection may
+        # change during iteration
+        kill_coros = self._trigger2coros.copy()
+        for trigger, waiting in kill_coros.items():
             for coro in waiting:
                 if _debug:
                     self.log.debug("Killing %s" % str(coro))


### PR DESCRIPTION
Hello there - I am actually rather new to cocotb, but have created several very similar environments in my past positions, one using C++ and another Java. I'm quite happy to see Python has been used, and am ready to get moving with the environment.

I had no problems running the example tests in `examples/endian_swapper/tests`, targeting VHDL and GHDL:

`TOPLEVEL_LANG=vhdl SIM=ghdl make`

However, I would consistently get:

`RuntimeError: dictionary changed size during iteration`

Right as the first test raised a success. This resulted in NULL being returned by the call to `PyObject_Call()` on line 105 of simulatormodule.c - I tracked down the problem by printing the exception trace in this location, and finding the location of my change. It would appear that, as a result of being killed, coroutines may remove themselves from the scheduler; altering the very collection which is iterated over to kill coroutines.

My patch is simple - to simply make a deep copy of the collection before iterating, leaving the original available for modification as the result of side-effects. I usually have to do something exactly like this during implementation of Observer patterns: clone the collection of Observers, and then iterate over the clone... so that Observers can respond by unsubscribing from the original collection.