### PR TITLE
Allow the scheduler to handle yielding a list of coroutines and triggers

### DIFF
--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -51,8 +51,8 @@ Before python 3.3, this requires a `ReturnValue` to be raised.
             raise TestFailure("Signal did not change")
 
 
-Coroutines may also yield a list of triggers to indicate that execution should
-resume if *any* of them fires:
+Coroutines may also yield a list of triggers and coroutines to indicate that
+execution should resume if *any* of them fires:
 
 .. code-block:: python
 

--- a/tests/test_cases/issue_588/Makefile
+++ b/tests/test_cases/issue_588/Makefile
@@ -1,0 +1,31 @@
+###############################################################################
+# Copyright (c) 2018 Potential Ventures Ltd
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Potential Ventures Ltd,
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_588

--- a/tests/test_cases/issue_588/issue_588.py
+++ b/tests/test_cases/issue_588/issue_588.py
@@ -1,0 +1,29 @@
+# Test case for issue 588- yielding both coroutines and triggers in a list.
+# This is a very simple test; it just makes sure we can yield a list of both.
+
+import cocotb
+from cocotb import triggers, result, utils, clock
+
+import sys
+
+@cocotb.coroutine
+def sample_coroutine(dut):
+    """ Very simple coroutine that waits 5 ns."""
+    yield triggers.Timer(5, "ns")
+    dut._log.info("Sample coroutine yielded.")
+
+@cocotb.test()
+def issue_588_coroutine_list(dut):
+    """ Yield a list of triggers and coroutines."""
+
+    # Record simulation time.
+    current_time = utils.get_sim_time("ns")
+
+    # Yield a list, containing a RisingEdge trigger and a coroutine.
+    yield [sample_coroutine(dut), triggers.Timer(100, "ns")]
+
+    # Make sure that only 5 ns passed, because the sample coroutine
+    # terminated first.
+    new_time = utils.get_sim_time("ns")
+    if int(new_time - current_time) != 5:
+        raise result.TestFailure("Did not yield coroutine in list.")


### PR DESCRIPTION
Currently the cocotb scheduler understands how to yield a coroutine from another coroutine; it queues it and calls .join() automatically. It also understands how to yield a list of triggers and resume execution when the first one finishes.

But it does not understand how to yield a list of triggers and coroutines (or just coroutines); it will complain if the list contains anything that's not a trigger.

This commit fixes it so that if the scheduler encounters a list, it will iterate through that list and build a new one, calling ```.join()``` automatically on any objects of type RunningCoroutine. If the list contains something that was not a trigger or coroutine, it is dropped.

Then the size of the new and old lists are compared; if they differ it means that the list contained something that was not a trigger or a coroutine, and so we do nothing. Otherwise we yield it.

The commit also includes a very minimal test for this functionality.

This resolves issue #588.