### PR TITLE
Add __repr__ to BinaryValue

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -369,6 +369,9 @@ class BinaryValue(object):
     def __str__(self):
         return self.binstr
 
+    def __repr__(self):
+        return self.__str__()
+
     def __bool__(self):
         return self.__nonzero__()
 


### PR DESCRIPTION
I added the __repr__() function to BinaryValue which simply outputs the binstr of it. After the python documentation, __repr__ needs to be unambiguous, which in this case, it is, because its the complete set of bits.

This is a change I did to make BinaryValue compatible with the current scoreboard.compare() implementation.