### PR TITLE
Rebase the hierarchical trigger branch against latest cocotb

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -50,13 +50,32 @@ class Trigger(object):
         self.log = SimLog("cocotb.%s" % (self.__class__.__name__), id(self))
         self.signal = None
         self.primed = False
+        self._callback_list = []
 
     def prime(self, *args):
         self.primed = True
 
-    def unprime(self):
+    def unprime(self, callback=None):
         """Remove any pending callbacks if necessary"""
-        self.primed = False
+        if callback and callback in self._callback_list:
+            self._callback_list.remove(callback)
+
+    def _callback(self, trigger):
+        assert trigger == self
+        # Make copy in case a callback re-primes us
+        # Since we triggered, clearing the callback list will allow
+        # GPITriggers to unprime/reprime properly
+        callbacks = self._callback_list[:]
+        self._callback_list = []
+        for callback in callbacks:
+            self.unprime(callback)
+            callback(trigger)
+
+    def needs_advance(self):
+        return False
+
+    def primed_for(self, trigger):
+        return trigger in self._callback_list
 
     def __del__(self):
         """Ensure if a trigger drops out of scope we remove any pending
@@ -93,12 +112,16 @@ class GPITrigger(Trigger):
         # else:
         self.cbhdl = 0
 
-    def unprime(self):
+    def unprime(self, callback=None):
         """Disable a primed trigger, can be reprimed"""
-        if self.cbhdl != 0:
-            simulator.deregister_callback(self.cbhdl)
-        self.cbhdl = 0
-        Trigger.unprime(self)
+        Trigger.unprime(self, callback)
+        if not len(self._callback_list):
+            if self.cbhdl != 0:
+                simulator.deregister_callback(self.cbhdl)
+            self.cbhdl = 0
+
+    def needs_advance(self):
+        return True
 
     def __del__(self):
         """Remove knowledge of the trigger"""
@@ -119,9 +142,11 @@ class Timer(GPITrigger):
 
     def prime(self, callback):
         """Register for a timed callback"""
+        if callback not in self._callback_list:
+            self._callback_list.append(callback)
         if self.cbhdl == 0:
             self.cbhdl = simulator.register_timed_callback(self.sim_steps,
-                                                           callback, self)
+                                                           self._callback, self)
             if self.cbhdl == 0:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
         Trigger.prime(self)
@@ -138,8 +163,10 @@ class _ReadOnly(GPITrigger):
         GPITrigger.__init__(self)
 
     def prime(self, callback):
+        if callback not in self._callback_list:
+            self._callback_list.append(callback)
         if self.cbhdl == 0:
-            self.cbhdl = simulator.register_readonly_callback(callback, self)
+            self.cbhdl = simulator.register_readonly_callback(self._callback, self)
             if self.cbhdl == 0:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
         Trigger.prime(self)
@@ -163,10 +190,12 @@ class _ReadWrite(GPITrigger):
         GPITrigger.__init__(self)
 
     def prime(self, callback):
+        if callback not in self._callback_list:
+            self._callback_list.append(callback)
         if self.cbhdl == 0:
             # import pdb
             # pdb.set_trace()
-            self.cbhdl = simulator.register_rwsynch_callback(callback, self)
+            self.cbhdl = simulator.register_rwsynch_callback(self._callback, self)
             if self.cbhdl == 0:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
         Trigger.prime(self)
@@ -189,8 +218,10 @@ class _NextTimeStep(GPITrigger):
         GPITrigger.__init__(self)
 
     def prime(self, callback):
+        if callback not in self._callback_list:
+            self._callback_list.append(callback)
         if self.cbhdl == 0:
-            self.cbhdl = simulator.register_nextstep_callback(callback, self)
+            self.cbhdl = simulator.register_nextstep_callback(self._callback, self)
             if self.cbhdl == 0:
                 raise_error(self, "Unable set up %s Trigger" % (str(self)))
         Trigger.prime(self)
@@ -215,10 +246,12 @@ class _Edge(GPITrigger):
 
     def prime(self, callback):
         """Register notification of a value change via a callback"""
+        if callback not in self._callback_list:
+            self._callback_list.append(callback)
         if self.cbhdl == 0:
             self.cbhdl = simulator.register_value_change_callback(self.signal.
                                                                   _handle,
-                                                                  callback,
+                                                                  self._callback,
                                                                   3,
                                                                   self)
             if self.cbhdl == 0:
@@ -241,10 +274,12 @@ class _RisingOrFallingEdge(_Edge):
             self._rising = 2
 
     def prime(self, callback):
+        if callback not in self._callback_list:
+            self._callback_list.append(callback)
         if self.cbhdl == 0:
             self.cbhdl = simulator.register_value_change_callback(self.signal.
                                                                   _handle,
-                                                                  callback,
+                                                                  self._callback,
                                                                   self._rising,
                                                                   self)
             if self.cbhdl == 0:
@@ -279,75 +314,122 @@ def FallingEdge(signal):
     return signal._f_edge
 
 
-class ClockCycles(_Edge):
+class Sequential(PythonTrigger):
     """
-    Execution will resume after N rising edges or N falling edges
+    Combines multiple triggers together sequentially.  Coroutine will continue when all
+    triggers have fired, each in turn.
     """
-    def __init__(self, signal, num_cycles, rising=True):
-        _Edge.__init__(self, signal)
-        self.num_cycles = num_cycles
-        if rising is True:
-            self._rising = 1
-        else:
-            self._rising = 2
-
-    def prime(self, callback):
-        self._callback = callback
-
-        def _check(obj):
-            self.unprime()
-
-            if self.signal.value:
-                self.num_cycles -= 1
-
-                if self.num_cycles <= 0:
-                    self._callback(self)
-                    return
-
-            self.cbhdl = simulator.register_value_change_callback(self.signal.
-                                                                  _handle,
-                                                                  _check,
-                                                                  self._rising,
-                                                                  self)
-            if self.cbhdl == 0:
-                raise_error(self, "Unable set up %s Trigger" % (str(self)))
-
-        self.cbhdl = simulator.register_value_change_callback(self.signal.
-                                                              _handle,
-                                                              _check,
-                                                              self._rising,
-                                                              self)
-        if self.cbhdl == 0:
-            raise_error(self, "Unable set up %s Trigger" % (str(self)))
-        Trigger.prime(self)
-
-    def __str__(self):
-        return self.__class__.__name__ + "(%s)" % self.signal._name
-
-
-class Combine(PythonTrigger):
-    """
-    Combines multiple triggers together.  Coroutine will continue when all
-    triggers have fired
-    """
-
     def __init__(self, *args):
         PythonTrigger.__init__(self)
-        self._triggers = args
-        # TODO: check that trigger is an iterable containing
-        # only Trigger objects
+        self._triggers = list(args)
+        self._active = None
+        self._fired = []
+        self._gpi_based = False
         try:
             for trigger in self._triggers:
                 if not isinstance(trigger, Trigger):
                     raise TriggerException("All combined triggers must be "
                                            "instances of Trigger! Got: %s" %
                                            trigger.__class__.__name__)
+                self._gpi_based |= trigger.needs_advance()
         except Exception:
             raise TriggerException("%s requires a list of Trigger objects" %
                                    self.__class__.__name__)
 
     def prime(self, callback):
-        self._callback = callback
+        if callback not in self._callback_list:
+            self._callback_list.append(callback)
+        if not self._triggers:
+            raise TriggerException("%s requires a list of Trigger objects, but they vanished" %
+                                   self.__class__.__name__)
+        self._active = self._triggers.pop(0)
+        Trigger.prime(self)
+        self._active.prime(self._check_all_fired)
+
+    def _check_all_fired(self, trigger):
+        self._fired.append(trigger)
+        if len(self._triggers):
+            self._active = self._triggers.pop(0)
+            self._active.prime(self._check_all_fired)
+        else:
+            # reset lists in case we are primed again
+            self._triggers = self._fired
+            self._fired = []
+            self._callback(self)
+
+    def needs_advance(self):
+        return self._gpi_based
+
+
+class RepeatNTriggers(PythonTrigger):
+    """
+    Execution will resume after N occurrances of a trigger
+    """
+    def __init__(self, trigger, num_cycles):
+        PythonTrigger.__init__(self)
+        self._trigger = trigger
+        self._num_cycles = num_cycles
+        self._count = 0
+        self._gpi_based = trigger.needs_advance()
+
+    def prime(self, callback):
+        if callback not in self._callback_list:
+            self._callback_list.append(callback)
+        if self._num_cycles < 1:
+            # This is essentially a NullTrigger
+            callback(self)
+            return
+        self._count = 0
+        Trigger.prime(self, callback)
+        self._trigger.prime(self._check_all_fired)
+
+    def _check_all_fired(self, trigger):
+        self._count += 1
+        if self._count >= self._num_cycles:
+            self._callback(self)
+        else:
+            trigger.prime(self._check_all_fired)
+        return
+
+    def needs_advance(self):
+        return self._gpi_based
+
+
+class ClockCycles(RepeatNTriggers):
+    """
+    Execution will resume after N rising edges or N falling edges
+    """
+    def __init__(self, signal, num_cycles, rising=True):
+        if rising:
+            RepeatNTriggers.__init__(self, RisingEdge(signal), num_cycles)
+        else:
+            RepeatNTriggers.__init__(self, FallingEdge(signal), num_cycles)
+
+
+class Combine(PythonTrigger):
+    """
+    Combines multiple triggers together.  Coroutine will continue when all
+    triggers have fired.  Order does not matter.
+    """
+
+    def __init__(self, *args):
+        PythonTrigger.__init__(self)
+        self._triggers = list(args)
+        self._gpi_based = False
+        try:
+            for trigger in self._triggers:
+                if not isinstance(trigger, Trigger):
+                    raise TriggerException("All combined triggers must be "
+                                           "instances of Trigger! Got: %s" %
+                                           trigger.__class__.__name__)
+                self._gpi_based |= trigger.needs_advance()
+        except Exception:
+            raise TriggerException("%s requires a list of Trigger objects" %
+                                   self.__class__.__name__)
+
+    def prime(self, callback):
+        if callback not in self._callback_list:
+            self._callback_list.append(callback)
         self._fired = []
         for trigger in self._triggers:
             trigger.prime(self._check_all_fired)
@@ -355,13 +437,15 @@ class Combine(PythonTrigger):
 
     def _check_all_fired(self, trigger):
         self._fired.append(trigger)
-        if self._fired == self._triggers:
+        if len(self._fired) == len(self._triggers):
             self._callback(self)
 
-    def unprime(self):
+    def unprime(self, callback=None):
         for trigger in self._triggers:
-            trigger.unprime()
+            trigger.unprime(self._check_all_fired)
 
+    def needs_advance(self):
+        return self._gpi_based
 
 class _Event(PythonTrigger):
     """

--- a/tests/designs/sample_module/sample_module.v
+++ b/tests/designs/sample_module/sample_module.v
@@ -54,11 +54,15 @@ module sample_module (
 
     input                                       stream_out_ready,
     output reg [7:0]                            stream_out_data_comb,
+    output reg                                  stream_out_valid,
     output reg [7:0]                            stream_out_data_registered,
 
     output                                      and_output
 
 );
+
+always @(posedge clk)
+    stream_out_valid <= stream_in_valid;
 
 always @(posedge clk)
     stream_out_data_registered <= stream_in_data;

--- a/tests/designs/sample_module/sample_module.vhdl
+++ b/tests/designs/sample_module/sample_module.vhdl
@@ -56,6 +56,7 @@ entity sample_module is
         stream_out_data_comb            : out   std_ulogic_vector(7 downto 0);
         stream_out_data_registered      : out   std_ulogic_vector(7 downto 0);
         stream_out_data_wide            : out   std_ulogic_vector(63 downto 0);
+        stream_out_valid                : out   std_ulogic;
         stream_out_ready                : in    std_ulogic;
         stream_out_real                 : out   real;
         stream_out_int                  : out   integer;
@@ -102,6 +103,7 @@ begin
 
 process (clk) begin
     if rising_edge(clk) then
+        stream_out_valid           <= stream_in_valid;
         stream_out_data_registered <= stream_in_data;
     end if;
 end process;

--- a/tests/test_cases/issue_520/Makefile
+++ b/tests/test_cases/issue_520/Makefile
@@ -1,0 +1,31 @@
+###############################################################################
+# Copyright (c) 2015 Potential Ventures Ltd
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Potential Ventures Ltd,
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_520

--- a/tests/test_cases/issue_520/issue_520.py
+++ b/tests/test_cases/issue_520/issue_520.py
@@ -1,0 +1,117 @@
+import cocotb
+from cocotb.log import SimLog
+from cocotb.triggers import Timer, Edge, RisingEdge, FallingEdge, Join, ReadOnly
+from cocotb.triggers import ClockCycles, Sequential, RepeatNTriggers, Combine
+from cocotb.result import TestFailure, ReturnValue
+
+import sys
+
+@cocotb.coroutine
+def clock_gen(signal, per):
+    for c in range(2*100):
+        signal <= 0
+        yield Timer(per // 2)
+        signal <= 1
+        yield Timer(per // 2)
+
+class Testbench:
+    def __init__(self, dut):
+        self._dut = dut
+        cocotb.fork(clock_gen(dut.clk, 1000))
+        cocotb.fork(self.datagen(dut))
+
+    @cocotb.coroutine
+    def datagen(self, dut):
+        dut.stream_in_data <= 0
+        dut.stream_in_valid <= 0
+        dut.stream_in_func_en <= 1
+        dut.stream_out_ready <= 1
+        for c in range(2):
+            yield RisingEdge(dut.clk)
+        for d in range(128):
+            yield RisingEdge(dut.clk)
+            yield Timer(1)
+            dut.stream_in_data <= d
+            dut.stream_in_valid <= 1
+            print 'Data set to',d
+            yield RisingEdge(dut.clk)
+            yield Timer(1)
+            dut.stream_in_data <= 0
+            dut.stream_in_valid <= 0
+
+
+@cocotb.test()
+def issue_520_clockcycles(dut):
+    """ ClockCycles should work for both rising and falling edges """
+    tb = Testbench(dut)
+    yield ClockCycles(dut.clk, 10, rising=True)
+    #print 'Back from yield'
+    yield ClockCycles(dut.clk, 10, rising=False)
+    #print 'Back from yield again'
+
+@cocotb.test()
+def issue_520_sequential(dut):
+    """ Use a sequential trigger composed of 3 sub-triggers, one of which is also a layered trigger """
+    tb = Testbench(dut)
+    yield Sequential(RisingEdge(dut.stream_out_valid),
+                     ClockCycles(dut.clk, 8), ReadOnly())
+    #yield ReadOnly()
+    #print 'Back from yield', dut.stream_out_valid.value, int(dut.stream_out_data_registered)
+    if not dut.stream_out_valid.value:
+        raise TestFailure("valid should be low on even clock cycles after first valid edge")
+    if int(dut.stream_out_data_registered) != 8 // 2:
+        raise TestFailure("Data value mismatch")
+
+    yield RisingEdge(dut.clk)
+    yield ReadOnly()
+    if dut.stream_out_valid.value:
+        raise TestFailure("valid should be high on odd clock cycles after first valid edge")
+    if int(dut.stream_out_data_registered) != 0:
+        raise TestFailure("Data value mismatch")
+
+
+@cocotb.test()
+def issue_520_repeatN(dut):
+    """ Demonstrate RepeatNTriggers """
+    tb = Testbench(dut)
+    yield RisingEdge(dut.stream_out_valid)
+    yield RepeatNTriggers(ClockCycles(dut.clk, 7), 4)
+    yield ReadOnly()
+
+    if not dut.stream_out_valid.value:
+        raise TestFailure("valid should be low on odd clock cycles after first valid")
+    print 'value:', int(dut.stream_out_data_registered)
+    if int(dut.stream_out_data_registered) != 7*4 // 2:
+        raise TestFailure("Data value mismatch")
+
+    yield RisingEdge(dut.clk)
+    yield ReadOnly()
+    if dut.stream_out_valid.value:
+        raise TestFailure("valid should be high on even clock cycles after first valid")
+    if int(dut.stream_out_data_registered) != 0:
+        raise TestFailure("Data value mismatch")
+
+
+@cocotb.test()
+def issue_520_Combine(dut):
+    """ Demonstrate RepeatNTriggers """
+    tb = Testbench(dut)
+    yield RisingEdge(dut.stream_out_valid)
+    # Test Combine.  The ClockCycles will be the last element to finish, result same as RepeatN above
+    yield Combine(RisingEdge(dut.stream_out_valid), ClockCycles(dut.clk, 7*4), FallingEdge(dut.clk))
+    yield ReadOnly()
+
+    if not dut.stream_out_valid.value:
+        raise TestFailure("valid should be low on odd clock cycles after first valid")
+    print 'value:', int(dut.stream_out_data_registered)
+    if int(dut.stream_out_data_registered) != 7*4 // 2:
+        raise TestFailure("Data value mismatch")
+
+    yield RisingEdge(dut.clk)
+    yield ReadOnly()
+    if dut.stream_out_valid.value:
+        raise TestFailure("valid should be high on even clock cycles after first valid")
+    if int(dut.stream_out_data_registered) != 0:
+        raise TestFailure("Data value mismatch")
+
+

--- a/tests/test_cases/issue_520/issue_520.py
+++ b/tests/test_cases/issue_520/issue_520.py
@@ -24,7 +24,6 @@ class Testbench:
     def datagen(self, dut):
         dut.stream_in_data <= 0
         dut.stream_in_valid <= 0
-        dut.stream_in_func_en <= 1
         dut.stream_out_ready <= 1
         for c in range(2):
             yield RisingEdge(dut.clk)


### PR DESCRIPTION
My cocotb testbenches currently all depend on @putsplut's  PR #538, which adds support for multi-layer, hierarchical triggers. This solves, for example, a conflict between the RisingEdge and ClockCycles trigger when they're listening on the same signal-- see issue #520.

Unfortunately I am not sure what the status of that pull request is-- it does not merge without conflicts into current master. So I decided to do the rebase myself and open a new pull request.

My hope is that by sorting out the merge conflicts, it will be easier for this branch to finally be merged.

I am reasonably confident I did the rebase correctly-- in order to try and validate that, I have ran the following:

* The full set of cocotb tests on Icarus Verilog, which all passed.
* The full set of cocotb tests on Cadence IUS. These didn't all pass, but I think this is because of unrelated problems like [this issue](https://github.com/potentialventures/cocotb/issues/595)-- they weren't all passing before, so this isn't surprising.
* The new tests added in this pull request (```tests/issue_520```), which *do* pass when ran on IUS.
* Our own testbenches, which all assume this feature works (i.e. that the ClockCycles and RisingEdge triggers can listen on the same signal when ran in separate coroutines). They appear to be functioning as expected.

Additional tests on other simulators would be appreciated!