### PR TITLE
Fix the endian_swapper test to get the wavedrom test running again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install:
   - sudo apt-get install -qq iverilog-daily
   - pip install coverage
   - pip install xunitparser
-  - if [ $( python -c "from __future__ import print_function; import sys; print(sys.version_info.major)") -eq 3 ]; then ln -s /opt/python/3.4.4/bin/python3.4-config /home/travis/virtualenv/python3.4/bin/python3-config; fi
-  - if [ $( python -c "from __future__ import print_function; import sys; print(sys.version_info.major)") -eq 3 ]; then ln -s /opt/python/3.4.4/bin/python3.4-config /home/travis/virtualenv/python3.4/bin/python-config; fi
+  - if [ $( python -c "from __future__ import print_function; import sys; print(sys.version_info.major)") -eq 3 ]; then ln -sf /opt/python/3.4.4/bin/python3.4-config /home/travis/virtualenv/python3.4/bin/python3-config; fi
+  - if [ $( python -c "from __future__ import print_function; import sys; print(sys.version_info.major)") -eq 3 ]; then ln -sf /opt/python/3.4.4/bin/python3.4-config /home/travis/virtualenv/python3.4/bin/python-config; fi
   - if [ $( python -c "from __future__ import print_function; import sys; print(sys.version_info.major)") -eq 3 ]; then export LD_LIBRARY_PATH=/opt/python/3.4.4/lib:$LD_LIBRARY_PATH; fi
   - export PYTHONPATH=$PYTHONPATH:$(python -c "from __future__ import print_function; from distutils.sysconfig import get_python_lib; print(get_python_lib())") 
 script:

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ clean:
 
 do_tests: 
 	$(MAKE) -k -C tests
+	$(MAKE) -k -C examples
 
 # For jenkins we use the exit code to detect compile errors or catestrphic
 # failures and the xml to track test results

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -182,7 +182,7 @@ def wavedrom_test(dut):
     """
     Generate a JSON wavedrom diagram of a trace
     """
-    cocotb.fork(clock_gen(dut.clk))
+    cocotb.fork(Clock(dut.clk,5000).start())
     yield RisingEdge(dut.clk)
     tb = EndianSwapperTB(dut)
     yield tb.reset()


### PR DESCRIPTION
The endian_swapper test fails due to what looks like oversight in the wavedrom test. This quick update fixes that. 