### PR TITLE
Add intersphinx extension for Python 3.

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -39,8 +39,11 @@ extensions = [
     'sphinx.ext.imgmath', 
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
+    'sphinx.ext.intersphinx',
     'cairosvgconverter',
     ]
+
+intersphinx_mapping = {'https://docs.python.org/3': None}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
This gives us much nicer hyperlinked docs.