### PR TITLE
Make `<=` raise an exception if confused with comparison

### DIFF
--- a/cocotb/bus.py
+++ b/cocotb/bus.py
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 
     A bus is simply defined as a collection of signals
 """
+from cocotb.handle import AssignmentResult
 
 
 def _build_sig_attr_dict(signals):
@@ -209,3 +210,4 @@ class Bus(object):
     def __le__(self, value):
         """Overload the less than or equal to operator for value assignment"""
         self.drive(value)
+        return AssignmentResult(self, value)

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -382,6 +382,27 @@ class HierarchyArrayObject(RegionObject):
         raise TypeError("Not permissible to set %s at index %d" % (self._name, index))
 
 
+class AssignmentResult(object):
+    """
+    Object that exists solely to provide an error message if the caller
+    is not aware of cocotb's meaning of ``<=``.
+    """
+    def __init__(self, signal, value):
+        self._signal = signal
+        self._value = value
+
+    def __bool__(self):
+        raise TypeError(
+            "Attempted to use `{0._signal!r} <= {0._value!r}` (a cocotb "
+            "delayed write) as if it were a numeric comparison. To perform "
+            "comparison, use `{0._signal!r}.value <= {0._value!r}` instead."
+            .format(self)
+        )
+
+    # python 2
+    __nonzero__ = __bool__
+
+
 class NonHierarchyObject(SimHandleBase):
 
     """
@@ -416,6 +437,7 @@ class NonHierarchyObject(SimHandleBase):
                 module.signal <= 2
         """
         self.value = value
+        return AssignmentResult(self, value)
 
     def __eq__(self, other):
         if isinstance(other, SimHandleBase):

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -820,6 +820,25 @@ def test_singleton_isinstance(dut):
     yield Timer(1)
 
 
+@cocotb.test()
+def test_lessthan_raises_error(dut):
+    """
+    Test that trying to use <= as if it were a comparison produces an error
+    """
+    ret = dut.stream_in_data <= 0x12
+    try:
+        bool(ret)
+    except TypeError:
+        pass
+    else:
+        raise TestFailure(
+            "No exception was raised when confusing comparison with assignment"
+        )
+
+    # to make this a generator
+    if False: yield
+
+
 if sys.version_info[:2] >= (3, 3):
     # this would be a syntax error in older python, so we do the whole
     # thing inside exec


### PR DESCRIPTION
this will make incorrect code like the following raise `TypeError`

```python
if module.signal <= 1:
    print("This used to just never run, and perform the write")
```