### PR TITLE
Fix test_integers

### DIFF
--- a/tests/test_cases/issue_134/test_integers.py
+++ b/tests/test_cases/issue_134/test_integers.py
@@ -10,7 +10,6 @@ from cocotb.binary import BinaryValue
 
 
 @cocotb.test(expect_error=cocotb.SIM_NAME in ["Icarus Verilog"])
-@cocotb.test()
 def test_integer(dut):
     """
     Test access to integers


### PR DESCRIPTION
Remove the double test decorator causing incorrect data in the results.xml

Per request in #826, splitting un-related changes to separate pull-request.