### PR TITLE
Improve error message when unscheduling a previously unscheduled coroutine (Fixed #650)

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -93,6 +93,7 @@ class RunningCoroutine(object):
         self._coro = inst
         self._started = False
         self._finished = False
+        self._unscheduled = False
         self._callbacks = []
         self._join = _Join(self)
         self._parent = parent
@@ -147,8 +148,13 @@ class RunningCoroutine(object):
 
     def kill(self):
         """Kill a coroutine"""
+        if self._unscheduled:
+            error_msg = "Attempted to kill a previously unscheduled coroutine."
+            raise raise_error(self, error_msg)
+
         self.log.debug("kill() called on coroutine")
         cocotb.scheduler.unschedule(self)
+        self._unscheduled = True
 
     def _finished_cb(self):
         """Called when the coroutine completes.

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -669,6 +669,30 @@ def test_binary_value(dut):
 
     yield Timer(100)  # Make it do something with time
 
+@cocotb.test()
+def test_error_message_on_multiple_unschedule(dut):
+    """
+    Test error messaging on an unsupported attempt to unschedule a previously
+    unscheduled coroutine.
+    """
+
+    clk_gen = cocotb.fork(Clock(dut.clk, 100).start())
+
+    clk_gen.kill()
+
+    def fail_test():
+         raise TestFailure(
+            "Expected an error on attempt to kill a coroutine twice.")
+
+    try:
+        clk_gen.kill()
+    except TestError as e:
+        if e.args != ("Attempted to kill a previously unscheduled coroutine.",):
+            fail_test()
+        else:
+            yield RisingEdge(dut.clk)
+    else:
+        fail_test()
 
 if sys.version_info[:2] >= (3, 3):
     # this would be a syntax error in older python, so we do the whole


### PR DESCRIPTION
…utine.

Unscheduling a coroutine is not idempotent and successive attempts likely indicate a test defect. The current error message is an unintentional artifact of the RunningCoroutine implementation.

#650 