### PR TITLE
fix #857

### DIFF
--- a/cocotb/__init__.py
+++ b/cocotb/__init__.py
@@ -85,7 +85,7 @@ if "COCOTB_SIM" in os.environ:
 
 
 scheduler = Scheduler()
-regression = None
+regression_manager = None
 
 plusargs = {}
 
@@ -161,11 +161,11 @@ def _initialise_testbench(root_name):
     modules = module_str.split(',')
     hooks = hooks_str.split(',') if hooks_str else []
 
-    global regression
+    global regression_manager
 
-    regression = RegressionManager(root_name, modules, tests=test_str, seed=seed, hooks=hooks)
-    regression.initialise()
-    regression.execute()
+    regression_manager = RegressionManager(root_name, modules, tests=test_str, seed=seed, hooks=hooks)
+    regression_manager.initialise()
+    regression_manager.execute()
 
     _rlock.release()
     return True

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -304,7 +304,7 @@ class RegressionManager(object):
         self.execute()
 
     def execute(self):
-        self._running_test = cocotb.regression.next_test()
+        self._running_test = cocotb.regression_manager.next_test()
         if self._running_test:
             start = ''
             end   = ''

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -309,7 +309,7 @@ class Scheduler(object):
             if self._test_result is not None:
                 if _debug:
                     self.log.debug("Issue test result to regression object")
-                cocotb.regression.handle_result(self._test_result)
+                cocotb.regression_manager.handle_result(self._test_result)
                 self._test_result = None
             if self._entrypoint is not None:
                 test = self._entrypoint
@@ -732,7 +732,7 @@ class Scheduler(object):
            once we return the sim will close us so no cleanup is needed.
         """
         self.log.debug("Issue sim closedown result to regression object")
-        cocotb.regression.handle_result(test_result)
+        cocotb.regression_manager.handle_result(test_result)
 
     def cleanup(self):
         """Clear up all our state.

--- a/tests/test_cases/issue_857/Makefile
+++ b/tests/test_cases/issue_857/Makefile
@@ -1,0 +1,31 @@
+###############################################################################
+# Copyright (c) 2015 Potential Ventures Ltd
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Potential Ventures Ltd,
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_857

--- a/tests/test_cases/issue_857/issue_857.py
+++ b/tests/test_cases/issue_857/issue_857.py
@@ -1,0 +1,11 @@
+import cocotb
+from cocotb import triggers, result
+import cocotb.regression
+import types
+
+
+@cocotb.test()
+def issue_857(dut):
+    """ cocotb.regression must be a module """
+    if not isinstance(cocotb.regression, types.ModuleType):
+        yield result.TestFailure("cocotb.regression is not a module")

--- a/tests/test_cases/issue_857/issue_857.py
+++ b/tests/test_cases/issue_857/issue_857.py
@@ -8,7 +8,7 @@ def dummy_coroutine(dut):
     yield cocotb.triggers.Timer(10, 'ns')
 
 
-# Try to instantiate the TestFactory class using it's full specifier name.
+# Try to instantiate the TestFactory class using its full specifier name.
 #
 # In issue #857, a global variable named "regression" in the cocotb module hide
 # the module cocotb.regression, so the TestFactory class is not accessible with 

--- a/tests/test_cases/issue_857/issue_857.py
+++ b/tests/test_cases/issue_857/issue_857.py
@@ -1,11 +1,34 @@
 import cocotb
-from cocotb import triggers, result
 import cocotb.regression
-import types
+import cocotb.triggers
 
 
-@cocotb.test()
-def issue_857(dut):
-    """ cocotb.regression must be a module """
-    if not isinstance(cocotb.regression, types.ModuleType):
-        yield result.TestFailure("cocotb.regression is not a module")
+@cocotb.coroutine
+def test_adder(dut, val_a, val_b):
+    dut.a = val_a
+    dut.b = val_b
+    yield cocotb.triggers.Timer(10, 'ns')
+    assert dut.z == val_a + val_b
+
+
+# Try to instantiate the TestFactory class using it's full specifier name.
+#
+# In issue #857, a global variable named "regression" in the cocotb module hide
+# the module cocotb.regression, so the TestFactory class is not accessible with 
+# an import like
+#
+# >>> import cocotb.regression
+# >>> factory = cocotb.regression.FactoryManager()
+#
+# The class is still accessible by an import like
+#
+# >>> from cocotb.regression import TestFactory
+# >>> factory = TestFactory()
+#
+# but the discoverer of the bug prefers the former approach.
+#
+# And in general, it's probably a good idea to not have name conflicts ;)
+test_factory = cocotb.regression.TestFactory(test_adder)
+test_factory.add_option('val_a', range(16))
+test_factory.add_option('val_b', range(16))
+test_factory.generate_tests()

--- a/tests/test_cases/issue_857/issue_857.py
+++ b/tests/test_cases/issue_857/issue_857.py
@@ -5,13 +5,13 @@ import cocotb.triggers
 
 @cocotb.coroutine
 def dummy_coroutine(dut):
-    yield cocotb.triggers.Timer(10, 'ns')
+    yield cocotb.triggers.Timer(10, "ns")
 
 
 # Try to instantiate the TestFactory class using its full specifier name.
 #
 # In issue #857, a global variable named "regression" in the cocotb module hide
-# the module cocotb.regression, so the TestFactory class is not accessible with 
+# the module cocotb.regression, so the TestFactory class is not accessible with
 # an import like
 #
 # >>> import cocotb.regression

--- a/tests/test_cases/issue_857/issue_857.py
+++ b/tests/test_cases/issue_857/issue_857.py
@@ -4,11 +4,8 @@ import cocotb.triggers
 
 
 @cocotb.coroutine
-def test_adder(dut, val_a, val_b):
-    dut.a = val_a
-    dut.b = val_b
+def dummy_coroutine(dut):
     yield cocotb.triggers.Timer(10, 'ns')
-    assert dut.z == val_a + val_b
 
 
 # Try to instantiate the TestFactory class using it's full specifier name.
@@ -28,7 +25,5 @@ def test_adder(dut, val_a, val_b):
 # but the discoverer of the bug prefers the former approach.
 #
 # And in general, it's probably a good idea to not have name conflicts ;)
-test_factory = cocotb.regression.TestFactory(test_adder)
-test_factory.add_option('val_a', range(16))
-test_factory.add_option('val_b', range(16))
+test_factory = cocotb.regression.TestFactory(dummy_coroutine)
 test_factory.generate_tests()


### PR DESCRIPTION
Rename global variable "regression" in cocotb module for avoiding name conflict with the cocotb.regression module