### PR TITLE
Cleanup list of coros for pending triggers.

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -424,6 +424,14 @@ class Scheduler(object):
                     if pending.primed:
                         pending.unprime()
                     del self._trigger2coros[pending]
+                # can't unprime trigger because other coroutines are waiting,
+                # but we should remove all coroutines being woken from the list
+                else:
+                    self._trigger2coros[pending] = [
+                        coro
+                        for coro in self._trigger2coros[pending]
+                        if coro not in scheduling
+                    ]
 
             for coro in scheduling:
                 if _debug:

--- a/tests/test_cases/test_multi_trig_multi_coro/Makefile
+++ b/tests/test_cases/test_multi_trig_multi_coro/Makefile
@@ -1,0 +1,32 @@
+###############################################################################
+# Copyright (c) 2013 Potential Ventures Ltd
+# Copyright (c) 2013 SolarFlare Communications Inc
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Potential Ventures Ltd,
+#       SolarFlare Communications Inc nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+include ../../designs/sample_module/Makefile
+
+MODULE = test_multi_trig_multi_coro

--- a/tests/test_cases/test_multi_trig_multi_coro/test_multi_trig_multi_coro.py
+++ b/tests/test_cases/test_multi_trig_multi_coro/test_multi_trig_multi_coro.py
@@ -1,0 +1,58 @@
+import cocotb
+from cocotb.log import SimLog
+from cocotb.triggers import Timer, RisingEdge, FallingEdge
+from cocotb.result import TestFailure, TestSuccess
+
+import sys
+
+@cocotb.coroutine
+def clock_gen(signal, num):
+    for x in range(num):
+        signal <= 0
+        yield Timer(500)
+        signal <= 1
+        yield Timer(500)
+
+class DualMonitor:
+    def __init__(self, signal):
+        self.log = SimLog("cocotb.%s" % (signal._name))
+        self.monitor_edges = [0, 0]
+        self.signal = signal
+
+    @cocotb.coroutine
+    def signal_mon(self, signal, idx):
+        while True:
+            result = yield RisingEdge(signal)
+            self.log.info("signal_mon called on %s" % result)
+            self.monitor_edges[idx] += 1
+            
+    @cocotb.coroutine
+    def signal_mon_both(self, signal, idx):
+        while True:
+            result = yield [RisingEdge(signal), FallingEdge(signal)]
+            self.log.info("signal_mon_both called on %s" % result)
+            self.monitor_edges[idx] += 1
+
+    @cocotb.coroutine
+    def start(self):
+        clock_edges = 10
+
+        cocotb.fork(clock_gen(self.signal, clock_edges))
+        yield Timer(1)
+        cocotb.fork(self.signal_mon(self.signal, 0))
+        cocotb.fork(self.signal_mon_both(self.signal, 1))
+
+        yield Timer(2001)
+
+        self.log.info("signal_mon coroutine saw %d edges" % self.monitor_edges[0])
+        self.log.info("signal_mon_both coroutine saw %d edges" % self.monitor_edges[1])
+        if self.monitor_edges[1] != self.monitor_edges[0] * 2:
+            raise TestFailure("%d is not twice %d" % (self.monitor_edges[1], self.monitor_edges[0]))
+        else:
+            raise TestSuccess("%d is twice %d" % (self.monitor_edges[1], self.monitor_edges[0]))
+
+
+@cocotb.test()
+def test1(dut):
+    """ Start DualMonitor to monitor clock edges """
+    yield DualMonitor(dut.clk).start()


### PR DESCRIPTION
Fixes #839, #841.
If a coroutine is waiting on a list of triggers, when one of those
triggers fires, the scheduler attempts to cleanup the other pending
triggers. An issue can occur where a separate coroutine is waiting on
one of the other pending triggers, so it is not unprimed, but the
coroutine being woken is not correctly removed from the list of
waiting coroutines for the still-pending trigger.

This change cleans up the coro lists of other pending triggers that
any coroutine in the scheduling set was also waiting on.

Also added a test to catch regressions in the scheduler.