### PR TITLE
Avoid recursing in the scheduler

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -319,16 +319,18 @@ class Scheduler(object):
                 self.schedule(test)
                 self.advance()
 
-    def react(self, trigger, depth=0):
+    def react(self, trigger):
         """React called when a trigger fires.
 
         We find any coroutines that are waiting on the particular trigger and
         schedule them.
         """
-        if _profiling and not depth:
+        if _profiling:
             ctx = profiling_context()
         else:
             ctx = nullcontext()
+
+        called_by_simulator = isinstance(trigger, GPITrigger)
 
         with ctx:
             # When a trigger fires it is unprimed internally
@@ -361,6 +363,8 @@ class Scheduler(object):
 
                 self._readwrite.unprime()
 
+                # this should be the only trigger, probably?
+                assert not self._pending_triggers
                 return
 
             # Similarly if we've scheduled our next_timestep on way to readwrite
@@ -374,82 +378,93 @@ class Scheduler(object):
                         "Priming ReadWrite trigger so we can playback writes")
                     self._readwrite.prime(self.react)
 
+                # this should be the only trigger, probably?
+                assert not self._pending_triggers
                 return
 
-            if trigger not in self._trigger2coros:
-
-                # GPI triggers should only be ever pending if there is an
-                # associated coroutine waiting on that trigger, otherwise it would
-                # have been unprimed already
-                if isinstance(trigger, GPITrigger):
-                    self.log.critical(
-                        "No coroutines waiting on trigger that fired: %s" %
-                        str(trigger))
-
-                    trigger.log.info("I'm the culprit")
-                # For Python triggers this isn't actually an error - we might do
-                # event.set() without knowing whether any coroutines are actually
-                # waiting on this event, for example
-                elif _debug:
-                    self.log.debug(
-                        "No coroutines waiting on trigger that fired: %s" %
-                        str(trigger))
-
-                return
-
-            # Scheduled coroutines may append to our waiting list so the first
-            # thing to do is pop all entries waiting on this trigger.
-            scheduling = self._trigger2coros.pop(trigger)
-
-            if _debug:
-                debugstr = "\n\t".join([coro.__name__ for coro in scheduling])
-                if len(scheduling):
-                    debugstr = "\n\t" + debugstr
-                self.log.debug("%d pending coroutines for event %s%s" %
-                               (len(scheduling), str(trigger), debugstr))
-
-            # This trigger isn't needed any more
-            trigger.unprime()
-
-            # If the coroutine was waiting on multiple triggers we may be able
-            # to unprime the other triggers that didn't fire
-            scheduling_set = set(scheduling)
-            other_triggers = {
-                t
-                for coro in scheduling
-                for t in self._coro2triggers[coro]
-            } - {trigger}
-
-            for pending in other_triggers:
-                # every coroutine waiting on this trigger is already being woken
-                if scheduling_set.issuperset(self._trigger2coros[pending]):
-                    if pending.primed:
-                        pending.unprime()
-                    del self._trigger2coros[pending]
-
-            for coro in scheduling:
-                if _debug:
-                    self.log.debug("Scheduling coroutine %s" % (coro.__name__))
-                self.schedule(coro, trigger=trigger)
-                if _debug:
-                    self.log.debug("Scheduled coroutine %s" % (coro.__name__))
-
-            if not depth:
-                # Schedule may have queued up some events so we'll burn through those
-                while self._pending_events:
-                    if _debug:
-                        self.log.debug("Scheduling pending event %s" %
-                                       (str(self._pending_events[0])))
-                    self._pending_events.pop(0).set()
-
+            # work through triggers one by one
+            is_first = True
+            self._pending_triggers.append(trigger)
             while self._pending_triggers:
+                trigger = self._pending_triggers.pop(0)
+
+                if not is_first and isinstance(trigger, GPITrigger):
+                    self.log.warning(
+                        "A GPI trigger occurred after entering react - this "
+                        "should not happen."
+                    )
+                    assert False
+
+                # this only exists to enable the warning above
+                is_first = False
+
+                if trigger not in self._trigger2coros:
+
+                    # GPI triggers should only be ever pending if there is an
+                    # associated coroutine waiting on that trigger, otherwise it would
+                    # have been unprimed already
+                    if isinstance(trigger, GPITrigger):
+                        self.log.critical(
+                            "No coroutines waiting on trigger that fired: %s" %
+                            str(trigger))
+
+                        trigger.log.info("I'm the culprit")
+                    # For Python triggers this isn't actually an error - we might do
+                    # event.set() without knowing whether any coroutines are actually
+                    # waiting on this event, for example
+                    elif _debug:
+                        self.log.debug(
+                            "No coroutines waiting on trigger that fired: %s" %
+                            str(trigger))
+
+                    continue
+
+                # Scheduled coroutines may append to our waiting list so the first
+                # thing to do is pop all entries waiting on this trigger.
+                scheduling = self._trigger2coros.pop(trigger)
+
                 if _debug:
-                    self.log.debug("Scheduling pending trigger %s" %
-                                   (str(self._pending_triggers[0])))
-                self.react(self._pending_triggers.pop(0), depth=depth + 1)
+                    debugstr = "\n\t".join([coro.__name__ for coro in scheduling])
+                    if len(scheduling):
+                        debugstr = "\n\t" + debugstr
+                    self.log.debug("%d pending coroutines for event %s%s" %
+                                   (len(scheduling), str(trigger), debugstr))
+
+                # This trigger isn't needed any more
+                trigger.unprime()
+
+                # If the coroutine was waiting on multiple triggers we may be able
+                # to unprime the other triggers that didn't fire
+                scheduling_set = set(scheduling)
+                other_triggers = {
+                    t
+                    for coro in scheduling
+                    for t in self._coro2triggers[coro]
+                } - {trigger}
+
+                for pending in other_triggers:
+                    # every coroutine waiting on this trigger is already being woken
+                    if scheduling_set.issuperset(self._trigger2coros[pending]):
+                        if pending.primed:
+                            pending.unprime()
+                        del self._trigger2coros[pending]
+
+                for coro in scheduling:
+                    if _debug:
+                        self.log.debug("Scheduling coroutine %s" % (coro.__name__))
+                    self.schedule(coro, trigger=trigger)
+                    if _debug:
+                        self.log.debug("Scheduled coroutine %s" % (coro.__name__))
+
+            # Schedule may have queued up some events so we'll burn through those
+            while self._pending_events:
+                if _debug:
+                    self.log.debug("Scheduling pending event %s" %
+                                   (str(self._pending_events[0])))
+                self._pending_events.pop(0).set()
 
             # We only advance for GPI triggers
-            if not depth and isinstance(trigger, GPITrigger):
+            if called_by_simulator:
                 self.advance()
 
                 if _debug:

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -252,6 +252,7 @@ class Scheduler(object):
 
         # Select the appropriate scheduling algorithm for this simulator
         self.advance = self.default_scheduling_algorithm
+        self._is_reacting = False
 
     def default_scheduling_algorithm(self):
         """
@@ -320,17 +321,39 @@ class Scheduler(object):
                 self.advance()
 
     def react(self, trigger):
-        """React called when a trigger fires.
+        """
+        Called when a trigger fires.
 
-        We find any coroutines that are waiting on the particular trigger and
-        schedule them.
+        We ensure that we only start the event loop once, rather than
+        letting it recurse.
+        """
+        if self._is_reacting:
+            # queue up the trigger, the event loop will get to it
+            self._pending_triggers.append(trigger)
+            return
+
+        # start the event loop
+        self._is_reacting = True
+        try:
+            self._event_loop(trigger)
+        finally:
+            self._is_reacting = False
+
+
+    def _event_loop(self, trigger):
+        """
+        Run an event loop triggered by the given trigger.
+
+        The loop will keep running until no further triggers fire.
+
+        This should be triggered by only:
+        * The beginning of a test, when there is no trigger to react to
+        * A GPI trigger
         """
         if _profiling:
             ctx = profiling_context()
         else:
             ctx = nullcontext()
-
-        called_by_simulator = isinstance(trigger, GPITrigger)
 
         with ctx:
             # When a trigger fires it is unprimed internally
@@ -363,8 +386,6 @@ class Scheduler(object):
 
                 self._readwrite.unprime()
 
-                # this should be the only trigger, probably?
-                assert not self._pending_triggers
                 return
 
             # Similarly if we've scheduled our next_timestep on way to readwrite
@@ -378,8 +399,6 @@ class Scheduler(object):
                         "Priming ReadWrite trigger so we can playback writes")
                     self._readwrite.prime(self.react)
 
-                # this should be the only trigger, probably?
-                assert not self._pending_triggers
                 return
 
             # work through triggers one by one
@@ -456,20 +475,18 @@ class Scheduler(object):
                     if _debug:
                         self.log.debug("Scheduled coroutine %s" % (coro.__name__))
 
-            # Schedule may have queued up some events so we'll burn through those
-            while self._pending_events:
-                if _debug:
-                    self.log.debug("Scheduling pending event %s" %
-                                   (str(self._pending_events[0])))
-                self._pending_events.pop(0).set()
+                # Schedule may have queued up some events so we'll burn through those
+                while self._pending_events:
+                    if _debug:
+                        self.log.debug("Scheduling pending event %s" %
+                                       (str(self._pending_events[0])))
+                    self._pending_events.pop(0).set()
 
-            # We only advance for GPI triggers
-            if called_by_simulator:
-                self.advance()
-
-                if _debug:
-                    self.log.debug("All coroutines scheduled, handing control back"
-                                   " to simulator")
+            # no more pending triggers
+            self.advance()
+            if _debug:
+                self.log.debug("All coroutines scheduled, handing control back"
+                               " to simulator")
 
 
     def unschedule(self, coro):

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -39,7 +39,8 @@ Also used as regression test of cocotb capabilities
 
 import cocotb
 from cocotb.triggers import (Timer, Join, RisingEdge, FallingEdge, Edge,
-                             ReadOnly, ReadWrite, ClockCycles, NextTimeStep)
+                             ReadOnly, ReadWrite, ClockCycles, NextTimeStep,
+                             NullTrigger)
 from cocotb.clock import Clock
 from cocotb.result import ReturnValue, TestFailure, TestError, TestSuccess
 from cocotb.utils import get_sim_time
@@ -869,9 +870,53 @@ def test_exceptions():
     def raise_soon():
         yield Timer(10)
         raise ValueError('It is soon now')
-    
+
     try:
         yield raise_soon()
+    except ValueError:
+        pass
+    else:
+        raise TestFailure("Exception was not raised")
+
+@cocotb.test()
+def test_stack_overflow(dut):
+    """
+    Test against stack overflows when starting many coroutines that terminate
+    before passing control to the simulator.
+    """
+    @cocotb.coroutine
+    def null_coroutine():
+        yield NullTrigger()
+
+    for _ in range(10000):
+        yield null_coroutine()
+
+    yield Timer(100)
+
+
+@cocotb.test()
+def test_immediate_coro(dut):
+    """
+    Test that coroutines can return immediately
+    """
+    # note: it seems that the test still has to yield at least once, even
+    # if the subroutines do not
+    yield Timer(1)
+
+    @cocotb.coroutine
+    def immediate_value():
+        raise ReturnValue(42)
+        yield
+
+    @cocotb.coroutine
+    def immediate_exception():
+        raise ValueError
+        yield
+
+    assert (yield immediate_value()) == 42
+
+    try:
+        yield immediate_exception()
     except ValueError:
         pass
     else:


### PR DESCRIPTION
By doing this, we don't have to worry about hitting the recursion limit. I suspect there are some open issues this solves.

Submitting as is since not all tests run locally for me.

Diff makes more sense with whitespace changes hidden.