### PR TITLE
Use the new ParametrizedSingleton for unparametrized singleton types too

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -36,6 +36,7 @@ also have pending writes we have to schedule the ReadWrite callback before
 the ReadOnly (and this is invalid, at least in Modelsim).
 """
 import collections
+import copy
 import os
 import time
 import logging
@@ -67,7 +68,7 @@ else:
 import cocotb
 import cocotb.decorators
 from cocotb.triggers import (Trigger, GPITrigger, Timer, ReadOnly, PythonTrigger,
-                             _NextTimeStep, _ReadWrite, Event, Join)
+                             NextTimeStep, ReadWrite, Event, Join)
 from cocotb.log import SimLog
 from cocotb.result import (TestComplete, TestError, ReturnValue, raise_error,
                            create_error, ExternalException)
@@ -194,8 +195,12 @@ class Scheduler(object):
 
     # Singleton events, recycled to avoid spurious object creation
     _readonly = ReadOnly()
-    _next_timestep = _NextTimeStep()
-    _readwrite = _ReadWrite()
+    # TODO[gh-759]: For some reason, the scheduler requires that these triggers
+    # are _not_ the same instances used by the tests themselves. This is risky,
+    # because it can lead to them overwriting each other's callbacks. We should
+    # try to remove this `copy.copy` in future.
+    _next_timestep = copy.copy(NextTimeStep())
+    _readwrite = copy.copy(ReadWrite())
     _timer1 = Timer(1)
     _timer0 = Timer(0)
 

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -133,11 +133,16 @@ class Timer(GPITrigger):
     def __str__(self):
         return self.__class__.__name__ + "(%1.2fps)" % get_time_from_sim_steps(self.sim_steps,units='ps')
 
-class _ReadOnly(GPITrigger):
+
+class ReadOnly(with_metaclass(ParametrizedSingleton, GPITrigger)):
     """
     Execution will resume when the readonly portion of the sim cycles is
     readched
     """
+    @classmethod
+    def __singleton_key__(cls):
+        return None
+
     def __init__(self):
         GPITrigger.__init__(self)
 
@@ -151,18 +156,16 @@ class _ReadOnly(GPITrigger):
     def __str__(self):
         return self.__class__.__name__ + "(readonly)"
 
-_ro = _ReadOnly()
 
-
-def ReadOnly():
-    return _ro
-
-
-class _ReadWrite(GPITrigger):
+class ReadWrite(with_metaclass(ParametrizedSingleton, GPITrigger)):
     """
     Execution will resume when the readwrite portion of the sim cycles is
     reached
     """
+    @classmethod
+    def __singleton_key__(cls):
+        return None
+
     def __init__(self):
         GPITrigger.__init__(self)
 
@@ -178,17 +181,15 @@ class _ReadWrite(GPITrigger):
     def __str__(self):
         return self.__class__.__name__ + "(readwritesync)"
 
-_rw = _ReadWrite()
 
-
-def ReadWrite():
-    return _rw
-
-
-class _NextTimeStep(GPITrigger):
+class NextTimeStep(with_metaclass(ParametrizedSingleton, GPITrigger)):
     """
     Execution will resume when the next time step is started
     """
+    @classmethod
+    def __singleton_key__(cls):
+        return None
+
     def __init__(self):
         GPITrigger.__init__(self)
 
@@ -201,12 +202,6 @@ class _NextTimeStep(GPITrigger):
 
     def __str__(self):
         return self.__class__.__name__ + "(nexttimestep)"
-
-_nxts = _NextTimeStep()
-
-
-def NextTimeStep():
-    return _nxts
 
 
 class _EdgeBase(with_metaclass(ParametrizedSingleton, GPITrigger)):

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -782,6 +782,21 @@ def test_edge_identity(dut):
     yield Timer(1)
 
 
+@cocotb.test()
+def test_singleton_isinstance(dut):
+    """
+    Test that the result of trigger expression have a predictable type
+    """
+    assert isinstance(RisingEdge(dut.clk), RisingEdge)
+    assert isinstance(FallingEdge(dut.clk), FallingEdge)
+    assert isinstance(Edge(dut.clk), Edge)
+    assert isinstance(NextTimestep(), NextTimestep)
+    assert isinstance(ReadOnly(), ReadOnly)
+    assert isinstance(ReadWrite(), ReadWrite)
+
+    yield Timer(1)
+
+
 if sys.version_info[:2] >= (3, 3):
     # this would be a syntax error in older python, so we do the whole
     # thing inside exec


### PR DESCRIPTION
This means that `help(ReadOnly)` and `isinstance(Readonly(), Readonly)` behave how you'd expect them too.

For some reason, the scheduler requires non-singleton instances of NextTimeStep and ReadWrite.
If normal singleton instances are used, `test_cocotb.test_readwrite_in_readonly` causes the test that follows it to fail.
This can be investigated more later.