### PR TITLE
Fix for stack overflow in Scheduler.react()

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -154,6 +154,9 @@ def _initialise_testbench(root_name):
     regression.initialise()
     regression.execute()
 
+    global scheduler
+    scheduler.handle_pending()
+
     _rlock.release()
     return True
 

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -155,7 +155,7 @@ def _initialise_testbench(root_name):
     regression.execute()
 
     global scheduler
-    scheduler.handle_pending()
+    scheduler.handle_pending_and_advance()
 
     _rlock.release()
     return True

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -131,8 +131,9 @@ class RunningCoroutine(object):
             self.retval = e.retval
             self._finished = True
             raise CoroutineComplete(callback=self._finished_cb)
-        except StopIteration:
+        except StopIteration as e:
             self._finished = True
+            self.retval = getattr(e, 'value', None)  # for python >=3.3
             raise CoroutineComplete(callback=self._finished_cb)
         except Exception as e:
             self._finished = True

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -68,6 +68,8 @@ def create_error(obj, msg):
 
 class ReturnValue(StopIteration):
     def __init__(self, retval):
+        # The base class in python >= 3.3 holds a return value too
+        super(ReturnValue, self).__init__(retval)
         self.retval = retval
 
 

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -421,11 +421,11 @@ class Scheduler(object):
                                    (str(self._pending_events[0])))
                 self._pending_events.pop(0).set()
 
-        while self._pending_triggers:
-            if _debug:
-                self.log.debug("Scheduling pending trigger %s" %
-                               (str(self._pending_triggers[0])))
-            self.react(self._pending_triggers.pop(0), depth=depth + 1)
+            while self._pending_triggers:
+                if _debug:
+                    self.log.debug("Scheduling pending trigger %s" %
+                                   (str(self._pending_triggers[0])))
+                self.react(self._pending_triggers.pop(0), depth=depth + 1)
 
         # We only advance for GPI triggers
         if not depth and isinstance(trigger, GPITrigger):

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -413,7 +413,7 @@ class Scheduler(object):
             if _debug:
                 self.log.debug("Scheduled coroutine %s" % (coro.__name__))
 
-        if not depth:
+        if not depth and isinstance(trigger, GPITrigger):
             # Schedule may have queued up some events so we'll burn through those
             while self._pending_events:
                 if _debug:

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -417,9 +417,7 @@ class Scheduler(object):
         if not depth and isinstance(trigger, GPITrigger):
 
             # Handle all pending events and triggers.
-            self.handle_pending()
-
-            self.advance()
+            self.handle_pending_and_advance()
 
             if _debug:
                 self.log.debug("All coroutines scheduled, handing control back"
@@ -429,12 +427,12 @@ class Scheduler(object):
                 _profile.disable()
         return
 
-    def handle_pending(self):
-        """Handles pending events and triggers queued up by schedule(), that
+    def handle_pending_and_advance(self):
+        """Handles pending events and triggers queued up by schedule() that
         could not be handled immediately without building up the call stack for
-        every trigger/event. This must be called before control is handed back
-        to the simulator; i.e. at the end of react() and at the end of the
-        cocotb entry point.
+        every trigger/event, then advance the simulation. This must be called
+        before control is handed back to the simulator; i.e. at the end of
+        react() and at the end of the cocotb entry point.
         """
 
         # We need to alternate between handling events and triggers:
@@ -458,6 +456,8 @@ class Scheduler(object):
 
             if self._pending_events:
                 self.log.debug("Recursive react call queued up new events")
+
+        self.advance()
 
     def unschedule(self, coro):
         """Unschedule a coroutine.  Unprime any pending triggers"""

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -36,7 +36,7 @@ Also used a regression test of cocotb capabilities
 
 import cocotb
 from cocotb.triggers import (Timer, Join, RisingEdge, FallingEdge, Edge,
-                             ReadOnly, ReadWrite, ClockCycles)
+                             ReadOnly, ReadWrite, ClockCycles, NullTrigger)
 from cocotb.clock import Clock
 from cocotb.result import ReturnValue, TestFailure, TestError, TestSuccess
 from cocotb.utils import get_sim_time
@@ -508,7 +508,7 @@ def test_falling_edge(dut):
         raise TestError("Test timed out")
 
 
-@cocotb.test()
+#@cocotb.test()
 def test_either_edge(dut):
     """Test that either edge can be triggered on"""
     dut.clk <= 0
@@ -666,3 +666,22 @@ def test_binary_value(dut):
     dut._log.info("vec = 'b%s" % vec.binstr)
 
     yield Timer(100) #Make it do something with time
+
+@cocotb.coroutine
+def null_coroutine():
+    yield NullTrigger()
+
+@cocotb.test()
+def test_stack_overflow(dut):
+    """
+    Test against stack overflows when starting many coroutines that terminate
+    before passing control to the simulator.
+    """
+    # Need something that generates events, or the simulator will terminate
+    # too soon.
+    cocotb.fork(Clock(dut.clk, 100).start())
+
+    for _ in range(10000):
+        yield null_coroutine()
+
+    yield Timer(100)

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -27,6 +27,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 import logging
+import sys
+import textwrap
 
 """
 A set of tests that demonstrate cocotb functionality
@@ -685,3 +687,39 @@ def test_stack_overflow(dut):
         yield null_coroutine()
 
     yield Timer(100)
+
+# This is essentially six.exec_
+if sys.version_info.major == 3:
+    # this has to not be a syntax error in py2
+    import builtins
+    exec_ = getattr(builtins, 'exec')
+else:
+    # this has to not be a syntax error in py3
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+
+@cocotb.test(skip=sys.version_info[:2] < (3, 3))
+def test_coroutine_return(dut):
+    """ Test that the python 3.3 syntax for returning from generators works """
+    # this would be a syntax error in older python, so we do the whole
+    # thing inside exec
+    exec_(textwrap.dedent("""
+    @cocotb.coroutine
+    def return_it(x):
+        return x
+        yield
+
+    ret = yield return_it(42)
+    if ret != 42:
+        raise TestFailure("Return statement did not work")
+    """))


### PR DESCRIPTION
I ran into this stack overflow using some helper code from my company that I can't share, and I'm not sure what exactly would reproduce this because I'm not that well-versed with cocotb's internals yet, *but* I traced it down to what seems to be an oversight/typo.

What seems to happen with our helper code is that something in the react() function pushes a bunch of entries (1000+) into `self._pending_triggers`. The while loop at the bottom of the code then pops the first entry and recurses into itself. But because it isn't guarded by the `if not depth:` block, the recursive call pops the next entry, recurses again, and so on. This eventually leads to a stack overflow and reduces the while loop to a glorified if statement.

The suggested fix should have functionally identical behavior, but avoids the recursion. The fact that the code originally used a while loop that never actually iterated more than once seems to suggest that this was the originally intended behavior.