### PR TITLE
Add sphinxcontrib-trio as a Sphinx extension.

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -2,3 +2,4 @@
 Sphinx>=1.6
 sphinx-rtd-theme
 cairosvg
+sphinxcontrib-trio

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -41,6 +41,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.intersphinx',
     'cairosvgconverter',
+    'sphinxcontrib_trio',
     ]
 
 intersphinx_mapping = {'https://docs.python.org/3': None}


### PR DESCRIPTION
Fixes #793.
This alone only adds "_for ... in_" before coroutines in rendered output but for the future enables better (auto-)documentation as described in its docs.