### PR TITLE
Make USER_DIR independent of SIM_ROOT

### DIFF
--- a/makefiles/Makefile.inc
+++ b/makefiles/Makefile.inc
@@ -34,7 +34,7 @@ export SIM_ROOT:=$(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
 endif
 
 ifeq ($(USER_DIR),)
-export USER_DIR:=$(SIM_ROOT)
+export USER_DIR:=$(abspath $(dir $(firstword $(MAKEFILE_LIST))))
 endif
 
 BUILD_DIR=$(USER_DIR)/build


### PR DESCRIPTION
*Note: This is part of a series of preparatory PRs to get #517 merged. I'm trying to split out all not strictly related commits to make sure we run all the tests and are able to back out individual parts as needed. @themperek please double-check the commit messages and let me know if they are wrong/misleading or too short to explain the change in sufficient detail.*

USER_DIR is the path containing the user-called Makefile, i.e. where the
user code lives. Extract this path from MAKEFILE_LIST intead of relying
on SIM_ROOT.

This is preparing for a world where the cocotb directory structure and
with it SIM_ROOT will change. No user-visible changes are expected after
applying this commit.