### PR TITLE
trivial: Don't try to print results if none there

### DIFF
--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -213,7 +213,8 @@ class RegressionManager(object):
             self.log.info("Writing coverage data")
             self._cov.save()
             self._cov.html_report()
-        self._log_test_summary()
+        if len(self.test_results) > 0:
+            self._log_test_summary()
         self._log_sim_summary()
         self.log.info("Shutting down...")
         self.xunit.write()


### PR DESCRIPTION
If self.test_results contains no elements, the calculation of the
lengths of the fields fails. Don't try to print the results then at
all.