### PR TITLE
Comment out unused html_static_path definition.

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -141,7 +141,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
Prevents "WARNING: html_static_path entry '/home/colin/cocotb/documentation/source/_static' does not exist".