### PR TITLE
Added info to NullTrigger from Event.wait()

### DIFF
--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -397,7 +397,7 @@ class Event(PythonTrigger):
         :meth:`~cocotb.triggers.Event.clear` should be called.
         """
         if self.fired:
-            return NullTrigger()
+            return NullTrigger(name="{}.wait()".format(str(self)))
         return _Event(self)
 
     def clear(self):
@@ -499,6 +499,9 @@ class NullTrigger(Trigger):
 
     def prime(self, callback):
         callback(self)
+
+    def __str__(self):
+        return self.__class__.__name__ + "(%s)" % self.name
 
 
 class Join(with_metaclass(ParametrizedSingleton, PythonTrigger)):


### PR DESCRIPTION
NullTriggers returned as a result of waiting on a fired Event now
include the Event name.

In the case of a looped coroutine waiting on an Event that has been
fired but not cleared, the exhibited behavior is usually hitting the
recursion limit in the scheduler and throwing an exception. Having the
information about the Event in the NullTrigger object is very helpful
when debugging.