### PR TITLE
Fix AvalonSTPkts _send_string

### DIFF
--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -573,6 +573,7 @@ class AvalonSTPkts(ValidatedBusDriver):
 
         # Drive some defaults since we don't know what state we're in
         # self.bus.empty <= 0
+        yield NextTimeStep()
         self.bus.startofpacket <= 0
         self.bus.endofpacket <= 0
         self.bus.valid <= 0


### PR DESCRIPTION
As pointed out by issue #662 the ping tun tap example crashes, because a write
is attempted during a read-only phase. This fix was inspired by the discussion
on issue #537. It waits for the NExtTimeStep before driving default values on the
bus in AvalonSTPkts::_send_string