### PR TITLE
Minor fix to new test_singleton_isinstance in test_cocotb.py

### DIFF
--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -39,7 +39,7 @@ Also used as regression test of cocotb capabilities
 
 import cocotb
 from cocotb.triggers import (Timer, Join, RisingEdge, FallingEdge, Edge,
-                             ReadOnly, ReadWrite, ClockCycles)
+                             ReadOnly, ReadWrite, ClockCycles, NextTimeStep)
 from cocotb.clock import Clock
 from cocotb.result import ReturnValue, TestFailure, TestError, TestSuccess
 from cocotb.utils import get_sim_time
@@ -813,7 +813,7 @@ def test_singleton_isinstance(dut):
     assert isinstance(RisingEdge(dut.clk), RisingEdge)
     assert isinstance(FallingEdge(dut.clk), FallingEdge)
     assert isinstance(Edge(dut.clk), Edge)
-    assert isinstance(NextTimestep(), NextTimestep)
+    assert isinstance(NextTimeStep(), NextTimeStep)
     assert isinstance(ReadOnly(), ReadOnly)
     assert isinstance(ReadWrite(), ReadWrite)
 


### PR DESCRIPTION
This is cleaning up after a change made in #752. The NextTimeStep trigger wasn't imported from cocotb.triggers, and also the "s" in Timestep was not capitalized in the test itself.

I was testing the latest cocotb git master on ius (Cadence Incisive) and happened to notice this. All the other tests seem to be passing, which is good!