### PR TITLE
Log the exception type, not just the message

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -137,7 +137,7 @@ class RunningCoroutine(object):
             raise CoroutineComplete(callback=self._finished_cb)
         except Exception as e:
             self._finished = True
-            raise raise_error(self, "Send raised exception: %s" % (str(e)))
+            raise raise_error(self, "Send raised exception:")
 
     def throw(self, exc):
         return self._coro.throw(exc)
@@ -232,7 +232,7 @@ class RunningTest(RunningCoroutine):
         except StopIteration:
             raise TestSuccess()
         except Exception as e:
-            raise raise_error(self, "Send raised exception: %s" % (str(e)))
+            raise raise_error(self, "Send raised exception:")
 
     def _handle_error_message(self, msg):
         self.error_messages.append(msg)
@@ -359,7 +359,7 @@ class hook(coroutine):
             try:
                 return RunningCoroutine(self._func(*args, **kwargs), self)
             except Exception as e:
-                raise raise_error(self, str(e))
+                raise raise_error(self, "Hook raised exception:")
 
         _wrapped_hook.im_hook = True
         _wrapped_hook.name = self._func.__name__
@@ -402,7 +402,7 @@ class test(coroutine):
             try:
                 return RunningTest(self._func(*args, **kwargs), self)
             except Exception as e:
-                raise raise_error(self, str(e))
+                raise raise_error(self, "Test raised exception:")
 
         _wrapped_test.im_test = True    # For auto-regressions
         _wrapped_test.name = self._func.__name__

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -39,14 +39,14 @@ def raise_error(obj, msg):
         obj has a log method
         msg is a string
     """
-    exc_type, exc_value, exc_traceback = sys.exc_info()
+    exc_info = sys.exc_info()
     # 2.6 cannot use named access
     if sys.version_info[0] >= 3:
         buff = StringIO()
-        traceback.print_tb(exc_traceback, file=buff)
+        traceback.print_exception(*exc_info, file=buff)
     else:
         buff_bytes = BytesIO()
-        traceback.print_tb(exc_traceback, file=buff_bytes)
+        traceback.print_exception(*exc_info, file=buff_bytes)
         buff = StringIO(buff_bytes.getvalue().decode("UTF-8"))
     obj.log.error("%s\n%s" % (msg, buff.getvalue()))
     exception = TestError(msg)


### PR DESCRIPTION
Previously this would omit an important part of the exception, the type!

Extracted from #640