### PR TITLE
Fixes #743: Check if an event has fired when waiting.

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -402,6 +402,8 @@ class Event(PythonTrigger):
     def wait(self):
         """This can be yielded to block this coroutine
         until another wakes it"""
+        if self.fired:
+            return NullTrigger()
         return _Event(self)
 
     def clear(self):


### PR DESCRIPTION
Prevents #743: hanging when `wait()` is called on an event that has already fired