### PR TITLE
Reject extra kwargs in BusDriver.__init__

### DIFF
--- a/cocotb/drivers/__init__.py
+++ b/cocotb/drivers/__init__.py
@@ -39,6 +39,7 @@ from cocotb.triggers import (Event, RisingEdge, ReadOnly, Timer, NextTimeStep,
 from cocotb.bus import Bus
 from cocotb.log import SimLog
 from cocotb.result import ReturnValue
+from cocotb.utils import reject_remaining_kwargs
 
 
 class BitDriver(object):
@@ -220,11 +221,14 @@ class BusDriver(Driver):
     _optional_signals = []
 
     def __init__(self, entity, name, clock, **kwargs):
+        # emulate keyword-only arguments in python 2
+        index = kwargs.pop("array_idx", None)
+        reject_remaining_kwargs('__init__', kwargs)
+
         self.log = SimLog("cocotb.%s.%s" % (entity._name, name))
         Driver.__init__(self)
         self.entity = entity
         self.clock = clock
-        index = kwargs.get("array_idx")
         self.bus = Bus(self.entity, name, self._signals,
                        self._optional_signals, array_idx=index)
 

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -511,6 +511,31 @@ class nullcontext(object):
         pass
 
 
+def reject_remaining_kwargs(name, kwargs):
+    """
+    Helper function to emulate python 3 keyword-only arguments.
+
+    Use as::
+
+        def func(x1, **kwargs):
+            a = kwargs.pop('a', 1)
+            b = kwargs.pop('b', 2)
+            reject_remaining_kwargs('func', kwargs)
+            ...
+
+    To emulate the Python 3 syntax::
+
+        def func(x1, *, a=1, b=2):
+            ...
+    """
+    if kwargs:
+        # match the error message to what python 3 produces
+        bad_arg = next(iter(kwargs))
+        raise TypeError(
+            '{}() got an unexpected keyword argument {!r}'.format(name, bad_arg)
+        )
+
+
 if __name__ == "__main__":
     import random
     a = ""

--- a/cocotb/wavedrom.py
+++ b/cocotb/wavedrom.py
@@ -30,6 +30,7 @@ from collections import OrderedDict, defaultdict
 import cocotb
 from cocotb.bus import Bus
 from cocotb.triggers import RisingEdge, ReadOnly
+from cocotb.utils import reject_remaining_kwargs
 
 
 class Wavedrom(object):
@@ -140,7 +141,9 @@ class trace(object):
     """
 
     def __init__(self, *args, **kwargs):
-        self._clock = kwargs.get("clk", None)
+        # emulate keyword-only arguments in python 2
+        self._clock = kwargs.pop("clk", None)
+        reject_remaining_kwargs('__init__', kwargs)
 
         self._signals = []
         for arg in args:


### PR DESCRIPTION
Silently discarded misspelt kwargs is a recipe for disaster.

This fixes #830 by rejecting the kwargs in BusDriver rather than accepting them in BusMonitor

This also fixes the same problem in wavedrom