### PR TITLE
Fix missing stack traces when stdout/stderr is a pipe

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -37,13 +37,6 @@ import threading
 import random
 import time
 
-# If stdout/stderr are not line buffered because they're pipes, make them line
-# buffered now to ensure that prints such as stack traces always appear.
-if not sys.stdout.line_buffering:
-    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 1)
-if not sys.stderr.line_buffering:
-    sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 1)
-
 import cocotb.handle
 from cocotb.scheduler import Scheduler
 from cocotb.log import SimLogFormatter, SimBaseLog, SimLog
@@ -75,6 +68,21 @@ if "SPHINX_BUILD" not in os.environ:
     loggpi = SimLog('cocotb.gpi')
     # Notify GPI of log level
     simulator.log_level(_default_log)
+
+    # If stdout/stderr are not TTYs, Python may not have opened them with line
+    # buffering. In that case, try to reopen them with line buffering
+    # explicitly enabled. This ensures that prints such as stack traces always
+    # appear. Continue silently if this fails.
+    try:
+        if not sys.stdout.isatty():
+            sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 1)
+            log.debug("Reopened stdout with line buffering")
+        if not sys.stderr.isatty():
+            sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 1)
+            log.debug("Reopened stderr with line buffering")
+    except Exception as e:
+        log.warning("Failed to ensure that stdout/stderr are line buffered: %s", e)
+        log.warning("Some stack traces may not appear because of this.")
 
 
 scheduler = Scheduler()

--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -37,6 +37,12 @@ import threading
 import random
 import time
 
+# If stdout/stderr are not line buffered because they're pipes, make them line
+# buffered now to ensure that prints such as stack traces always appear.
+if not sys.stdout.line_buffering:
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 1)
+if not sys.stderr.line_buffering:
+    sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 1)
 
 import cocotb.handle
 from cocotb.scheduler import Scheduler

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -91,14 +91,6 @@ class RegressionManager(object):
         self._hooks = hooks
 
     def initialise(self):
-        try:
-            self._initialise()
-        except Exception as e:
-            import traceback
-            self.log.error(traceback.format_exc())
-            raise
-        
-    def _initialise(self):
 
         self.start_time = time.time()
         self.test_results = []


### PR DESCRIPTION
At least in Aldec Riviera with the `-interceptcoutput` command line flag, Python exceptions caught or generated by the C layer were never printed. This is apparently because stderr was not buffered and is never flushed. With this change stdout/stderr are guaranteed to be line-buffered. This at least makes #619 redundant (the exception is printed twice with this, so I reverted that one in this PR), and I'm guessing a lot of other missing errors for which special cases were made are also resolved by this.