### PR TITLE
Update cocotb docs to indicate that Python 2.6 is no longer supported

### DIFF
--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -11,7 +11,7 @@ Pre-requisites
 
 Cocotb has the following requirements:
 
-* Python 2.6+
+* Python 2.7+
 * Python-dev packages
 * GCC and associated development packages
 * GNU Make


### PR DESCRIPTION
We no longer support Python 2.6-- various backwards-compatibility-breaking changes (such as 2.7+ string formatting styles) have been merged over the past year or so. Thus, the documentation should be updated.