### PR TITLE
Log simplification

### DIFF
--- a/tests/test_cases/test_external/test_external.py
+++ b/tests/test_cases/test_external/test_external.py
@@ -169,7 +169,7 @@ def test_ext_function_return(dut):
 def test_print_sim_time(dut, base_time):
     # We are not calling out here so time should not advance
     # And should also remain consistent
-    for _ in range(10):
+    for _ in range(5):
         _t = get_sim_time('ns')
         dut._log.info("Time reported = %d", _t)
         if _t != base_time:
@@ -194,7 +194,7 @@ def test_time_in_external(dut):
     yield Timer(10, 'ns')
     time = get_sim_time('ns')
     dut._log.info("Time at start of test = %d" % time)
-    for i in range(1000):
+    for i in range(100):
         dut._log.info("Loop call %d" % i)
         yield external(test_print_sim_time)(dut, time)
 


### PR DESCRIPTION
Travis-CI starts complaining about the log size. Seems that in Travis it is not possible to set it >4MB, so test results logs need to be simplified. There was one test producing in particular a lot of data :)