### PR TITLE
Add Memory and MemoryWord to recognized array like handles (Fix for issue #685)

### DIFF
--- a/lib/vpi/VpiImpl.cpp
+++ b/lib/vpi/VpiImpl.cpp
@@ -78,6 +78,7 @@ gpi_objtype_t to_gpi_objtype(int32_t vpitype)
         case vpiNetBit:
         case vpiReg:
         case vpiRegBit:
+        case vpiMemoryWord:
             return GPI_REGISTER;
 
         case vpiRealVar:
@@ -88,6 +89,7 @@ gpi_objtype_t to_gpi_objtype(int32_t vpitype)
         case vpiRegArray:
         case vpiNetArray:
         case vpiGenScopeArray:
+        case vpiMemory:
             return GPI_ARRAY;
 
         case vpiEnumNet:
@@ -152,6 +154,7 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiIntegerVar:
         case vpiIntegerNet:
         case vpiRealVar:
+        case vpiMemoryWord:
             new_obj = new VpiSignalObjHdl(this, new_hdl, to_gpi_objtype(type), false);
             break;
         case vpiParameter:
@@ -161,6 +164,7 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
         case vpiNetArray:
         case vpiInterfaceArray:
         case vpiPackedArrayVar:
+        case vpiMemory:
             new_obj = new VpiArrayObjHdl(this, new_hdl, to_gpi_objtype(type));
             break;
         case vpiStructVar:

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -103,5 +103,12 @@ for (idx = 0; idx < NUM_OF_MODULES; idx=idx+1) begin
 end
 endgenerate
 
+reg[7:0] register_array [1:0];
+always @(posedge clk) begin
+    //Ensure interanl array is not optimzed out
+    register_array[0] <= 0;
+end
+
 endmodule
+
 

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -103,9 +103,9 @@ for (idx = 0; idx < NUM_OF_MODULES; idx=idx+1) begin
 end
 endgenerate
 
-reg[7:0] register_array [1:0];
+reg [7:0] register_array [1:0];
 always @(posedge clk) begin
-    //Ensure internal array is not optimzed out
+    // Ensure internal array is not optimized out
     register_array[0] <= 0;
 end
 

--- a/tests/designs/sample_module/sample_module.sv
+++ b/tests/designs/sample_module/sample_module.sv
@@ -105,10 +105,8 @@ endgenerate
 
 reg[7:0] register_array [1:0];
 always @(posedge clk) begin
-    //Ensure interanl array is not optimzed out
+    //Ensure internal array is not optimzed out
     register_array[0] <= 0;
 end
 
 endmodule
-
-

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -308,17 +308,16 @@ def access_boolean(dut):
 @cocotb.test()
 def access_internal_register_array(dut):
     """Test access to an internal register array"""
-    tlog = logging.getLogger("cocotb.test")
 
     if (dut.register_array[0].value.binstr != "xxxxxxxx"):
-       raise TestFailure("Failed to access internal register array value")
+        raise TestFailure("Failed to access internal register array value")
 
     dut.register_array[1].setimmediatevalue(4)
     
     yield Timer(1)
 
     if (dut.register_array[1].value != 4):
-       raise TestFailure("Failed to set internal register array value")
+        raise TestFailure("Failed to set internal register array value")
 
 @cocotb.test(skip=True)
 def skip_a_test(dut):

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -305,6 +305,20 @@ def access_boolean(dut):
     if (int(curr_val) == int(output_bool)):
         raise TestFailure("Value did not propogate")
 
+@cocotb.test()
+def access_internal_register_array(dut):
+    """Test access to an internal register array"""
+    tlog = logging.getLogger("cocotb.test")
+
+    if(dut.register_array[0].value.binstr != "xxxxxxxx"):
+       raise TestFailure("Failed to access internal register array value")
+
+    dut.register_array[1].setimmediatevalue(4)
+    
+    yield Timer(1)
+
+    if(dut.register_array[1].value !=4):
+       raise TestFailure("Failed to set internal register array value")
 
 @cocotb.test(skip=True)
 def skip_a_test(dut):
@@ -364,3 +378,4 @@ def custom_type(dut):
 
     if expected_top != count:
         raise TestFailure("Expected %d found %d for cosLut" % (expected_top, count))
+

--- a/tests/test_cases/test_discovery/test_discovery.py
+++ b/tests/test_cases/test_discovery/test_discovery.py
@@ -310,14 +310,14 @@ def access_internal_register_array(dut):
     """Test access to an internal register array"""
     tlog = logging.getLogger("cocotb.test")
 
-    if(dut.register_array[0].value.binstr != "xxxxxxxx"):
+    if (dut.register_array[0].value.binstr != "xxxxxxxx"):
        raise TestFailure("Failed to access internal register array value")
 
     dut.register_array[1].setimmediatevalue(4)
     
     yield Timer(1)
 
-    if(dut.register_array[1].value !=4):
+    if (dut.register_array[1].value != 4):
        raise TestFailure("Failed to set internal register array value")
 
 @cocotb.test(skip=True)


### PR DESCRIPTION
Necessary to introspect register arrays in Icarus Verilog. Conforms to VPI spec.