### PR TITLE
Fix for random crashes under Ubuntu 16.04 LTS (Issue #586)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,10 @@
-env:
-  global:
-   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created via the "travis encrypt" command using the project repo's public key
-   - secure: "YTKZKkNH8t11bZCtR4nMjszifW+QlIAluDAthYq8I4EpuRSKQ1ntVi9MnDs6EQu8CD9LfFOeQ0wymRU71FOf22n54sCVQgbo8OcwHXa/3PUeWi9A/i+BqRZ7iCdeGFJH8rQaCWov6mCyVjjdie52kwWv3jy1ZaTeuUTX54EKFII="
-language: python
-python:
-  - "2.7"
-  - "3.4"
-before_install:
-  # workaround for travis-ci/travis-ci/#5326
-  - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
-  - sudo add-apt-repository -y ppa:team-electronics/ppa
-  - sudo apt-get update -qq
-install:
-  - sudo apt-get install -qq iverilog-daily
-  - pip install coverage
-  - pip install xunitparser
-  - if [ $( python -c "from __future__ import print_function; import sys; print(sys.version_info.major)") -eq 3 ]; then ln -sf /opt/python/3.4.4/bin/python3.4-config /home/travis/virtualenv/python3.4/bin/python3-config; fi
-  - if [ $( python -c "from __future__ import print_function; import sys; print(sys.version_info.major)") -eq 3 ]; then ln -sf /opt/python/3.4.4/bin/python3.4-config /home/travis/virtualenv/python3.4/bin/python-config; fi
-  - if [ $( python -c "from __future__ import print_function; import sys; print(sys.version_info.major)") -eq 3 ]; then export LD_LIBRARY_PATH=/opt/python/3.4.4/lib:$LD_LIBRARY_PATH; fi
-  - export PYTHONPATH=$PYTHONPATH:$(python -c "from __future__ import print_function; from distutils.sysconfig import get_python_lib; print(get_python_lib())") 
+# See Dockerfile for the full build instructions
+sudo: required
+language: cpp
+
+services:
+  - docker
+
 script:
-  - make test
-addons:
-  coverity_scan:
-    project:
-      name: "potentialventures/cocotb"
-      description: "Python Co-simulation library for RTL verification"
-    notification_email: github@potentialventures.com
-    build_command:   "make"
-    branch_pattern: coverity_scan
+  - docker build .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM librecores/ci-osstools:2018.1-rc1
+
+# make sources available in docker image
+RUN mkdir -p /src
+ADD . /src
+WORKDIR /src
+
+RUN apt-get update; apt-get install -y virtualenv python3-venv python3-dev
+
+# Build and test using Python 2
+RUN mkdir /build-py2; cp -r /src /build-py2
+ENV COCOTB=/build-py2/src
+RUN bash -lc 'virtualenv /build-py2/venv; source /build-py2/venv/bin/activate; pip install coverage xunitparser; make -C /build-py2/src test'
+
+# Build and test using Python 3
+RUN mkdir /build-py3; cp -r /src /build-py3
+ENV COCOTB=/build-py3/src
+RUN bash -lce 'python3 -m venv /build-py3/venv; source /build-py3/venv/bin/activate; pip install coverage xunitparser; make -C /build-py3/src test'
+

--- a/bin/combine_results.py
+++ b/bin/combine_results.py
@@ -51,14 +51,14 @@ def main():
     result = ET.Element("testsuites", name=args.testsuites_name);
     
     for fname in find_all("results.xml", args.directory):
-        if args.debug : print "Reading file %s" % fname
+        if args.debug : print("Reading file %s" % fname)
         tree = ET.parse(fname)
         for ts in tree.getiterator("testsuite"):
-            if args.debug : print ("Ts name : %s, package : %s" % ( ts.get('name'), ts.get('package')))
+            if args.debug : print("Ts name : %s, package : %s" % ( ts.get('name'), ts.get('package')))
             use_element = None
             for existing in result:
                 if ((existing.get('name') == ts.get('name') and (existing.get('package') == ts.get('package')))):
-                    if args.debug : print "Already found"
+                    if args.debug : print("Already found")
                     use_element=existing
                     break
             if use_element is None:
@@ -73,7 +73,7 @@ def main():
         for testcase in testsuite.iter('testcase'):
             for failure in testcase.iter('failure'):
                 if args.set_rc: rc=1
-                print "Failure in testsuite: '%s' testcase: '%s' with parameters '%s'" % (testsuite.get('name'), testcase.get('name'), testsuite.get('package'))
+                print("Failure in testsuite: '%s' testcase: '%s' with parameters '%s'" % (testsuite.get('name'), testcase.get('name'), testsuite.get('package')))
             
     
     ET.ElementTree(result).write(args.output_file, encoding="UTF-8")

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -513,11 +513,11 @@ class BinaryValue(object):
     def __setitem__(self, key, val):
         ''' BinaryValue uses verilog/vhdl style slices as opposed to python
         style'''
-        if not isinstance(val, str) and not isinstance(val, (int, long)):
+        if not isinstance(val, str) and not isinstance(val, get_python_integer_types()):
             raise TypeError('BinaryValue slices only accept string or integer values')
 
         # convert integer to string
-        if isinstance(val, (int, long)):
+        if isinstance(val, get_python_integer_types()):
             if isinstance(key, slice):
                 num_slice_bits = abs(key.start - key.stop) + 1
             else:

--- a/cocotb/bus.py
+++ b/cocotb/bus.py
@@ -85,7 +85,7 @@ class Bus(object):
         self._name = name
         self._signals = {}
 
-        for attr_name, sig_name in _build_sig_attr_dict(signals).iteritems():
+        for attr_name, sig_name in _build_sig_attr_dict(signals).items():
             if name:
                 signame = name + bus_separator + sig_name
             else:
@@ -98,7 +98,7 @@ class Bus(object):
             self._signals[attr_name] = getattr(self, attr_name)
 
         # Also support a set of optional signals that don't have to be present
-        for attr_name, sig_name in _build_sig_attr_dict(optional_signals).iteritems():
+        for attr_name, sig_name in _build_sig_attr_dict(optional_signals).items():
             if name:
                 signame = name + bus_separator + sig_name
             else:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -32,6 +32,7 @@ export COCOTB
 
 EXAMPLES := adder/tests \
 	    endian_swapper/tests \
+            axi_lite_slave/tests \
 
 .PHONY: $(EXAMPLES)
 

--- a/examples/axi_lite_slave/hdl/axi_lite_slave.v
+++ b/examples/axi_lite_slave/hdl/axi_lite_slave.v
@@ -97,7 +97,7 @@ localparam      READ_WAIT_FOR_USER  = 4'h4;
 localparam      SEND_READ_DATA      = 4'h5;
 
 //registes/wires
-reg   [3:0]                           state;
+reg   [3:0]                           state = IDLE;
 
 //submodules
 //asynchronous logic

--- a/examples/axi_lite_slave/hdl/tb_axi_lite_slave.v
+++ b/examples/axi_lite_slave/hdl/tb_axi_lite_slave.v
@@ -44,7 +44,7 @@ output      [DATA_WIDTH - 1: 0]     AXIML_RDATA
 //Registers
 
 reg               r_rst;
-reg               test_id         = 0;
+reg [7:0] 	  test_id         = 0;
 
 //Workaround for weird icarus simulator bug
 always @ (*)      r_rst           = rst;

--- a/examples/axi_lite_slave/tests/Makefile
+++ b/examples/axi_lite_slave/tests/Makefile
@@ -6,7 +6,6 @@ COCOTB=$(PWD)/../../..
 PYTHONPATH := ./model:$(PYTHONPATH)
 
 export PYTHONPATH
-export PYTHONHOME=$(shell python -c "from distutils.sysconfig import get_config_var; print(get_config_var('prefix'))")
 
 EXTRA_ARGS+=-I$(TOPDIR)/hdl/
 

--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -52,9 +52,9 @@ def write_address_0(dut):
     if value != DATA:
         #Fail
         raise TestFailure("Register at address 0x%08X should have been: \
-                           0x%08X but was 0x%08X" % (ADDRESS, DATA, value))
+                           0x%08X but was 0x%08X" % (ADDRESS, DATA, int(value)))
 
-    dut.log.info("Write 0x%08X to addres 0x%08X" % (value, ADDRESS))
+    dut.log.info("Write 0x%08X to addres 0x%08X" % (int(value), ADDRESS))
 
 
 #Read back a value at address 0x01
@@ -73,12 +73,12 @@ def read_address_1(dut):
     """
     #Reset
     dut.rst <=  1
-    dut.test_id <= 0
+    dut.test_id <= 1
     axim = AXI4LiteMaster(dut, "AXIML", dut.clk)
     setup_dut(dut)
     yield Timer(CLK_PERIOD * 10)
     dut.rst <= 0
-
+    yield Timer(CLK_PERIOD)
     ADDRESS = 0x01
     DATA = 0xCD
 
@@ -91,9 +91,9 @@ def read_address_1(dut):
     if value != DATA:
         #Fail
         raise TestFailure("Register at address 0x%08X should have been: \
-                           0x%08X but was 0x%08X" % (ADDRESS, DATA, value))
+                           0x%08X but was 0x%08X" % (ADDRESS, DATA, int(value)))
 
-    dut.log.info("Read: 0x%08X From Address: 0x%08X" % (value, ADDRESS))
+    dut._log.info("Read: 0x%08X From Address: 0x%08X" % (int(value), ADDRESS))
 
 
 
@@ -133,9 +133,9 @@ def write_and_read(dut):
     if value != DATA:
         #Fail
         raise TestFailure("Register at address 0x%08X should have been: \
-                           0x%08X but was 0x%08X" % (ADDRESS, DATA, value))
+                           0x%08X but was 0x%08X" % (ADDRESS, DATA, int(value)))
 
-    dut.log.info("Write 0x%08X to addres 0x%08X" % (value, ADDRESS))
+    dut._log.info("Write 0x%08X to addres 0x%08X" % (int(value), ADDRESS))
 
 @cocotb.test(skip = False, expect_error=True)
 def write_fail(dut):
@@ -165,8 +165,8 @@ def write_fail(dut):
         yield axim.write(ADDRESS, DATA)
         yield Timer(CLK_PERIOD * 10)
     except AXIProtocolError as e:
-        print "Exception: %s" % str(e)
-        dut.log.info("Bus Successfully Raised an Error")
+        print ("Exception: %s" % str(e))
+        dut._log.info("Bus Successfully Raised an Error")
         raise TestSuccess()
     raise TestFailure("AXI Bus Should have raised an ERROR when writing to \
                         the wrong bus")
@@ -199,8 +199,8 @@ def read_fail(dut):
         yield axim.read(ADDRESS, DATA)
         yield Timer(CLK_PERIOD * 10)
     except AXIProtocolError as e:
-        print "Exception: %s" % str(e)
-        dut.log.info("Bus Successfully Raised an Error")
+        print ("Exception: %s" % str(e))
+        dut._log.info("Bus Successfully Raised an Error")
         raise TestSuccess()
     raise TestFailure("AXI Bus Should have raised an ERROR when writing to \
                         the wrong bus")

--- a/lib/simulator/simulatormodule.c
+++ b/lib/simulator/simulatormodule.c
@@ -437,7 +437,7 @@ static PyObject *register_value_change_callback(PyObject *self, PyObject *args) 
     }
 
     PyObject *pSihHdl = PyTuple_GetItem(args, 0);
-    sig_hdl = (gpi_sim_hdl)PyLong_AsUnsignedLong(pSihHdl);
+    sig_hdl = (gpi_sim_hdl)PyLong_AsLong(pSihHdl);
 
     // Extract the callback function
     function = PyTuple_GetItem(args, 1);
@@ -448,7 +448,7 @@ static PyObject *register_value_change_callback(PyObject *self, PyObject *args) 
     Py_INCREF(function);
 
     PyObject *pedge = PyTuple_GetItem(args, 2);
-    edge = (unsigned int)PyLong_AsUnsignedLong(pedge);
+    edge = (unsigned int)PyLong_AsLong(pedge);
 
     // Remaining args for function
     if (numargs > 3)
@@ -1024,7 +1024,7 @@ static PyObject *deregister_callback(PyObject *self, PyObject *args)
     gstate = TAKE_GIL();
 
     pSihHdl = PyTuple_GetItem(args, 0);
-    hdl = (gpi_sim_hdl)PyLong_AsUnsignedLong(pSihHdl);
+    hdl = (gpi_sim_hdl)PyLong_AsLong(pSihHdl);
 
     gpi_deregister_callback(hdl);
 
@@ -1045,7 +1045,7 @@ static PyObject *log_level(PyObject *self, PyObject *args)
     gstate = TAKE_GIL();
 
     py_level = PyTuple_GetItem(args, 0);
-    new_level = (enum gpi_log_levels)PyLong_AsUnsignedLong(py_level);
+    new_level = (enum gpi_log_levels)PyLong_AsLong(py_level);
 
     set_log_level(new_level);
 

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -155,6 +155,14 @@ def test_adding_a_coroutine_without_starting(dut):
     yield Join(forked)
     yield Timer(100)
 
+def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+    """
+    Polyfill for math.isclose() (Python 3.5+): floating-point "equal"
+
+    Implementation taken from
+    https://www.python.org/dev/peps/pep-0485/#proposed-implementation
+    """
+    return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 @cocotb.test(expect_fail=False)
 def test_clock_with_units(dut):
@@ -180,14 +188,14 @@ def test_clock_with_units(dut):
     yield RisingEdge(dut.clk)
 
     edge_time_ns = get_sim_time(units='ns')
-    if edge_time_ns != start_time_ns + 1000.0:
+    if not isclose(edge_time_ns, start_time_ns + 1000.0):
         raise TestFailure("Expected a period of 1 us")
 
     start_time_ns = edge_time_ns
 
     yield RisingEdge(dut.clk)
     edge_time_ns = get_sim_time(units='ns')
-    if edge_time_ns != start_time_ns + 1000.0:
+    if not isclose(edge_time_ns, start_time_ns + 1000.0):
         raise TestFailure("Expected a period of 1 us")
 
     clk_gen.kill()
@@ -201,14 +209,14 @@ def test_clock_with_units(dut):
     yield RisingEdge(dut.clk)
 
     edge_time_ns = get_sim_time(units='ns')
-    if edge_time_ns != start_time_ns + 4.0:
+    if not isclose(edge_time_ns, start_time_ns + 4.0):
         raise TestFailure("Expected a period of 4 ns")
 
     start_time_ns = edge_time_ns
 
     yield RisingEdge(dut.clk)
     edge_time_ns = get_sim_time(units='ns')
-    if edge_time_ns != start_time_ns + 4.0:
+    if not isclose(edge_time_ns, start_time_ns + 4.0):
         raise TestFailure("Expected a period of 4 ns")
 
     clk_gen.kill()


### PR DESCRIPTION
Problem was caused by faulty pointer passing between C and Python. Under
Ubuntu 16.04 LTS, the C library alloc (or loader?) causes virtual
addresses to be used in the upper half of the 32 bit address space, when
a 32-bit simulator and 32-bit Python is used. The integer value in
Python can not be converted using an "Unsigned" conversion function in
that case. The resulting pointer is -1, which causes a SEGFAULT.