### PR TITLE
Make things decorated with `cocotb.test` actually instances of `cocotb.test`

### DIFF
--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -839,6 +839,16 @@ def test_lessthan_raises_error(dut):
     if False: yield
 
 
+@cocotb.test()
+def test_tests_are_tests(dut):
+    """
+    Test that things annotated with cocotb.test are tests
+    """
+    yield Timer(1)
+
+    assert isinstance(test_tests_are_tests, cocotb.test)
+
+
 if sys.version_info[:2] >= (3, 3):
     # this would be a syntax error in older python, so we do the whole
     # thing inside exec


### PR DESCRIPTION
Does the same for hooks.

This removes the truly bizarre pattern of calling `super().__init__` from within `__call__`.

As a nice bonus, this means that the following no longer calls `coroutine.__init__` twice on the same instance:

```python
failing_test = cocotb.test(expect_fail=True)

@failing_test
def will_fail():
    yield Timer(1)
    assert 1 == 2

@failing_test
def will_also_fail():
    yield Timer(1)
    assert 1 == 2
```

---

An alternative approach, avoiding the metaclass, would be to introduce a separate `cocotb.Test` class, which is produced by a `cocotb.test` helper function.