### PR TITLE
Add support for structured nets (IUS Real Number  Models).

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -666,8 +666,11 @@ class RealObject(ModifiableObject):
         This operation will fail unless the handle refers to a modifiable
         object eg net, signal or variable.
         """
-        if not isinstance(value, float):
-            self._log.critical("Unsupported type for real value assignment: %s (%s)" % (type(value), repr(value)))
+        try:
+            value = float(value)
+        except ValueError:
+            self._log.critical("Unsupported type for real value assignment: %s (%s)" %
+                               (type(value), repr(value)))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 
         simulator.set_signal_val_real(self._handle, value)

--- a/include/vpi_user.h
+++ b/include/vpi_user.h
@@ -853,6 +853,8 @@ typedef struct t_cb_data
 #define cbNBASynch               30
 #define cbAtEndOfSimTime         31
 
+/**************************** Verilog AMS ****************************/
+#define vpiRealNet             526
 
 /************************* FUNCTION DECLARATIONS **************************/
 

--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -222,7 +222,8 @@ int VpiSignalObjHdl::initialise(std::string &name, std::string &fq_name) {
     int32_t type = vpi_get(vpiType, GpiObjHdl::get_handle<vpiHandle>());
     if ((vpiIntVar == type) ||
         (vpiIntegerVar == type) ||
-        (vpiIntegerNet == type )) {
+        (vpiIntegerNet == type ) ||
+        (vpiRealNet == type)) {
         m_num_elems = 1;
     } else {
         m_num_elems = vpi_get(vpiSize, GpiObjHdl::get_handle<vpiHandle>());
@@ -544,6 +545,7 @@ void vpi_mappings(GpiIteratorMapping<int32_t, int32_t> &map)
         vpiMemory,
         vpiIntegerVar,
         vpiRealVar,
+        vpiRealNet,
         vpiStructVar,
         vpiStructNet,
         //vpiVariables          // Aldec SEGV on plain Verilog
@@ -683,9 +685,10 @@ VpiIterator::VpiIterator(GpiImplInterface *impl, GpiObjHdl *hdl) : GpiIterator(i
         return;
     }
 
-    LOG_DEBUG("Created iterator working from type %d %s",
+    LOG_DEBUG("Created iterator working from type %d %s (%s)",
               *one2many,
-              vpi_get_str(vpiFullName, vpi_hdl));
+              vpi_get_str(vpiFullName, vpi_hdl),
+              vpi_get_str(vpiType, vpi_hdl));
 
     m_iterator = iterator;
 }

--- a/lib/vpi/VpiImpl.cpp
+++ b/lib/vpi/VpiImpl.cpp
@@ -80,6 +80,7 @@ gpi_objtype_t to_gpi_objtype(int32_t vpitype)
         case vpiRegBit:
             return GPI_REGISTER;
 
+        case vpiRealNet:
         case vpiRealVar:
             return GPI_REAL;
 
@@ -152,6 +153,7 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiIntegerVar:
         case vpiIntegerNet:
         case vpiRealVar:
+        case vpiRealNet:
             new_obj = new VpiSignalObjHdl(this, new_hdl, to_gpi_objtype(type), false);
             break;
         case vpiParameter:

--- a/tests/test_cases/issue_134/test_reals.py
+++ b/tests/test_cases/issue_134/test_reals.py
@@ -26,3 +26,21 @@ def assign_double(dut):
     log.info("Read back value %g" % got)
     if got != val:
         raise TestFailure("Values didn't match!")
+
+
+@cocotb.test(expect_error=cocotb.SIM_NAME in ["Icarus Verilog"])
+def assign_int(dut):
+    """Assign a random integer value to ensure we can write types convertible to int, read it back from
+    the DUT and check it matches what we assigned.
+    """
+    val = random.randint(-2**31, 2**31 - 1)
+    log = logging.getLogger("cocotb.test")
+    yield Timer(1)
+    log.info("Setting the value %i" % val)
+    dut.stream_in_real <= val
+    yield Timer(1)
+    yield Timer(1) # Workaround for VHPI scheduling - needs investigation
+    got = dut.stream_out_real
+    log.info("Read back value %d" % got)
+    if got != float(val):
+        raise TestFailure("Values didn't match!")


### PR DESCRIPTION
This allows CocoTB to observe structured nets, like the `EEnets` that are used in IUS AMS/Real Number Model flows. You can't drive individual components (even in SystemVerilog), so the solution for driving `EEnet` types would be similar to the following:
```verilog
import EE_pkg::*;

module dut(inout EEnet out);
    real out_v, out_r;

    // EEnet = '{V, I, R};
    assign out = '{out_v, 0, out_r};
endmodule
```
You can then drive `out_v` and `out_r` from CocoTB. This change will allow you to also observe values via `dut.out.V.value`, for example.

I also made a small change to allow `float` convertible types (like `int`) to be assigned to `real` values.