### PR TITLE
Change gpi_log() formatting to match Python

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -169,7 +169,7 @@ class SimLogFormatter(logging.Formatter):
     def _format(self, level, record, msg, coloured=False):
         time_ns = get_sim_time('ns')
         simtime = "%6.2fns" % (time_ns)
-        prefix = simtime.rjust(10) + ' ' + level + ' '
+        prefix = simtime.rjust(11) + ' ' + level + ' '
         if not _suppress:
             prefix += self.ljust(record.name, _RECORD_CHARS) + \
                       self.rjust(os.path.split(record.filename)[1], _FILENAME_CHARS) + \

--- a/cocotb/share/lib/gpi_log/gpi_logging.c
+++ b/cocotb/share/lib/gpi_log/gpi_logging.c
@@ -118,14 +118,21 @@ void gpi_log(const char *name, long level, const char *pathname, const char *fun
             n = vsnprintf(log_buff, LOG_SIZE, msg, ap);
             va_end(ap);
 
-            if (0 > n) {
+            if (n < 0) {
                fprintf(stderr, "Log message construction failed\n");
             }
- 
+
             fprintf(stdout, "     -.--ns ");
             fprintf(stdout, "%-9s", log_level(level));
             fprintf(stdout, "%-35s", name);
-            fprintf(stdout, "%20s:", pathname);
+
+            n = strlen(pathname);
+            if (n > 20) {
+                fprintf(stdout, "..%18s:", (pathname + (n - 18)));
+            } else {
+                fprintf(stdout, "%20s:", pathname);
+            }
+
             fprintf(stdout, "%-4ld", lineno);
             fprintf(stdout, " in %-31s ", funcname);
             fprintf(stdout, "%s", log_buff);


### PR DESCRIPTION
Make gpi_log() formatting match Python SimLogFormatter.format().
It now properly truncates long path names to show ".." followed by
the last 18 characters. fprintf formatting strings will not truncate
passed in strings, but will print the entire string until the null
terminator.

Changed Python logging to print 6 digits of sim time nanoseconds.