### PR TITLE
Add support for async/await

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -29,6 +29,8 @@
 
 import os
 import weakref
+import sys
+import textwrap
 
 if "COCOTB_SIM" in os.environ:
     import simulator
@@ -39,7 +41,7 @@ from cocotb.log import SimLog
 from cocotb.result import raise_error
 from cocotb.utils import (
     get_sim_steps, get_time_from_sim_steps, with_metaclass,
-    ParametrizedSingleton
+    ParametrizedSingleton, exec_
 )
 from cocotb import outcomes
 
@@ -73,6 +75,14 @@ class Trigger(object):
     @property
     def _outcome(self):
         return outcomes.Value(self)
+
+    # Once 2.7 is dropped, this can be run unconditionally
+    if sys.version_info >= (3, 3):
+        exec_(textwrap.dedent("""
+        def __await__(self):
+            # hand the trigger back to the scheduler trampoline
+            return (yield self)
+        """))
 
 
 class PythonTrigger(Trigger):

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -931,3 +931,6 @@ def test_immediate_coro(dut):
         pass
     else:
         raise TestFailure("Exception was not raised")
+
+if sys.version_info[:2] >= (3, 5):
+    from test_cocotb_35 import *

--- a/tests/test_cases/test_cocotb/test_cocotb_35.py
+++ b/tests/test_cases/test_cocotb/test_cocotb_35.py
@@ -1,0 +1,109 @@
+"""
+This file contains tests that use syntax introduced in Python 3.5.
+
+This is likely to mean this file only tests `async def` functions.
+"""
+
+import cocotb
+from cocotb.triggers import Timer
+from cocotb.outcomes import Value, Error
+from cocotb.result import TestFailure
+
+
+class produce:
+    """ Test helpers that produce a value / exception in different ways """
+    @staticmethod
+    @cocotb.coroutine
+    def coro(outcome):
+        yield Timer(1)
+        return outcome.get()
+
+    @staticmethod
+    @cocotb.coroutine
+    async def async_annotated(outcome):
+        await Timer(1)
+        return outcome.get()
+
+    @staticmethod
+    async def async_(outcome):
+        await Timer(1)
+        return outcome.get()
+
+
+class SomeException(Exception):
+    """ Custom exception to test for that can't be thrown by internals """
+    pass
+
+
+# just to be sure...
+@cocotb.test(expect_fail=True)
+async def test_async_test_can_fail(dut):
+    await Timer(1)
+    raise TestFailure
+
+
+@cocotb.test()
+def test_annotated_async_from_coro(dut):
+    """
+    Test that normal coroutines are able to call async functions annotated
+    with `@cocotb.coroutine`
+    """
+    v = yield produce.async_annotated(Value(1))
+    assert v == 1
+
+    try:
+        yield produce.async_annotated(Error(SomeException))
+    except SomeException:
+        pass
+    else:
+        assert False
+
+
+@cocotb.test()
+async def test_annotated_async_from_async(dut):
+    """ Test that async coroutines are able to call themselves """
+    v = await produce.async_annotated(Value(1))
+    assert v == 1
+
+    try:
+        await produce.async_annotated(Error(SomeException))
+    except SomeException:
+        pass
+    else:
+        assert False
+
+
+@cocotb.test()
+async def test_annotated_async_from_async(dut):
+    """ Test that async coroutines are able to call raw async functions """
+    v = await produce.async_(Value(1))
+    assert v == 1
+
+    try:
+        await produce.async_(Error(SomeException))
+    except SomeException:
+        pass
+    else:
+        assert False
+
+
+@cocotb.test()
+async def test_coro_from_async(dut):
+    """ Test that async coroutines are able to call regular ones """
+    v = await produce.coro(Value(1))
+    assert v == 1
+
+    try:
+        await produce.coro(Error(SomeException))
+    except SomeException:
+        pass
+    else:
+        assert False
+
+
+@cocotb.test()
+async def test_trigger_await_gives_self(dut):
+    """ Test that await returns the trigger itself for triggers """
+    t = Timer(1)
+    t2 = await t
+    assert t2 is t


### PR DESCRIPTION
This keeps the old scheduler, and converts async functions into a form the scheduler understands.

Unlike nested calls to coroutines, where the nested call is passed to the scheduler, only the outermost call in an async function chain is passed to the scheduler.