### PR TITLE
Allow ordering of tests by stage

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -173,6 +173,11 @@ class RunningCoroutine(object):
             otherwise return true"""
         return not self._finished
 
+    def sort_name(self):
+        if self.stage is None:
+            return "%s.%s" % (self.module, self.funcname)
+        else:
+            return "%s.%d.%s" % (self.module, self.stage, self.funcname)
 
 class RunningTest(RunningCoroutine):
     """Add some useful Test functionality to a RunningCoroutine"""
@@ -383,7 +388,7 @@ class test(coroutine):
             Order tests logically into stages, where multiple tests can share a stage
     """
     def __init__(self, timeout=None, expect_fail=False, expect_error=False,
-                 skip=False, stage=0):
+                 skip=False, stage=None):
         self.timeout = timeout
         self.expect_fail = expect_fail
         self.expect_error = expect_error

--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -194,6 +194,7 @@ class RunningTest(RunningCoroutine):
         self.expect_fail = parent.expect_fail
         self.expect_error = parent.expect_error
         self.skip = parent.skip
+        self.stage = parent.stage
 
         self.handler = RunningTest.ErrorLogHandler(self._handle_error_message)
         cocotb.log.addHandler(self.handler)
@@ -378,13 +379,16 @@ class test(coroutine):
             This is for cocotb internal regression use
         skip: (bool):
             Don't execute this test as part of the regression
+        stage: (int)
+            Order tests logically into stages, where multiple tests can share a stage
     """
     def __init__(self, timeout=None, expect_fail=False, expect_error=False,
-                 skip=False):
+                 skip=False, stage=0):
         self.timeout = timeout
         self.expect_fail = expect_fail
         self.expect_error = expect_error
         self.skip = skip
+        self.stage = stage
 
     def __call__(self, f):
         super(test, self).__init__(f)

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -179,13 +179,11 @@ class RegressionManager(object):
                         self._queue.append(test)
                         self.ntests += 1
 
-        self._queue.sort(key=lambda test: "%s.%i.%s" %
-                         (test.module, test.stage, test.funcname))
+        self._queue.sort(key=lambda test: test.sort_name())
 
         for valid_tests in self._queue:
-            self.log.info("Found test %s.%i.%s" %
+            self.log.info("Found test %s.%s" %
                           (valid_tests.module,
-                           valid_tests.stage,
                            valid_tests.funcname))
 
         for module_name in self._hooks:

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -179,12 +179,13 @@ class RegressionManager(object):
                         self._queue.append(test)
                         self.ntests += 1
 
-        self._queue.sort(key=lambda test: "%s.%s" %
-                         (test.module, test.funcname))
+        self._queue.sort(key=lambda test: "%s.%i.%s" %
+                         (test.module, test.stage, test.funcname))
 
         for valid_tests in self._queue:
-            self.log.info("Found test %s.%s" %
+            self.log.info("Found test %s.%i.%s" %
                           (valid_tests.module,
+                           valid_tests.stage,
                            valid_tests.funcname))
 
         for module_name in self._hooks:


### PR DESCRIPTION
To allow some logical sorting of tests, add a stage parameter to the
decorator. This can be used to ease the analysis of output files or
the test outputs.

The stage has no other functionality except sorting.