### PR TITLE
Make SVG images in PDF doc work

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     'sphinx.ext.todo', 
     'sphinx.ext.coverage', 
     'sphinx.ext.pngmath', 
+    'sphinx.ext.imgconverter', 
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
     ]

--- a/documentation/source/endian_swapper.rst
+++ b/documentation/source/endian_swapper.rst
@@ -17,7 +17,7 @@ Design
 
 We have a relatively simplistic RTL block called the endian_swapper.  The DUT has three interfaces, all conforming to the Avalon standard:
 
-.. image:: diagrams/svg/endian_swapper_design.*
+.. image:: diagrams/svg/endian_swapper_design.svg
 
 The DUT will swap the endianness of packets on the Avalon-ST bus if a configuration bit is set.  For every packet arriving on the "stream_in" interface the entire packet will be endian swapped if the configuration bit is set, otherwise the entire packet will pass through unmodified.
 
@@ -46,7 +46,7 @@ To begin with we create a class to encapsulate all the common code for the testb
 
 With the above code we have created a testbench with the following structure:
 
-.. image:: diagrams/svg/endian_swapper_testbench.*
+.. image:: diagrams/svg/endian_swapper_testbench.svg
 
 If we inspect this line-by-line:
 

--- a/documentation/source/hal_cosimulation.rst
+++ b/documentation/source/hal_cosimulation.rst
@@ -60,7 +60,7 @@ decorator turns a normal function that isn't a `coroutine` into a blocking
 to be called by a normal thread.  The call sequence looks like this:
 
 
-.. image:: diagrams/svg/hal_cosimulation.*
+.. image:: diagrams/svg/hal_cosimulation.svg
 
 
 Implementation

--- a/documentation/source/introduction.rst
+++ b/documentation/source/introduction.rst
@@ -63,7 +63,7 @@ Overview
 A typical cocotb testbench requires no additional RTL code. The Design Under Test (DUT) is instantiated as the toplevel in the simulator without any wrapper code. Cocotb drives stimulus onto the inputs to the DUT (or further down the hierarchy) and monitors the outputs directly from Python.
 
 
-.. image:: diagrams/svg/cocotb_overview.*
+.. image:: diagrams/svg/cocotb_overview.svg
 
 A test is simply a Python function.  At any given time either the simulator is advancing time or the Python code is executing.  The **yield** keyword is used to indicate when to pass control of execution back to the simulator.  A test can spawn multiple coroutines, allowing for independent flows of execution.
 

--- a/documentation/source/ping_tun_tap.rst
+++ b/documentation/source/ping_tun_tap.rst
@@ -31,7 +31,7 @@ Linux has a `TUN/TAP`_ virtual network device which we can use for this
 purpose, allowing `ping`_ to run unmodified and unaware that it is
 communicating with our simulation rather than a remote network endpoint.
 
-.. image:: diagrams/svg/ping_tun_tap.*
+.. image:: diagrams/svg/ping_tun_tap.svg
 
 
 Implementation


### PR DESCRIPTION
Fixes #738.
This is untested because it needs to run through a readthedocs build to see if all is fine.
The SVG vector graphics will become bitmaps (see the note in http://www.sphinx-doc.org/en/master/usage/extensions/imgconverter.html), but thats better than not having images at all.