### PR TITLE
Add osx and more python versions to travis (linux)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 sudo: required
 language: python
 cache: pip
+dist: xenial
 
 git:
   quiet: true
@@ -12,10 +13,13 @@ services:
 jobs:
   include:
     - stage: PythonLint
+      os: linux
       python: 3.5
       install: pip install flake8
       script: flake8 --exit-zero cocotb/
+      
     - stage: SimTests
+      os: linux
       python: 2.7
       before_install: &docker_prep
         - docker build -t cocotb .
@@ -26,7 +30,9 @@ jobs:
         - echo 'Running cocotb tests with Python 2.7 ...' && echo 'travis_fold:start:cocotb_py27' 
         - docker exec -it -e TRAVIS=true cocotb bash -lc 'pip install tox; cd /src; tox -e py27'
         - echo -e 'travis_fold:end:cocotb_py27'
+        
     - stage: SimTests
+      os: linux
       python: 3.5
       before_install: *docker_prep 
       script:
@@ -34,3 +40,41 @@ jobs:
         - docker exec -it -e TRAVIS=true cocotb bash -lc 'pip install tox; cd /src; tox -e py35'
         - echo 'travis_fold:end:cocotb_py35'
 
+    - stage: SimTests
+      python: 3.7
+      before_install: &travis_linx_prep
+        - sudo apt-get install gperf
+        - git clone https://github.com/steveicarus/iverilog.git --depth=1 --branch v10_2
+        - cd iverilog && autoconf && ./configure && make -j2 && sudo make install && cd ..
+        - pip install tox
+        - pyenv global system $TRAVIS_PYTHON_VERSION
+      script:
+        - echo 'Running cocotb tests with Python 3.7 ...' && echo -en 'travis_fold:start:cocotb_py37'
+        - tox -e py37
+        - echo 'travis_fold:end:cocotb_py37'
+        
+    - stage: SimTests
+      python: 3.6.7
+      before_install: *travis_linx_prep
+      script:
+        - echo 'Running cocotb tests with Python 3.6.7 ...' && echo -en 'travis_fold:start:cocotb_py36'
+        - tox -e py36
+        - echo 'travis_fold:end:cocotb_py36'
+        
+    - stage: SimTests
+      os: osx
+      language: generic
+      python: 2.7
+      before_install: &osx_prep
+        - brew install icarus-verilog
+        - pip install tox
+      script:
+        - tox -e py27
+
+    - stage: SimTests
+      os: osx
+      language: generic
+      python: 3.6
+      before_install: *osx_prep
+      script:
+        - tox -e py36


### PR DESCRIPTION
- Added python 3.6 and 3.7 Linux on travis.
- Add osx testing (2.7 and 3.6)
