### PR TITLE
Add support for vpiUnionVar

### DIFF
--- a/lib/vpi/VpiImpl.cpp
+++ b/lib/vpi/VpiImpl.cpp
@@ -107,6 +107,7 @@ gpi_objtype_t to_gpi_objtype(int32_t vpitype)
 
         case vpiStructVar:
         case vpiStructNet:
+        case vpiUnionVar:
             return GPI_STRUCTURE;
 
         case vpiModport:
@@ -169,6 +170,7 @@ GpiObjHdl* VpiImpl::create_gpi_obj_from_handle(vpiHandle new_hdl,
             break;
         case vpiStructVar:
         case vpiStructNet:
+        case vpiUnionVar:
             new_obj = new VpiObjHdl(this, new_hdl, to_gpi_objtype(type));
             break;
         case vpiModule:


### PR DESCRIPTION
SystemVerilog supports unions along with structs, these are represented in the verilog programming language interface by `vpiUnionVar`

Originally reported by @stuarthodgson 