### PR TITLE
issue #658 - split up travis tests, make docker independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: python
 cache: pip
 
-#mainly for flake8 as everything else runs in docker
+# mainly for flake8 as everything else runs in docker
 python: 
   - 3.5
 
@@ -15,7 +15,7 @@ services:
 
 jobs:
   include:
-    - stage: PythonTests
+    - stage: PythonLint
       install: pip install flake8
       script: flake8 --exit-zero cocotb/
     - stage: SimTests
@@ -37,7 +37,7 @@ jobs:
         - COCOTB_PY35
       before_install: *docker_prep 
       script:
-        - echo 'Running cocotb tests with python 35' ... && echo -en 'travis_fold:start:cocotb_py35'
+        - echo 'Running cocotb tests with Python 3.5 ...' && echo -en 'travis_fold:start:cocotb_py35'
         - docker exec -it -e TRAVIS=true -e COCOTB=/build-py3/src cocotb bash -lc 'set -x; source /build-py3/venv/bin/activate; make -C /build-py3/src test'
         - echo 'travis_fold:end:cocotb_py35'
-        
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,43 @@
 # See Dockerfile for the full build instructions
 sudo: required
-language: cpp
+language: python
+cache: pip
+
+#mainly for flake8 as everything else runs in docker
+python: 
+  - 3.5
+
+git:
+  quiet: true
 
 services:
   - docker
 
-script:
-  - docker build .
-
+jobs:
+  include:
+    - stage: PythonTests
+      install: pip install flake8
+      script: flake8 --exit-zero cocotb/
+    - stage: SimTests
+      # env only here for easier visibiliyt in travis-ci
+      env:
+        - COCOTB_PY27
+      before_install: &docker_prep
+        - docker build -t cocotb .
+        - docker images -a
+        - docker run -d --name cocotb cocotb tail -f /dev/null
+        - docker ps -a
+      script:
+        - echo 'Running cocotb tests with python 27 ...' && echo 'travis_fold:start:cocotb_py27' 
+        - docker exec -it -e TRAVIS=true -e COCOTB=/build-py2/src cocotb bash -lc 'source /build-py2/venv/bin/activate; make -C /build-py2/src test'
+        - echo -e 'travis_fold:end:cocotb_py27'
+    - stage: SimTests
+      # env only here for easier visibiliyt in travis-ci
+      env:
+        - COCOTB_PY35
+      before_install: *docker_prep 
+      script:
+        - echo 'Running cocotb tests with python 35' ... && echo -en 'travis_fold:start:cocotb_py35'
+        - docker exec -it -e TRAVIS=true -e COCOTB=/build-py3/src cocotb bash -lc 'set -x; source /build-py3/venv/bin/activate; make -C /build-py3/src test'
+        - echo 'travis_fold:end:cocotb_py35'
+        

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       install: pip install flake8
       script: flake8 --exit-zero cocotb/
     - stage: SimTests
-      # env only here for easier visibiliyt in travis-ci
+      # env only here for easier visibility in travis-ci
       env:
         - COCOTB_PY27
       before_install: &docker_prep
@@ -32,7 +32,7 @@ jobs:
         - docker exec -it -e TRAVIS=true -e COCOTB=/build-py2/src cocotb bash -lc 'source /build-py2/venv/bin/activate; make -C /build-py2/src test'
         - echo -e 'travis_fold:end:cocotb_py27'
     - stage: SimTests
-      # env only here for easier visibiliyt in travis-ci
+      # env only here for easier visibility in travis-ci
       env:
         - COCOTB_PY35
       before_install: *docker_prep 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
         - docker run -d --name cocotb cocotb tail -f /dev/null
         - docker ps -a
       script:
-        - echo 'Running cocotb tests with python 27 ...' && echo 'travis_fold:start:cocotb_py27' 
+        - echo 'Running cocotb tests with Python 2.7 ...' && echo 'travis_fold:start:cocotb_py27' 
         - docker exec -it -e TRAVIS=true -e COCOTB=/build-py2/src cocotb bash -lc 'source /build-py2/venv/bin/activate; make -C /build-py2/src test'
         - echo -e 'travis_fold:end:cocotb_py27'
     - stage: SimTests

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,25 +7,33 @@ ARG MAKE_JOBS=-j2
 ARG ICARUS_VERILOG_VERSION=10_2 
 
 RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends \
-    wget git gperf make autoconf g++ flex bison \
-    python2.7-dev python3-dev\
-    python-pip \
-    python3 virtualenv python3-venv && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get clean && \
-    pip install --upgrade pip && \
-    g++ --version 
+       wget \
+       git \
+       gperf \
+       make \
+       autoconf \
+       g++ \
+       flex \
+       bison \
+       python2.7-dev python3-dev\
+       python-pip \
+       python3 \
+       virtualenv \
+       python3-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && pip install --upgrade pip \
+    && g++ --version
 
 # Icarus Verilog 
 ENV ICARUS_VERILOG_VERSION=${ICARUS_VERILOG_VERSION} 
 WORKDIR /usr/src/iverilog
-RUN git clone https://github.com/steveicarus/iverilog.git . && \
-    git checkout v${ICARUS_VERILOG_VERSION} && \
-    sh autoconf.sh && \
-    ./configure && \
-    make -s ${MAKE_JOBS} && \
-    make -s install && \
-    rm -r /usr/src/iverilog
+RUN git clone https://github.com/steveicarus/iverilog.git --depth=1 --branch v${ICARUS_VERILOG_VERSION} . \
+    && sh autoconf.sh \
+    && ./configure \
+    && make -s ${MAKE_JOBS} \
+    && make -s install \
+    && rm -r /usr/src/iverilog
 
 
 # make sources available in docker image - one copy per python version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,41 @@
-FROM librecores/ci-osstools:2018.1-rc1
+FROM ubuntu:16.04
 
-# make sources available in docker image
-RUN mkdir -p /src
-ADD . /src
-WORKDIR /src
+# travis-ci only provides 2
+ARG MAKE_JOBS=-j2
 
-RUN apt-get update; apt-get install -y virtualenv python3-venv python3-dev
+# Simulation 
+ARG ICARUS_VERILOG_VERSION=10_2 
 
-# Build and test using Python 2
-RUN mkdir /build-py2; cp -r /src /build-py2
-ENV COCOTB=/build-py2/src
-RUN bash -lc 'virtualenv /build-py2/venv; source /build-py2/venv/bin/activate; pip install coverage xunitparser; make -C /build-py2/src test'
+RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends \
+    wget git gperf make autoconf g++ flex bison \
+    python2.7-dev python3-dev\
+    python-pip \
+    python3 virtualenv python3-venv && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && \
+    pip install --upgrade pip && \
+    g++ --version 
 
-# Build and test using Python 3
-RUN mkdir /build-py3; cp -r /src /build-py3
-ENV COCOTB=/build-py3/src
-RUN bash -lce 'python3 -m venv /build-py3/venv; source /build-py3/venv/bin/activate; pip install coverage xunitparser; make -C /build-py3/src test'
+# Icarus Verilog 
+ENV ICARUS_VERILOG_VERSION=${ICARUS_VERILOG_VERSION} 
+WORKDIR /usr/src/iverilog
+RUN git clone https://github.com/steveicarus/iverilog.git . && \
+    git checkout v${ICARUS_VERILOG_VERSION} && \
+    sh autoconf.sh && \
+    ./configure && \
+    make -s ${MAKE_JOBS} && \
+    make -s install && \
+    rm -r /usr/src/iverilog
+
+
+# make sources available in docker image - one copy per python version
+COPY . /build-py2/src
+COPY . /build-py3/src
+
+# Build and prepare using Python 2
+RUN bash -c 'virtualenv /build-py2/venv; source /build-py2/venv/bin/activate; pip install coverage xunitparser; deactivate'
+
+# Build and prepare virtual env using Python 3
+RUN bash -c 'python3 -m venv /build-py3/venv; source /build-py3/venv/bin/activate; pip install coverage xunitparser; deactivate'
+
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -34,7 +34,15 @@ REGRESSIONS :=  $(shell ls test_cases/)
 all: $(REGRESSIONS)
 
 $(REGRESSIONS):
+ifeq ($(TRAVIS),true)
+	@echo "travs_fold:start:$@"
+endif
 	cd test_cases/$@ && $(MAKE)
+ifeq ($(TRAVIS),true)
+	@echo "travs_fold:end:$@"
+endif
+
+
 
 clean:
 	$(foreach TEST, $(REGRESSIONS), $(MAKE) -C test_cases/$(TEST) clean;)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -35,11 +35,11 @@ all: $(REGRESSIONS)
 
 $(REGRESSIONS):
 ifeq ($(TRAVIS),true)
-	@echo "travs_fold:start:$@"
+	@echo "travis_fold:start:$@"
 endif
 	cd test_cases/$@ && $(MAKE)
 ifeq ($(TRAVIS),true)
-	@echo "travs_fold:end:$@"
+	@echo "travis_fold:end:$@"
 endif
 
 


### PR DESCRIPTION
* split up py27 and py35 sims into indepentent tests
* fold travis output for better readability
* add flake8 test (marked with --exit-zero otherwise cocotb would fail)

see: https://travis-ci.com/s3bs/cocotb/builds/83579077

building our own version of iverilog 
the addition of flake8 is meant to start a discussion around pep8. 
#658 