### PR TITLE
Fixes for Python 3 compatibility.

### DIFF
--- a/bin/create_files.py
+++ b/bin/create_files.py
@@ -67,7 +67,7 @@ def print_files(path):
 
 def check_args(args):
     if len(args) is not 1:
-        print "Please specify a path"
+        print("Please specify a path")
         return
 
     print_files(args[0])

--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -85,9 +85,9 @@ class BinaryValue(object):
 
     >>> vec = BinaryValue()
     >>> vec.integer = 42
-    >>> print vec.binstr
+    >>> print(vec.binstr)
     101010
-    >>> print repr(vec.buff)
+    >>> print(repr(vec.buff))
     '*'
 
     """
@@ -376,12 +376,12 @@ class BinaryValue(object):
         """Provide boolean testing of a binstr.
 
         >>> val = BinaryValue("0000")
-        >>> if val: print "True"
-        ... else:   print "False"
+        >>> if val: print("True")
+        ... else:   print("False")
         False
         >>> val.integer = 42
-        >>> if val: print "True"
-        ... else:   print "False"
+        >>> if val: print("True")
+        ... else:   print("False")
         True
 
         """

--- a/cocotb/drivers/ad9361.py
+++ b/cocotb/drivers/ad9361.py
@@ -48,7 +48,7 @@ class AD9361(BusDriver):
 
     def send_data(self, i_data, q_data, i_data2=None, q_data2=None,
                   binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT):
-        print binaryRepresentation
+        print(binaryRepresentation)
         cocotb.fork(self.rx_data_to_ad9361(i_data, q_data, i_data2, q_data2,
                     binaryRepresentation))
 
@@ -145,8 +145,8 @@ class AD9361(BusDriver):
                 i_bin_val[11:6] = self.dut.tx_data_out_p.value.get_binstr()
             else:
                 i_bin_val[5:0] = self.dut.tx_data_out_p.value.get_binstr()
-                # print "i_data",i_bin_val.get_value()
-                # print "q_data",q_bin_val.get_value()
+                # print("i_data",i_bin_val.get_value())
+                # print("q_data",q_bin_val.get_value())
                 self.lbqi.append(i_bin_val)
                 self.lbqq.append(q_bin_val)
                 self.got_tx.set([i_bin_val, q_bin_val])

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -254,7 +254,7 @@ class AvalonMemory(BusDriver):
 
         if hasattr(self.bus, "readdata"):
             self._width = len(self.bus.readdata)
-            self.dataByteSize = self._width/8
+            self.dataByteSize = int(self._width/8)
             self._readable = True
 
         if hasattr(self.bus, "writedata"):
@@ -263,7 +263,7 @@ class AvalonMemory(BusDriver):
                 self.log.error("readdata and writedata bus" +
                                " are not the same size")
             self._width = width
-            self.dataByteSize = self._width/8
+            self.dataByteSize = int(self._width/8)
             self._writeable = True
 
         if not self._readable and not self._writeable:
@@ -402,7 +402,7 @@ class AvalonMemory(BusDriver):
                         self.log.error("Address must be aligned to data width" +
                                        "(addr = " + hex(addr) +
                                        ", width = " + str(self._width))
-                    addr = addr / self.dataByteSize
+                    addr = int(addr / self.dataByteSize)
                     burstcount = self.bus.burstcount.value.integer
                     byteenable = self.bus.byteenable.value
                     if byteenable != int("1"*len(self.bus.byteenable), 2):
@@ -699,4 +699,3 @@ class AvalonSTPkts(ValidatedBusDriver):
             self.log.info("Sucessfully sent packet of length %d bytes" % len(pkt))
         else:
             yield self._send_iterable(pkt, sync=sync)
-

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -457,7 +457,7 @@ class AvalonMemory(BusDriver):
                         self.log.debug("Data in   : %x" % data)
                         self.log.debug("Width     : %d" % self._width)
                         self.log.debug("Byteenable: %x" % byteenable)
-                        for i in xrange(self._width/8):
+                        for i in range(self._width/8):
                             if (byteenable & 2**i):
                                 mask |= 0xFF << (8*i)
                             else:

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -259,7 +259,7 @@ class HierarchyObject(RegionObject):
                 if len(sub) != len(value):
                     raise IndexError("Attempting to set %s with list length %d but target has length %d" % (
                         name, len(value), len(sub)))
-                for idx in xrange(len(value)):
+                for idx in range(len(value)):
                     sub[idx] = value[idx]
                 return
             else:
@@ -399,7 +399,7 @@ class NonHierarchyObject(SimHandleBase):
         if type(self) is NonHierarchyIndexableObject:
             #Need to iterate over the sub-object
             result =[]
-            for x in xrange(len(self)):
+            for x in range(len(self)):
                 result.append(self[x]._getvalue())
             return result
         else:
@@ -491,7 +491,7 @@ class NonHierarchyIndexableObject(NonHierarchyObject):
                 raise IndexError("Assigning list of length %d to object %s of length %d" % (
                     len(value), self.__getitem__(index)._fullname, len(self.__getitem__(index))))
             self._log.info("Setting item %s to %s" % (self.__getitem__(index)._fullname, value))
-            for idx in xrange(len(value)):
+            for idx in range(len(value)):
                 self.__getitem__(index).__setitem__(idx, value[idx])
         else:
             self.__getitem__(index).value = value

--- a/documentation/source/endian_swapper.rst
+++ b/documentation/source/endian_swapper.rst
@@ -139,7 +139,7 @@ We want to run different variations of tests but they will all have a very simil
             yield tb.stream_in.send(transaction)
         
         # Wait at least 2 cycles where output ready is low before ending the test
-        for i in xrange(2):
+        for i in range(2):
             yield RisingEdge(dut.clk)
             while not dut.stream_out_ready.value:
                 yield RisingEdge(dut.clk)

--- a/documentation/source/ping_tun_tap.rst
+++ b/documentation/source/ping_tun_tap.rst
@@ -118,7 +118,7 @@ write the received packet back to the TUN file descriptor.
     subprocess.check_call('ping -c 5 192.168.255.2 &', shell=True)
    
     # Respond to 5 pings, then quit
-    for i in xrange(5):
+    for i in range(5):
     
         cocotb.log.info("Waiting for packets on tun interface")
         packet = os.read(fd, 2048)

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -245,18 +245,18 @@ Accessing the .value property of a handle object will return a :class:`BinaryVal
     
     >>> # Read a value back from the dut
     >>> count = dut.counter.value
-    >>> 
-    >>> print count.binstr
+    >>>
+    >>> print(count.binstr)
     1X1010
     >>> # Resolve the value to an integer (X or Z treated as 0)
-    >>> print count.integer
+    >>> print(count.integer)
     42
 
 We can also cast the signal handle directly to an integer:
 
 .. code-block:: python
-    
-    >>> print int(dut.counter)
+
+    >>> print(int(dut.counter))
     42
 
 

--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -165,7 +165,7 @@ def write_fail(dut):
         yield axim.write(ADDRESS, DATA)
         yield Timer(CLK_PERIOD * 10)
     except AXIProtocolError as e:
-        print ("Exception: %s" % str(e))
+        print("Exception: %s" % str(e))
         dut._log.info("Bus Successfully Raised an Error")
         raise TestSuccess()
     raise TestFailure("AXI Bus Should have raised an ERROR when writing to \
@@ -199,10 +199,8 @@ def read_fail(dut):
         yield axim.read(ADDRESS, DATA)
         yield Timer(CLK_PERIOD * 10)
     except AXIProtocolError as e:
-        print ("Exception: %s" % str(e))
+        print("Exception: %s" % str(e))
         dut._log.info("Bus Successfully Raised an Error")
         raise TestSuccess()
     raise TestFailure("AXI Bus Should have raised an ERROR when writing to \
                         the wrong bus")
-
-

--- a/lib/gpi/GpiCommon.cpp
+++ b/lib/gpi/GpiCommon.cpp
@@ -112,7 +112,7 @@ int gpi_register_impl(GpiImplInterface *func_tbl)
 void gpi_embed_init(gpi_sim_info_t *info)
 {
     if (embed_sim_init(info))
-        gpi_sim_end();
+        gpi_embed_end();
 }
 
 void gpi_embed_end(void)
@@ -338,7 +338,7 @@ gpi_sim_hdl gpi_get_handle_by_index(gpi_sim_hdl parent, int32_t index)
     GpiObjHdl *base        = sim_to_hdl<GpiObjHdl*>(parent);
     GpiImplInterface *intf = base->m_impl;
 
-    /* Shouldn't need to iterate over interfaces because indexing into a handle shouldn't 
+    /* Shouldn't need to iterate over interfaces because indexing into a handle shouldn't
      * cross the interface boundaries.
      *
      * NOTE: IUS's VPI interface returned valid VHDL handles, but then couldn't

--- a/tests/test_cases/test_avalon/test_avalon.py
+++ b/tests/test_cases/test_avalon/test_avalon.py
@@ -103,8 +103,8 @@ def test_burst_read(dut):
     dut.user_read_buffer = 0
     yield RisingEdge(dut.clk)
 
-    print str(read_mem)
-    print str(len(read_mem)) + " 8bits values read"
+    print(str(read_mem))
+    print(str(len(read_mem)) + " 8bits values read")
 
     # checking values read
     for key, value in read_mem.items():
@@ -122,4 +122,3 @@ def test_burst_read(dut):
     yield Timer(10)
     dut.user_read_buffer = 0
     yield Timer(10)
-

--- a/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
+++ b/tests/test_cases/test_multi_dimension_array/test_cocotb_array.py
@@ -10,189 +10,189 @@ import simulator
 @cocotb.test()
 def test_in_vect_packed(dut):
     yield Timer(10)
-    print"Setting: dut.in_vect_packed type %s" % type(dut.in_vect_packed)
+    print("Setting: dut.in_vect_packed type %s" % type(dut.in_vect_packed))
     dut.in_vect_packed = 0x5
     yield Timer(10)
-    print"Getting: dut.out_vect_packed type %s" % type(dut.out_vect_packed)
+    print("Getting: dut.out_vect_packed type %s" % type(dut.out_vect_packed))
     if dut.out_vect_packed !=  0x5:
         raise TestFailure("Failed to readback dut.out_vect_packed")
 
 @cocotb.test()
 def test_in_vect_unpacked(dut):
     yield Timer(10)
-    print"Setting: dut.in_vect_unpacked type %s" % type(dut.in_vect_unpacked)
+    print("Setting: dut.in_vect_unpacked type %s" % type(dut.in_vect_unpacked))
     dut.in_vect_unpacked = [0x1, 0x0, 0x1]
     yield Timer(10)
-    print"Getting: dut.out_vect_unpacked type %s" % type( dut.out_vect_unpacked)
+    print("Getting: dut.out_vect_unpacked type %s" % type( dut.out_vect_unpacked))
     if dut.out_vect_unpacked !=  [0x1, 0x0, 0x1]:
         raise TestFailure("Failed to readback dut.out_vect_unpacked")
 
 @cocotb.test()
 def test_in_arr(dut):
     yield Timer(10)
-    print"Setting: dut.in_arr type %s" % type(dut.in_arr)
+    print("Setting: dut.in_arr type %s" % type(dut.in_arr))
     dut.in_arr = 0x5
     yield Timer(10)
-    print"Getting: dut.out_arr type %s" % type( dut.out_arr)
+    print("Getting: dut.out_arr type %s" % type( dut.out_arr))
     if dut.out_arr !=  0x5:
         raise TestFailure("Failed to readback dut.out_arr")
 
 @cocotb.test()
 def test_in_2d_vect_packed_packed(dut):
     yield Timer(10)
-    print"Setting: dut.in_2d_vect_packed_packed type %s" % type(dut.in_2d_vect_packed_packed)
+    print("Setting: dut.in_2d_vect_packed_packed type %s" % type(dut.in_2d_vect_packed_packed))
     dut.in_2d_vect_packed_packed = (0x5 << 6) | (0x5 << 3) | 0x5
     yield Timer(10)
-    print"Getting: dut.out_2d_vect_packed_packed type %s" % type( dut.out_2d_vect_packed_packed)
+    print("Getting: dut.out_2d_vect_packed_packed type %s" % type( dut.out_2d_vect_packed_packed))
     if dut.out_2d_vect_packed_packed !=  (0x5 << 6) | (0x5 << 3) | 0x5:
         raise TestFailure("Failed to readback dut.out_2d_vect_packed_packed")
 
 @cocotb.test()
 def test_in_2d_vect_packed_unpacked(dut):
     yield Timer(10)
-    print"Setting: dut.in_2d_vect_packed_unpacked type %s" % type(dut.in_2d_vect_packed_unpacked)
+    print("Setting: dut.in_2d_vect_packed_unpacked type %s" % type(dut.in_2d_vect_packed_unpacked))
     dut.in_2d_vect_packed_unpacked = [0x5, 0x5, 0x5]
     yield Timer(10)
-    print"Getting: dut.out_2d_vect_packed_unpacked type %s" % type( dut.out_2d_vect_packed_unpacked)
+    print("Getting: dut.out_2d_vect_packed_unpacked type %s" % type( dut.out_2d_vect_packed_unpacked))
     if dut.out_2d_vect_packed_unpacked !=  [0x5, 0x5, 0x5]:
         raise TestFailure("Failed to readback dut.out_2d_vect_packed_unpacked")
 
 @cocotb.test()
 def test_in_2d_vect_unpacked_unpacked(dut):
     yield Timer(10)
-    print"Setting: dut.in_2d_vect_unpacked_unpacked type %s" % type(dut.in_2d_vect_unpacked_unpacked)
+    print("Setting: dut.in_2d_vect_unpacked_unpacked type %s" % type(dut.in_2d_vect_unpacked_unpacked))
     dut.in_2d_vect_unpacked_unpacked = 3*[[0x1, 0x0, 0x1]]
     yield Timer(10)
-    print"Getting: dut.out_2d_vect_unpacked_unpacked type %s" % type( dut.out_2d_vect_unpacked_unpacked)
+    print("Getting: dut.out_2d_vect_unpacked_unpacked type %s" % type( dut.out_2d_vect_unpacked_unpacked))
     if dut.out_2d_vect_unpacked_unpacked !=  3*[[0x1, 0x0, 0x1]]:
         raise TestFailure("Failed to readback dut.out_2d_vect_unpacked_unpacked")
 
 @cocotb.test()
 def test_in_arr_packed(dut):
     yield Timer(10)
-    print"Setting: dut.in_arr_packed type %s" % type(dut.in_arr_packed)
+    print("Setting: dut.in_arr_packed type %s" % type(dut.in_arr_packed))
     dut.in_arr_packed = 365
     yield Timer(10)
-    print"Getting: dut.out_arr_packed type %s" % type( dut.out_arr_packed)
+    print("Getting: dut.out_arr_packed type %s" % type( dut.out_arr_packed))
     if dut.out_arr_packed !=  365:
         raise TestFailure("Failed to readback dut.out_arr_packed")
 
 @cocotb.test()
 def test_in_arr_unpacked(dut):
     yield Timer(10)
-    print"Setting: dut.in_arr_unpackedtype %s" % type(dut.in_arr_unpacked)
+    print("Setting: dut.in_arr_unpackedtype %s" % type(dut.in_arr_unpacked))
     dut.in_arr_unpacked = [0x5, 0x5, 0x5]
     yield Timer(10)
-    print"Getting: dut.out_arr_unpackedtype %s" % type( dut.out_arr_unpacked)
+    print("Getting: dut.out_arr_unpackedtype %s" % type( dut.out_arr_unpacked))
     if dut.out_arr_unpacked !=  [0x5, 0x5, 0x5]:
         raise TestFailure("Failed to readback dut.out_arr_unpacked")
 
 @cocotb.test()
 def test_in_2d_arr(dut):
     yield Timer(10)
-    print"Setting: dut.in_2d_arr type %s" % type(dut.in_2d_arr)
+    print("Setting: dut.in_2d_arr type %s" % type(dut.in_2d_arr))
     dut.in_2d_arr = 365
     yield Timer(10)
-    print"Getting: dut.out_2d_arr type %s" % type( dut.out_2d_arr)
+    print("Getting: dut.out_2d_arr type %s" % type( dut.out_2d_arr))
     if dut.out_2d_arr !=  365:
         raise TestFailure("Failed to readback dut.out_2d_arr")
 
 @cocotb.test()
 def test_in_vect_packed_packed_packed(dut):
     yield Timer(10)
-    print"Setting: dut.in_vect_packed_packed_packed type %s" % type(dut.in_vect_packed_packed_packed)
+    print("Setting: dut.in_vect_packed_packed_packed type %s" % type(dut.in_vect_packed_packed_packed))
     dut.in_vect_packed_packed_packed = 95869805
     yield Timer(10)
-    print"Getting: dut.out_vect_packed_packed_packed type %s" % type( dut.out_vect_packed_packed_packed)
+    print("Getting: dut.out_vect_packed_packed_packed type %s" % type( dut.out_vect_packed_packed_packed))
     if dut.out_vect_packed_packed_packed !=  95869805:
         raise TestFailure("Failed to readback dut.out_vect_packed_packed_packed")
 
 @cocotb.test()
 def test_in_vect_packed_packed_unpacked(dut):
     yield Timer(10)
-    print"Setting: dut.in_vect_packed_packed_unpacked type %s" % type(dut.in_vect_packed_packed_unpacked)
+    print("Setting: dut.in_vect_packed_packed_unpacked type %s" % type(dut.in_vect_packed_packed_unpacked))
     dut.in_vect_packed_packed_unpacked = [95869805, 95869805, 95869805]
     yield Timer(10)
-    print"Getting: dut.out_vect_packed_packed_unpacked type %s" % type( dut.out_vect_packed_packed_unpacked)
+    print("Getting: dut.out_vect_packed_packed_unpacked type %s" % type( dut.out_vect_packed_packed_unpacked))
     if dut.out_vect_packed_packed_unpacked !=  [365, 365, 365]:
         raise TestFailure("Failed to readback dut.out_vect_packed_packed_unpacked")
 
 @cocotb.test()
 def test_in_vect_packed_unpacked_unpacked(dut):
     yield Timer(10)
-    print"Setting: dut.in_vect_packed_unpacked_unpacked type %s" % type(dut.in_vect_packed_unpacked_unpacked)
+    print("Setting: dut.in_vect_packed_unpacked_unpacked type %s" % type(dut.in_vect_packed_unpacked_unpacked))
     dut.in_vect_packed_unpacked_unpacked = 3 *[3 * [5] ]
     yield Timer(10)
-    print"Getting: dut.out_vect_packed_unpacked_unpacked type %s" % type( dut.out_vect_packed_unpacked_unpacked)
+    print("Getting: dut.out_vect_packed_unpacked_unpacked type %s" % type( dut.out_vect_packed_unpacked_unpacked))
     if dut.out_vect_packed_unpacked_unpacked !=  3 *[3 * [5] ]:
         raise TestFailure("Failed to readback dut.out_vect_packed_unpacked_unpacked")
 
 @cocotb.test()
 def test_in_vect_unpacked_unpacked_unpacked(dut):
     yield Timer(10)
-    print"Setting: dut.in_vect_unpacked_unpacked_unpacked type %s" % type(dut.in_vect_unpacked_unpacked_unpacked)
+    print("Setting: dut.in_vect_unpacked_unpacked_unpacked type %s" % type(dut.in_vect_unpacked_unpacked_unpacked))
     dut.in_vect_unpacked_unpacked_unpacked = 3 *[3 * [[1, 0, 1]]]
     yield Timer(10)
-    print"Getting: dut.out_vect_unpacked_unpacked_unpacked type %s" % type( dut.out_vect_unpacked_unpacked_unpacked)
+    print("Getting: dut.out_vect_unpacked_unpacked_unpacked type %s" % type( dut.out_vect_unpacked_unpacked_unpacked))
     if dut.out_vect_unpacked_unpacked_unpacked !=  3 *[3 * [[1, 0, 1]]]:
         raise TestFailure("Failed to readback dut.out_vect_unpacked_unpacked_unpacked")
 
 @cocotb.test()
 def test_in_arr_packed_packed(dut):
     yield Timer(10)
-    print"Setting: dut.in_arr_packed_packed type %s" % type(dut.in_arr_packed_packed)
+    print("Setting: dut.in_arr_packed_packed type %s" % type(dut.in_arr_packed_packed))
     dut.in_arr_packed_packed = (365 << 18) | (365 << 9) | (365)
     yield Timer(10)
-    print"Getting: dut.out_arr_packed_packed type %s" % type( dut.out_arr_packed_packed)
+    print("Getting: dut.out_arr_packed_packed type %s" % type( dut.out_arr_packed_packed))
     if dut.out_arr_packed_packed !=  (365 << 18) | (365 << 9) | (365):
         raise TestFailure("Failed to readback dut.out_arr_packed_packed")
 
 @cocotb.test()
 def test_in_arr_packed_unpacked(dut):
     yield Timer(10)
-    print"Setting: dut.in_arr_packed_unpacked type %s" % type(dut.in_arr_packed_unpacked)
+    print("Setting: dut.in_arr_packed_unpacked type %s" % type(dut.in_arr_packed_unpacked))
     dut.in_arr_packed_unpacked = [365, 365, 365]
     yield Timer(10)
-    print"Getting: dut.out_arr_packed_unpacked type %s" % type( dut.out_arr_packed_unpacked)
+    print("Getting: dut.out_arr_packed_unpacked type %s" % type( dut.out_arr_packed_unpacked))
     if dut.out_arr_packed_unpacked !=  [365, 365, 365]:
         raise TestFailure("Failed to readback dut.out_arr_packed_unpacked")
 
 @cocotb.test()
 def test_in_arr_unpacked_unpacked(dut):
     yield Timer(10)
-    print"Setting: dut.in_arr_unpacked_unpacked type %s" % type(dut.in_arr_unpacked_unpacked)
+    print("Setting: dut.in_arr_unpacked_unpacked type %s" % type(dut.in_arr_unpacked_unpacked))
     dut.in_arr_unpacked_unpacked = 3 *[3 * [5] ]
     yield Timer(10)
-    print"Getting: dut.out_arr_unpacked_unpacked type %s" % type( dut.out_arr_unpacked_unpacked)
+    print("Getting: dut.out_arr_unpacked_unpacked type %s" % type( dut.out_arr_unpacked_unpacked))
     if dut.out_arr_unpacked_unpacked !=  3 *[3 * [5] ]:
         raise TestFailure("Failed to readback dut.out_arr_unpacked_unpacked")
 
 @cocotb.test()
 def test_in_2d_arr_packed(dut):
     yield Timer(10)
-    print"Setting: dut.in_2d_arr_packed type %s" % type(dut.in_2d_arr_packed)
+    print("Setting: dut.in_2d_arr_packed type %s" % type(dut.in_2d_arr_packed))
     dut.in_2d_arr_packed = (365 << 18) | (365 << 9) | (365)
     yield Timer(10)
-    print"Getting: dut.out_2d_arr_packed type %s" % type( dut.out_2d_arr_packed)
+    print("Getting: dut.out_2d_arr_packed type %s" % type( dut.out_2d_arr_packed))
     if dut.out_2d_arr_packed !=  (365 << 18) | (365 << 9) | (365):
         raise TestFailure("Failed to readback dut.out_2d_arr_packed")
 
 @cocotb.test()
 def test_in_2d_arr_unpacked(dut):
     yield Timer(10)
-    print"Setting: dut.in_2d_arr_unpacked type %s" % type(dut.in_2d_arr_unpacked)
+    print("Setting: dut.in_2d_arr_unpacked type %s" % type(dut.in_2d_arr_unpacked))
     dut.in_2d_arr_unpacked = [365, 365, 365]
     yield Timer(10)
-    print"Getting: dut.out_2d_arr_unpacked type %s" % type( dut.out_2d_arr_unpacked)
+    print("Getting: dut.out_2d_arr_unpacked type %s" % type( dut.out_2d_arr_unpacked))
     if dut.out_2d_arr_unpacked !=  [365, 365, 365]:
         raise TestFailure("Failed to readback dut.out_2d_arr_unpacked")
 
 @cocotb.test()
 def test_in_3d_arr(dut):
     yield Timer(10)
-    print"Setting: dut.in_3d_arr type %s" % type(dut.in_3d_arr)
+    print("Setting: dut.in_3d_arr type %s" % type(dut.in_3d_arr))
     dut.in_3d_arr = (365 << 18) | (365 << 9) | (365)
     yield Timer(10)
-    print"Getting: dut.out_3d_arr type %s" % type( dut.out_3d_arr)
+    print("Getting: dut.out_3d_arr type %s" % type( dut.out_3d_arr))
     if dut.out_3d_arr !=  (365 << 18) | (365 << 9) | (365):
         raise TestFailure("Failed to readback dut.out_3d_arr")


### PR DESCRIPTION
I found a few places where `xrange` was used. In Python 3, `xrange` was effectively renamed to `range` (with the old `range` being eliminated). The few places where `xrange` is used didn't stand out to me as places where the Python 2 `range` would have a performance impact, so I think it should be safe to mainline.