### PR TITLE
New test case for joining forked coroutines

### DIFF
--- a/cocotb/drivers/ad9361.py
+++ b/cocotb/drivers/ad9361.py
@@ -55,9 +55,9 @@ class AD9361(BusDriver):
     @cocotb.coroutine
     def rx_data_to_ad9361(self, i_data, q_data, i_data2=None, q_data2=None,
                           binaryRepresentation=BinaryRepresentation.TWOS_COMPLEMENT):
-        i_bin_val = BinaryValue(bits=12, bigEndian=False,
+        i_bin_val = BinaryValue(n_bits=12, bigEndian=False,
                                 binaryRepresentation=binaryRepresentation)
-        q_bin_val = BinaryValue(bits=12, bigEndian=False,
+        q_bin_val = BinaryValue(n_bits=12, bigEndian=False,
                                 binaryRepresentation=binaryRepresentation)
         index = 0
         if i_data2 is None and q_data2 is None:
@@ -132,8 +132,8 @@ class AD9361(BusDriver):
 
     @cocotb.coroutine
     def _tx_data_from_ad9361(self):
-        i_bin_val = BinaryValue(bits=12, bigEndian=False)
-        q_bin_val = BinaryValue(bits=12, bigEndian=False)
+        i_bin_val = BinaryValue(n_bits=12, bigEndian=False)
+        q_bin_val = BinaryValue(n_bits=12, bigEndian=False)
         while True:
             yield RisingEdge(self.dut.tx_clk_out_p)
             if self.dut.tx_frame_out_p.value.integer == 1:
@@ -154,8 +154,8 @@ class AD9361(BusDriver):
     @cocotb.coroutine
     def _ad9361_tx_to_rx_loopback(self):
         cocotb.fork(self._tx_data_from_ad9361())
-        i_bin_val = BinaryValue(bits=12, bigEndian=False)
-        q_bin_val = BinaryValue(bits=12, bigEndian=False)
+        i_bin_val = BinaryValue(n_bits=12, bigEndian=False)
+        q_bin_val = BinaryValue(n_bits=12, bigEndian=False)
         while True:
             yield RisingEdge(self.dut.rx_clk_in_p)
             if self.rx_frame_asserted:

--- a/cocotb/drivers/amba.py
+++ b/cocotb/drivers/amba.py
@@ -264,7 +264,7 @@ class AXI4Slave(BusDriver):
             burst_length = _awlen + 1
             bytes_in_beat = self._size_to_bytes_in_beat(_awsize)
 
-            word = BinaryValue(bits=bytes_in_beat*8, bigEndian=self.big_endian)
+            word = BinaryValue(n_bits=bytes_in_beat*8, bigEndian=self.big_endian)
 
             if __debug__:
                 self.log.debug(
@@ -313,7 +313,7 @@ class AXI4Slave(BusDriver):
             burst_length = _arlen + 1
             bytes_in_beat = self._size_to_bytes_in_beat(_arsize)
 
-            word = BinaryValue(bits=bytes_in_beat*8, bigEndian=self.big_endian)
+            word = BinaryValue(n_bits=bytes_in_beat*8, bigEndian=self.big_endian)
 
             if __debug__:
                 self.log.debug(

--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -274,7 +274,7 @@ class AvalonMemory(BusDriver):
         else:
             self._mem = memory
 
-        self._val = BinaryValue(bits=self._width, bigEndian=False)
+        self._val = BinaryValue(n_bits=self._width, bigEndian=False)
         self._readlatency_min = readlatency_min
         self._readlatency_max = readlatency_max
         self._responses = []
@@ -513,7 +513,7 @@ class AvalonST(ValidatedBusDriver):
             self.config[configoption] = value
             self.log.debug("Setting config option %s to %s" % (configoption, str(value)))
 
-        word = BinaryValue(bits=len(self.bus.data), bigEndian=self.config['firstSymbolInHighOrderBits'])
+        word = BinaryValue(n_bits=len(self.bus.data), bigEndian=self.config['firstSymbolInHighOrderBits'])
 
         self.bus.valid  <= 0
         self.bus.data   <= word
@@ -543,7 +543,7 @@ class AvalonST(ValidatedBusDriver):
         # Avoid spurious object creation by recycling
         clkedge = RisingEdge(self.clock)
 
-        word = BinaryValue(bits=len(self.bus.data), bigEndian=False)
+        word = BinaryValue(n_bits=len(self.bus.data), bigEndian=False)
 
         # Drive some defaults since we don't know what state we're in
         self.bus.valid <= 0
@@ -618,10 +618,10 @@ class AvalonSTPkts(ValidatedBusDriver):
         self.use_empty = (num_data_symbols > 1)
         self.config["useEmpty"] = self.use_empty
 
-        word   = BinaryValue(bits=len(self.bus.data),
+        word   = BinaryValue(n_bits=len(self.bus.data),
                              bigEndian=self.config['firstSymbolInHighOrderBits'])
 
-        single = BinaryValue(bits=1, bigEndian=False)
+        single = BinaryValue(n_bits=1, bigEndian=False)
 
         word.binstr   = ("x"*len(self.bus.data))
         single.binstr = ("x")
@@ -632,7 +632,7 @@ class AvalonSTPkts(ValidatedBusDriver):
         self.bus.endofpacket <= single
 
         if self.use_empty:
-            empty = BinaryValue(bits=len(self.bus.empty), bigEndian=False)
+            empty = BinaryValue(n_bits=len(self.bus.empty), bigEndian=False)
             empty.binstr  = ("x"*len(self.bus.empty))
             self.bus.empty <= empty
 
@@ -647,7 +647,7 @@ class AvalonSTPkts(ValidatedBusDriver):
                 raise AttributeError(
                         "%s has maxChannel=%d, but can only support a maximum channel of (2**channel_width)-1=%d, channel_width=%d" %
                         (self.name,self.config['maxChannel'],maxChannel,len(self.bus.channel)))
-            channel = BinaryValue(bits=len(self.bus.channel), bigEndian=False)
+            channel = BinaryValue(n_bits=len(self.bus.channel), bigEndian=False)
             channel.binstr = ("x"*len(self.bus.channel))
             self.bus.channel <= channel
 
@@ -678,12 +678,12 @@ class AvalonSTPkts(ValidatedBusDriver):
         # FIXME busses that aren't integer numbers of bytes
         bus_width = int(len(self.bus.data) / 8)
 
-        word = BinaryValue(bits=len(self.bus.data),
+        word = BinaryValue(n_bits=len(self.bus.data),
                            bigEndian=self.config['firstSymbolInHighOrderBits'])
 
-        single = BinaryValue(bits=1, bigEndian=False)
+        single = BinaryValue(n_bits=1, bigEndian=False)
         if self.use_empty:
-            empty = BinaryValue(bits=len(self.bus.empty), bigEndian=False)
+            empty = BinaryValue(n_bits=len(self.bus.empty), bigEndian=False)
 
         # Drive some defaults since we don't know what state we're in
         if self.use_empty:

--- a/cocotb/drivers/xgmii.py
+++ b/cocotb/drivers/xgmii.py
@@ -77,7 +77,7 @@ class _XGMIIBus(object):
                                 byte plus a control bit per byte in the MSBs.
         """
 
-        self._value = BinaryValue(bits=nbytes*9, bigEndian=False)
+        self._value = BinaryValue(n_bits=nbytes*9, bigEndian=False)
         self._integer = long(0)
         self._interleaved = interleaved
         self._nbytes = nbytes

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -456,7 +456,7 @@ class ConstantObject(NonHierarchyObject):
             self._value = simulator.get_signal_val_str(self._handle)
         else:
             val = simulator.get_signal_val_binstr(self._handle)
-            self._value = BinaryValue(bits=len(val))
+            self._value = BinaryValue(n_bits=len(val))
             try:
                 self._value.binstr = val
             except:
@@ -598,9 +598,9 @@ class ModifiableObject(NonConstantObject):
             return
 
         if isinstance(value, ctypes.Structure):
-            value = BinaryValue(value=cocotb.utils.pack(value), bits=len(self))
+            value = BinaryValue(value=cocotb.utils.pack(value), n_bits=len(self))
         elif isinstance(value, get_python_integer_types()):
-            value = BinaryValue(value=value, bits=len(self), bigEndian=False)
+            value = BinaryValue(value=value, n_bits=len(self), bigEndian=False)
         elif isinstance(value, dict):
             #We're given a dictionary with a list of values and a bit size...
             num = 0;
@@ -614,7 +614,7 @@ class ModifiableObject(NonConstantObject):
 
             for val in vallist:
                 num = (num << value["bits"]) + val;
-            value = BinaryValue(value=num, bits=len(self), bigEndian=False)
+            value = BinaryValue(value=num, n_bits=len(self), bigEndian=False)
 
         elif not isinstance(value, BinaryValue):
             self._log.critical("Unsupported type for value assignment: %s (%s)" % (type(value), repr(value)))


### PR DESCRIPTION
As requested in #748 

Also included changes of deprecated `bits` argument to `n_bits` to remove warnings.