### PR TITLE
Fix cocotb on Python 3.7

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -65,6 +65,7 @@ class SimBaseLog(logging.getLoggerClass()):
         else:
             hdlr.setFormatter(SimLogFormatter())
             self.colour = False
+        self._cache = {}
         self.name = name
         self.handlers = []
         self.disabled = False


### PR DESCRIPTION
Fix the following error on Python 3.7:

```
Traceback (most recent call last):
  File "/run/media/andy/Data/Autocopter/fpga/rectification/cocotb/cocotb/__init__.py", line 68, in <module>
    log.setLevel(_default_log)
  File "/usr/lib/python3.7/logging/__init__.py", line 1308, in setLevel
    self.manager._clear_cache()
  File "/usr/lib/python3.7/logging/__init__.py", line 1267, in _clear_cache
    logger._cache.clear()
AttributeError: 'SimBaseLog' object has no attribute '_cache'
```