### PR TITLE
Use weakref to deal with GC issues in .join(), rather than trying to clean up ourselves

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -37,7 +37,7 @@ from io import StringIO, BytesIO
 
 import cocotb
 from cocotb.log import SimLog
-from cocotb.triggers import _Join, PythonTrigger, Timer, Event, NullTrigger, Join
+from cocotb.triggers import Join, PythonTrigger, Timer, Event, NullTrigger
 from cocotb.result import (TestComplete, TestError, TestFailure, TestSuccess,
                            ReturnValue, raise_error, ExternalException)
 from cocotb.utils import get_sim_time
@@ -94,7 +94,6 @@ class RunningCoroutine(object):
         self._started = False
         self._finished = False
         self._callbacks = []
-        self._join = _Join(self)
         self._parent = parent
         self.__doc__ = parent._func.__doc__
         self.module = parent._func.__module__
@@ -159,10 +158,7 @@ class RunningCoroutine(object):
 
     def join(self):
         """Return a trigger that will fire when the wrapped coroutine exits"""
-        if self._finished:
-            return NullTrigger()
-        else:
-            return self._join
+        return Join(self)
 
     def has_started(self):
         return self._started

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -67,7 +67,7 @@ else:
 import cocotb
 import cocotb.decorators
 from cocotb.triggers import (Trigger, GPITrigger, Timer, ReadOnly, PythonTrigger,
-                             _NextTimeStep, _ReadWrite, Event, NullTrigger)
+                             _NextTimeStep, _ReadWrite, Event, Join)
 from cocotb.log import SimLog
 from cocotb.result import (TestComplete, TestError, ReturnValue, raise_error,
                            create_error, ExternalException)
@@ -450,11 +450,9 @@ class Scheduler(object):
                 del self._trigger2coros[trigger]
         del self._coro2triggers[coro]
 
-        if coro._join in self._trigger2coros:
-            self._pending_triggers.append(coro._join)
+        if Join(coro) in self._trigger2coros:
+            self._pending_triggers.append(Join(coro))
 
-        # Remove references to allow GC to clean up
-        del coro._join
 
     def save_write(self, handle, value):
         if self._mode == Scheduler._MODE_READONLY:


### PR DESCRIPTION
This prevents the error messages in #650.

It also:
* Fixes a bug where `coro.join()` returns the result the first time, but `None` on subsequent times
* Replaces four ways to spell join (`coro._join`, `coro.join()`, `_Join(coro)`, `Join(coro)`) with two (`coro.join()`, `Join(coro)`)