### PR TITLE
Add argv information for VHPI

### DIFF
--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -25,6 +25,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************************************************************/
 
+#include <assert.h>
 #include "VhpiImpl.h"
 
 extern "C" void handle_vhpi_callback(const vhpiCbDataT *cb_data);
@@ -764,16 +765,39 @@ VhpiStartupCbHdl::VhpiStartupCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl),
     cb_data.reason = vhpiCbStartOfSimulation;
 }
 
-int VhpiStartupCbHdl::run_callback(void) {
+int VhpiStartupCbHdl::run_callback() {
+    vhpiHandleT tool, argv_iter, argv_hdl;
     gpi_sim_info_t sim_info;
-    sim_info.argc = 0;
-    sim_info.argv = NULL;
-    sim_info.product = gpi_copy_name(vhpi_get_str(vhpiNameP, NULL));
-    sim_info.version = gpi_copy_name(vhpi_get_str(vhpiToolVersionP, NULL));
-    gpi_embed_init(&sim_info);
+    char **tool_argv = NULL;
+    uint32_t tool_argc = 0;
+    int i = 0;
 
-    free(sim_info.product);
-    free(sim_info.version);
+    tool = vhpi_handle(vhpiTool, NULL);
+    
+    sim_info.product = const_cast<char*>(static_cast<const char*>(vhpi_get_str(vhpiNameP, tool)));
+    sim_info.version = const_cast<char*>(static_cast<const char*>(vhpi_get_str(vhpiToolVersionP, tool)));
+
+    if (tool) {
+        tool_argc = vhpi_get(vhpiArgcP, tool);
+        tool_argv = (char **)malloc(sizeof(char *) * tool_argc);
+        assert(tool_argv);
+
+        argv_iter = vhpi_iterator(vhpiArgvs, tool);
+        if (argv_iter) {
+            while (argv_hdl = vhpi_scan(argv_iter)) {
+                tool_argv[i] = const_cast<char*>(static_cast<const char*>(vhpi_get_str(vhpiStrValP, argv_hdl)));
+                i++;
+            }
+            vhpi_release_handle(argv_iter);
+        }
+        sim_info.argc = tool_argc;
+        sim_info.argv = tool_argv;
+
+        vhpi_release_handle(tool);
+    }
+
+    gpi_embed_init(&sim_info);
+    free(tool_argv);
 
     return 0;
 }

--- a/cocotb/share/makefiles/simulators/Makefile.aldec
+++ b/cocotb/share/makefiles/simulators/Makefile.aldec
@@ -58,6 +58,9 @@ ALOG_ARGS += $(COMPILE_ARGS)
 ACOM_ARGS += $(COMPILE_ARGS)
 ASIM_ARGS += $(SIM_ARGS)
 
+# Plusargs need to be passed to ASIM command not vsimsa
+ASIM_ARGS += $(PLUSARGS)
+
 RTL_LIBRARY ?= work
 ALOG_ARGS += +define+COCOTB_SIM -dbg -pli libgpi
 ACOM_ARGS += -dbg
@@ -171,7 +174,7 @@ endif
 # that turns on batch mode (i.e. exit on completion/error)
 results.xml: $(SIM_BUILD)/runsim.tcl $(COCOTB_LIBS) $(COCOTB_VHPI_LIB) $(COCOTB_VPI_LIB) $(CUSTOM_SIM_DEPS)
 	set -o pipefail; cd $(SIM_BUILD) && PYTHONPATH=$(LIB_DIR):$(PWD):$(NEW_PYTHONPATH) GPI_EXTRA=$(GPI_EXTRA) TOPLEVEL_LANG=$(TOPLEVEL_LANG) \
-	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 $(CMD) $(PLUSARGS) -do runsim.tcl | tee sim.log
+	$(LIB_LOAD) MODULE=$(MODULE) TESTCASE=$(TESTCASE) TOPLEVEL=$(TOPLEVEL) COCOTB_SIM=1 $(CMD) -do runsim.tcl | tee sim.log
 
 clean::
 	@rm -rf $(SIM_BUILD)

--- a/tests/designs/plusargs_module/Makefile
+++ b/tests/designs/plusargs_module/Makefile
@@ -29,15 +29,7 @@
 
 TOPLEVEL_LANG ?= verilog
 
-ifneq ($(TOPLEVEL_LANG),verilog)
-
-all:
-	@echo "Skipping test due to TOPLEVEL_LANG=$(TOPLEVEL_LANG) not being verilog"
-clean::
-
-else
-
-TOPLEVEL = tb_top
+TOPLEVEL := tb_top
 
 ifeq ($(OS),Msys)
 WPWD=$(shell sh -c 'pwd -W')
@@ -47,9 +39,13 @@ endif
 
 COCOTB?=$(WPWD)/../../..
 
-VERILOG_SOURCES = $(COCOTB)/tests/designs/plusargs_module/tb_top.v
+ifeq ($(TOPLEVEL_LANG),verilog)
+    VERILOG_SOURCES = $(COCOTB)/tests/designs/plusargs_module/tb_top.v
+else ifeq ($(TOPLEVEL_LANG),vhdl)
+    VHDL_SOURCES =  $(COCOTB)/tests/designs/plusargs_module/tb_top.vhd
+else
+    $(error "A valid value (verilog or vhdl) was not provided for TOPLEVEL_LANG=$(TOPLEVEL_LANG)")
+endif
 
 include $(COCOTB)/makefiles/Makefile.inc
 include $(COCOTB)/makefiles/Makefile.sim
-
-endif

--- a/tests/designs/plusargs_module/tb_top.vhd
+++ b/tests/designs/plusargs_module/tb_top.vhd
@@ -1,0 +1,17 @@
+library ieee;
+
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity tb_top is
+end;
+
+architecture impl of tb_top is
+    signal dummy_sig : std_logic := '0';
+begin
+    process
+    begin
+        wait for 10ns;
+        dummy_sig <= '1';
+    end process;
+end architecture;

--- a/tests/test_cases/test_plusargs/plusargs.py
+++ b/tests/test_cases/test_plusargs/plusargs.py
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 
 import cocotb
 from cocotb.decorators import coroutine
+from cocotb.result import TestFailure
 from cocotb.triggers import Timer, Edge, Event
 
 import sys
@@ -45,5 +46,8 @@ def plusargs_test(dut):
 
     for name in cocotb.plusargs:
         print("COCOTB:", name, cocotb.plusargs[name])
+    
+    if cocotb.plusargs['foo'] != 'bar':
+        raise TestFailure("plusargs 'foo' value '{}' does not match expected 'bar'".format(cocotb.plusargs['foo']))
 
     yield Timer(10000)


### PR DESCRIPTION
Get argc/argv information from vhpiTool class. Copy data to sim_info
struct and free after gpi_embed_init() call.

Enables use of cocotb.plusargs when using VHPI.

I've only tested this on Aldec Active-HDL.