### PR TITLE
BUG: Fix RuntimeErrors on python 3.7

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -60,7 +60,7 @@ public(public)  # Emulate decorating ourself
 
 
 @public
-class CoroutineComplete(StopIteration):
+class CoroutineComplete(Exception):
     """
         To ensure that a coroutine has completed before we fire any triggers
         that are blocked waiting for the coroutine to end, we create a subclass
@@ -68,7 +68,7 @@ class CoroutineComplete(StopIteration):
         here.
     """
     def __init__(self, text="", callback=None):
-        StopIteration.__init__(self, text)
+        Exception.__init__(self, text)
         self.callback = callback
 
 

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -66,14 +66,12 @@ def create_error(obj, msg):
     return TestError("Creating error traceback failed")
 
 
-class ReturnValue(StopIteration):
+class ReturnValue(Exception):
     def __init__(self, retval):
-        # The base class in python >= 3.3 holds a return value too
-        super(ReturnValue, self).__init__(retval)
         self.retval = retval
 
 
-class TestComplete(StopIteration):
+class TestComplete(Exception):
     """
         Exceptions are used to pass test results around.
     """
@@ -83,7 +81,7 @@ class TestComplete(StopIteration):
         self.stderr = StringIO()
 
 
-class ExternalException(StopIteration):
+class ExternalException(Exception):
     def __init__(self, exception):
         self.exception = exception
 


### PR DESCRIPTION
PEP 479 makes it illegal to manually throw StopIteration in a generator, which in turn makes all of the `cocotb.result.*` exceptions unusable.:
```python
@cocotb.coroutine
def my_test():
    yield Timer(100)
    raise TestSuccess()  # converts into a RuntimeError in python 3.7, because `issubclass(TestSuccess, StopIteration)
```


This emits warnings from python 3.6, and is an error on 3.7 (or with `from __future__ import generator_stop` on 3.6)

The simple fix here is to just not derive from StopIteration.

https://www.python.org/dev/peps/pep-0479/