### PR TITLE
Fix for issue #583 : cleanup axi_lite_slave example to work in python 3 and 2

### DIFF
--- a/cocotb/bus.py
+++ b/cocotb/bus.py
@@ -85,7 +85,7 @@ class Bus(object):
         self._name = name
         self._signals = {}
 
-        for attr_name, sig_name in _build_sig_attr_dict(signals).iteritems():
+        for attr_name, sig_name in _build_sig_attr_dict(signals).items():
             if name:
                 signame = name + bus_separator + sig_name
             else:
@@ -98,7 +98,7 @@ class Bus(object):
             self._signals[attr_name] = getattr(self, attr_name)
 
         # Also support a set of optional signals that don't have to be present
-        for attr_name, sig_name in _build_sig_attr_dict(optional_signals).iteritems():
+        for attr_name, sig_name in _build_sig_attr_dict(optional_signals).items():
             if name:
                 signame = name + bus_separator + sig_name
             else:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -32,6 +32,7 @@ export COCOTB
 
 EXAMPLES := adder/tests \
 	    endian_swapper/tests \
+            axi_lite_slave/tests \
 
 .PHONY: $(EXAMPLES)
 

--- a/examples/axi_lite_slave/hdl/axi_lite_slave.v
+++ b/examples/axi_lite_slave/hdl/axi_lite_slave.v
@@ -97,7 +97,7 @@ localparam      READ_WAIT_FOR_USER  = 4'h4;
 localparam      SEND_READ_DATA      = 4'h5;
 
 //registes/wires
-reg   [3:0]                           state;
+reg   [3:0]                           state = IDLE;
 
 //submodules
 //asynchronous logic

--- a/examples/axi_lite_slave/hdl/tb_axi_lite_slave.v
+++ b/examples/axi_lite_slave/hdl/tb_axi_lite_slave.v
@@ -44,7 +44,7 @@ output      [DATA_WIDTH - 1: 0]     AXIML_RDATA
 //Registers
 
 reg               r_rst;
-reg               test_id         = 0;
+reg [7:0] 	  test_id         = 0;
 
 //Workaround for weird icarus simulator bug
 always @ (*)      r_rst           = rst;

--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -52,9 +52,9 @@ def write_address_0(dut):
     if value != DATA:
         #Fail
         raise TestFailure("Register at address 0x%08X should have been: \
-                           0x%08X but was 0x%08X" % (ADDRESS, DATA, value))
+                           0x%08X but was 0x%08X" % (ADDRESS, DATA, int(value)))
 
-    dut.log.info("Write 0x%08X to addres 0x%08X" % (value, ADDRESS))
+    dut.log.info("Write 0x%08X to addres 0x%08X" % (int(value), ADDRESS))
 
 
 #Read back a value at address 0x01
@@ -73,12 +73,12 @@ def read_address_1(dut):
     """
     #Reset
     dut.rst <=  1
-    dut.test_id <= 0
+    dut.test_id <= 1
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
     yield Timer(CLK_PERIOD * 10)
     dut.rst <= 0
-
+    yield Timer(CLK_PERIOD)
     ADDRESS = 0x01
     DATA = 0xCD
 
@@ -91,9 +91,9 @@ def read_address_1(dut):
     if value != DATA:
         #Fail
         raise TestFailure("Register at address 0x%08X should have been: \
-                           0x%08X but was 0x%08X" % (ADDRESS, DATA, value))
+                           0x%08X but was 0x%08X" % (ADDRESS, DATA, int(value)))
 
-    dut.log.info("Read: 0x%08X From Address: 0x%08X" % (value, ADDRESS))
+    dut._log.info("Read: 0x%08X From Address: 0x%08X" % (int(value), ADDRESS))
 
 
 
@@ -133,9 +133,9 @@ def write_and_read(dut):
     if value != DATA:
         #Fail
         raise TestFailure("Register at address 0x%08X should have been: \
-                           0x%08X but was 0x%08X" % (ADDRESS, DATA, value))
+                           0x%08X but was 0x%08X" % (ADDRESS, DATA, int(value)))
 
-    dut.log.info("Write 0x%08X to addres 0x%08X" % (value, ADDRESS))
+    dut._log.info("Write 0x%08X to addres 0x%08X" % (int(value), ADDRESS))
 
 @cocotb.test(skip = False, expect_error=True)
 def write_fail(dut):
@@ -165,8 +165,8 @@ def write_fail(dut):
         yield axim.write(ADDRESS, DATA)
         yield Timer(CLK_PERIOD * 10)
     except AXIProtocolError as e:
-        print "Exception: %s" % str(e)
-        dut.log.info("Bus Successfully Raised an Error")
+        print ("Exception: %s" % str(e))
+        dut._log.info("Bus Successfully Raised an Error")
         raise TestSuccess()
     raise TestFailure("AXI Bus Should have raised an ERROR when writing to \
                         the wrong bus")
@@ -199,8 +199,8 @@ def read_fail(dut):
         yield axim.read(ADDRESS, DATA)
         yield Timer(CLK_PERIOD * 10)
     except AXIProtocolError as e:
-        print "Exception: %s" % str(e)
-        dut.log.info("Bus Successfully Raised an Error")
+        print ("Exception: %s" % str(e))
+        dut._log.info("Bus Successfully Raised an Error")
         raise TestSuccess()
     raise TestFailure("AXI Bus Should have raised an ERROR when writing to \
                         the wrong bus")


### PR DESCRIPTION
with travis not currently working, it's a little harder to make sure I didn't break anything else, but with only 1 change not in the examples directory (that makes python 2 and 3 work, though less efficiently in 2) I think it should be safe. 