### PR TITLE
Fix Questa runsim.do file generation missing bailout on error

### DIFF
--- a/makefiles/simulators/Makefile.questa
+++ b/makefiles/simulators/Makefile.questa
@@ -91,7 +91,7 @@ $(SIM_BUILD)/runsim.do : $(VHDL_SOURCES) $(VERILOG_SOURCES) $(CUSTOM_SIM_DEPS) $
 	@echo "onerror {" >> $@
 	@echo "	quit -f -code 1" >> $@
 	@echo "}" >> $@
-	@echo "if [file exists $(RTL_LIBRARY)] {vdel -lib $(RTL_LIBRARY) -all}" > $@
+	@echo "if [file exists $(RTL_LIBRARY)] {vdel -lib $(RTL_LIBRARY) -all}" >> $@
 	@echo "vlib $(RTL_LIBRARY)" >> $@
 	@echo "vmap -c" >> $@
 	@echo "vmap $(RTL_LIBRARY) $(RTL_LIBRARY)" >> $@


### PR DESCRIPTION
A typo changed '>>' to '>' so the `onerror` function was getting written to runsim.do but then getting overwritten.