### PR TITLE
Fix for python 3.7 (remove StopIteration)

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -506,7 +506,7 @@ class NonHierarchyIndexableObject(NonHierarchyObject):
     def __iter__(self):
         try:
             if self._range is None:
-                raise StopIteration
+                return
 
             self._log.debug("Iterating with range [%d:%d]" % (self._range[0], self._range[1]))
             for i in self._range_iter(self._range[0], self._range[1]):


### PR DESCRIPTION
This seems to help fix the problem with python 3.7 #842 
Based on [PEP 479](https://www.python.org/dev/peps/pep-0479/)

I am not 100% sure this is right @eric-wieser 

Should also help for #833


