### PR TITLE
Fix gh-768

### DIFF
--- a/lib/vpi/VpiCbHdl.cpp
+++ b/lib/vpi/VpiCbHdl.cpp
@@ -325,11 +325,40 @@ long VpiSignalObjHdl::get_signal_value_long(void)
 // Value related functions
 int VpiSignalObjHdl::set_signal_value(long value)
 {
-    FENTER
     s_vpi_value value_s;
 
     value_s.value.integer = value;
     value_s.format = vpiIntVal;
+
+    return set_signal_value(value_s);
+}
+
+int VpiSignalObjHdl::set_signal_value(double value)
+{
+    s_vpi_value value_s;
+
+    value_s.value.real = value;
+    value_s.format = vpiRealVal;
+
+    return set_signal_value(value_s);
+}
+
+int VpiSignalObjHdl::set_signal_value(std::string &value)
+{
+    s_vpi_value value_s;
+
+    std::vector<char> writable(value.begin(), value.end());
+    writable.push_back('\0');
+
+    value_s.value.str = &writable[0];
+    value_s.format = vpiBinStrVal;
+
+    return set_signal_value(value_s);
+}
+
+int VpiSignalObjHdl::set_signal_value(s_vpi_value value_s)
+{
+    FENTER
 
     s_vpi_time vpi_time_s;
 
@@ -339,45 +368,6 @@ int VpiSignalObjHdl::set_signal_value(long value)
 
     // Use Inertial delay to schedule an event, thus behaving like a verilog testbench
     vpi_put_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s, &vpi_time_s, vpiInertialDelay);
-    check_vpi_error();
-
-    FEXIT
-    return 0;
-}
-
-int VpiSignalObjHdl::set_signal_value(double value)
-{
-    FENTER
-    s_vpi_value value_s;
-
-    value_s.value.real = value;
-    value_s.format = vpiRealVal;
-
-    s_vpi_time vpi_time_s;
-
-    vpi_time_s.type = vpiSimTime;
-    vpi_time_s.high = 0;
-    vpi_time_s.low  = 0;
-
-    vpi_put_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s, &vpi_time_s, vpiInertialDelay);
-    check_vpi_error();
-
-    FEXIT
-    return 0;
-}
-
-int VpiSignalObjHdl::set_signal_value(std::string &value)
-{
-    FENTER
-    s_vpi_value value_s;
-
-    std::vector<char> writable(value.begin(), value.end());
-    writable.push_back('\0');
-
-    value_s.value.str = &writable[0];
-    value_s.format = vpiBinStrVal;
-
-    vpi_put_value(GpiObjHdl::get_handle<vpiHandle>(), &value_s, NULL, vpiNoDelay);
     check_vpi_error();
 
     FEXIT

--- a/lib/vpi/VpiImpl.h
+++ b/lib/vpi/VpiImpl.h
@@ -214,6 +214,8 @@ public:
     int initialise(std::string &name, std::string &fq_name);
 
 private:
+    int set_signal_value(s_vpi_value value);
+
     VpiValueCbHdl m_rising_cb;
     VpiValueCbHdl m_falling_cb;
     VpiValueCbHdl m_either_cb;

--- a/tests/test_cases/issue_768_a/Makefile
+++ b/tests/test_cases/issue_768_a/Makefile
@@ -1,0 +1,3 @@
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_768

--- a/tests/test_cases/issue_768_a/issue_768.py
+++ b/tests/test_cases/issue_768_a/issue_768.py
@@ -1,0 +1,21 @@
+"""
+Control case for https://github.com/potentialventures/cocotb/issues/768.
+
+This passed before the bug fix, and should continue to pass
+
+Note that the bug only occurred if the test in question runs first - so
+no more tests can be added to this file.
+"""
+import cocotb
+from cocotb.triggers import Timer, ReadOnly
+from cocotb.binary import BinaryValue
+
+# this line is different between the two files
+value = 0
+
+@cocotb.test()
+def test(dut):
+    dut.stream_in_data.setimmediatevalue(value)
+    yield Timer(1)
+    assert dut.stream_in_data.value == 0
+    yield ReadOnly()

--- a/tests/test_cases/issue_768_b/Makefile
+++ b/tests/test_cases/issue_768_b/Makefile
@@ -1,0 +1,3 @@
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_768

--- a/tests/test_cases/issue_768_b/issue_768.py
+++ b/tests/test_cases/issue_768_b/issue_768.py
@@ -1,0 +1,20 @@
+"""
+Failing case for https://github.com/potentialventures/cocotb/issues/768.
+
+Note that the bug only occurred if the test in question runs first - so
+no more tests can be added to this file.
+"""
+
+import cocotb
+from cocotb.triggers import Timer, ReadOnly
+from cocotb.binary import BinaryValue
+
+# this line is different between the two files
+value = BinaryValue(0)
+
+@cocotb.test()
+def do_test(dut):
+    dut.stream_in_data.setimmediatevalue(value)
+    yield Timer(1)
+    assert dut.stream_in_data.value == 0
+    yield ReadOnly()


### PR DESCRIPTION
gh-768

There are three `set_signal_value` overload - two of them (reals, int32s) use `vpiInertialDelay`, but the third uses vpiNoDelay.

This is bad, because it means the behavior of `.setimmediatevalue` depends on whether the value fits in a string.

The assumption here is that the integer case is the correct one.
The string and integer overload were introduced simultaneously in e9104a8a1cb58774acfbd5c185f46a7ea969350e - neither was changed in response to a bug fix.

The best way to ensure three pieces of code do the same thing is put that thing in one piece of code - so this commit introduces a `set_signal_value(s_vpi_value)` function.