### PR TITLE
Fix scheduler issues caused by compound triggers

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -40,7 +40,6 @@ from io import StringIO, BytesIO
 
 import cocotb
 from cocotb.log import SimLog
-from cocotb.triggers import Join, PythonTrigger, Timer, Event, NullTrigger
 from cocotb.result import (TestComplete, TestError, TestFailure, TestSuccess,
                            ReturnValue, raise_error, ExternalException)
 from cocotb.utils import get_sim_time, with_metaclass, exec_
@@ -162,6 +161,10 @@ class RunningCoroutine(object):
 
     def kill(self):
         """Kill a coroutine."""
+        if self._outcome is not None:
+            # already finished, nothing to kill
+            return
+
         self.log.debug("kill() called on coroutine")
         # todo: probably better to throw an exception for anyone waiting on the coroutine
         self._outcome = outcomes.Value(None)
@@ -169,7 +172,7 @@ class RunningCoroutine(object):
 
     def join(self):
         """Return a trigger that will fire when the wrapped coroutine exits."""
-        return Join(self)
+        return cocotb.triggers.Join(self)
 
     def has_started(self):
         return self._started

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -540,6 +540,16 @@ class First(_AggregateWaitable):
     Wait for the first of multiple triggers.
 
     Returns the result of the trigger that fired.
+
+    .. note::
+        The event loop is single threaded, so while events may be simultaneous
+        in simulation time, they can never be simultaneous in real time.
+        For this reason, the value of ``t_ret is t1`` in the following example
+        is implementation-defined, and will vary by simulator::
+
+            t1 = Timer(10, units='ps')
+            t2 = Timer(10, units='ps')
+            t_ret = yield First(t1, t2)
     """
     @decorators.coroutine
     def _wait(self):

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -38,12 +38,15 @@ else:
     simulator = None
 
 from cocotb.log import SimLog
-from cocotb.result import raise_error
+from cocotb.result import raise_error, ReturnValue
 from cocotb.utils import (
     get_sim_steps, get_time_from_sim_steps, with_metaclass,
     ParametrizedSingleton, exec_
 )
+from cocotb import decorators
 from cocotb import outcomes
+import cocotb
+
 
 class TriggerException(Exception):
     pass
@@ -264,90 +267,6 @@ class Edge(_EdgeBase):
     _edge_type = 3
 
 
-class ClockCycles(GPITrigger):
-    """Execution will resume after *num_cycles* rising edges or *num_cycles* falling edges."""
-    
-    def __init__(self, signal, num_cycles, rising=True):
-        super(ClockCycles, self).__init__()
-        self.signal = signal
-        self.num_cycles = num_cycles
-        if rising is True:
-            self._rising = 1
-        else:
-            self._rising = 2
-
-    def prime(self, callback):
-        """FIXME: document"""
-        self._callback = callback
-
-        def _check(obj):
-            self.unprime()
-
-            if self.signal.value:
-                self.num_cycles -= 1
-
-                if self.num_cycles <= 0:
-                    self._callback(self)
-                    return
-
-            self.cbhdl = simulator.register_value_change_callback(self.signal.
-                                                                  _handle,
-                                                                  _check,
-                                                                  self._rising,
-                                                                  self)
-            if self.cbhdl == 0:
-                raise_error(self, "Unable set up %s Trigger" % (str(self)))
-
-        self.cbhdl = simulator.register_value_change_callback(self.signal.
-                                                              _handle,
-                                                              _check,
-                                                              self._rising,
-                                                              self)
-        if self.cbhdl == 0:
-            raise_error(self, "Unable set up %s Trigger" % (str(self)))
-        Trigger.prime(self)
-
-    def __str__(self):
-        return self.__class__.__name__ + "(%s)" % self.signal._name
-
-
-class Combine(PythonTrigger):
-    """Combines multiple triggers together.  Coroutine will continue when all
-    triggers have fired.
-    """
-
-    def __init__(self, *args):
-        PythonTrigger.__init__(self)
-        self._triggers = args
-        # TODO: check that trigger is an iterable containing
-        # only Trigger objects
-        try:
-            for trigger in self._triggers:
-                if not isinstance(trigger, Trigger):
-                    raise TriggerException("All combined triggers must be "
-                                           "instances of Trigger! Got: %s" %
-                                           trigger.__class__.__name__)
-        except Exception:
-            raise TriggerException("%s requires a list of Trigger objects" %
-                                   self.__class__.__name__)
-
-    def prime(self, callback):
-        self._callback = callback
-        self._fired = []
-        for trigger in self._triggers:
-            trigger.prime(self._check_all_fired)
-        Trigger.prime(self)
-
-    def _check_all_fired(self, trigger):
-        self._fired.append(trigger)
-        if self._fired == self._triggers:
-            self._callback(self)
-
-    def unprime(self):
-        """FIXME: document"""
-        for trigger in self._triggers:
-            trigger.unprime()
-
 
 class _Event(PythonTrigger):
     """Unique instance used by the Event object.
@@ -544,3 +463,133 @@ class Join(with_metaclass(ParametrizedSingleton, PythonTrigger)):
 
     def __str__(self):
         return self.__class__.__name__ + "(%s)" % self._coroutine.__name__
+
+
+class Waitable(object):
+    """
+    Compatibility layer that emulates `collections.abc.Awaitable`.
+
+    This converts a `_wait` abstract method into a suitable `__await__` on
+    supporting python versions (>=3.3).
+    """
+    @decorators.coroutine
+    def _wait(self):
+        """
+        Should be implemented by the subclass. Called by `yield self` to
+        convert the waitable object into a coroutine.
+
+        ReturnValue can be used here
+        """
+        raise NotImplementedError
+        yield
+
+    if sys.version_info >= (3, 3):
+        def __await__(self):
+            return self._wait().__await__()
+
+
+class _AggregateWaitable(Waitable):
+    """
+    Base class for Waitables that take mutiple triggers in their constructor
+    """
+    def __init__(self, *args):
+        self.triggers = tuple(args)
+
+        # Do some basic type-checking up front, rather than waiting until we
+        # yield them.
+        allowed_types = (Trigger, Waitable, decorators.RunningCoroutine)
+        for trigger in self.triggers:
+            if not isinstance(trigger, allowed_types):
+                raise TypeError(
+                    "All triggers must be instances of Trigger! Got: {}"
+                    .format(type(trigger).__name__)
+                )
+
+
+class Combine(_AggregateWaitable):
+    """
+    Waits until all the passed triggers have fired.
+
+    Like most triggers, this simply returns itself.
+    """
+    @decorators.coroutine
+    def _wait(self):
+        waiters = []
+        e = Event()
+        triggers = list(self.triggers)
+
+        # start a parallel task for each trigger
+        for t in triggers:
+            @cocotb.coroutine
+            def waiter(t=t):
+                try:
+                    yield t
+                finally:
+                    triggers.remove(t)
+                    if not triggers:
+                        e.set()
+            waiters.append(cocotb.fork(waiter()))
+
+        # wait for the last waiter to complete
+        yield e.wait()
+        raise ReturnValue(self)
+
+
+class First(_AggregateWaitable):
+    """
+    Wait for the first of multiple triggers.
+
+    Returns the result of the trigger that fired.
+    """
+    @decorators.coroutine
+    def _wait(self):
+        waiters = []
+        e = Event()
+        triggers = list(self.triggers)
+        completed = []
+        # start a parallel task for each trigger
+        for t in triggers:
+            @cocotb.coroutine
+            def waiter(t=t):
+                # capture the outcome of this trigger
+                try:
+                    ret = outcomes.Value((yield t))
+                except BaseException as exc:
+                    ret = outcomes.Error(exc)
+
+                completed.append(ret)
+                e.set()
+            waiters.append(cocotb.fork(waiter()))
+
+        # wait for a waiter to complete
+        yield e.wait()
+
+        # kill all the other waiters
+        # TODO: Should this kill the coroutines behind any Join triggers?
+        # Right now it does not.
+        for w in waiters:
+            w.kill()
+
+        # get the result from the first task
+        ret = completed[0]
+        raise ReturnValue(ret.get())
+
+
+class ClockCycles(Waitable):
+    """
+    Execution will resume after *num_cycles* rising edges or *num_cycles* falling edges.
+    """
+    def __init__(self, signal, num_cycles, rising=True):
+        self.signal = signal
+        self.num_cycles = num_cycles
+        if rising is True:
+            self._type = RisingEdge
+        else:
+            self._type = FallingEdge
+
+    @decorators.coroutine
+    def _wait(self):
+        trigger = self._type(self.signal)
+        for _ in range(self.num_cycles):
+            yield trigger
+        raise ReturnValue(self)

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -173,22 +173,10 @@ of :keyword:`yield`. Provided they are decorated with ``@cocotb.coroutine``,
 is determined by which type of function it appears in, not by the
 sub-coroutinue being called.
 
-..note::
-
-    It is currently not possible to ``await`` a list of triggers as can be done
-    in a ``yield``-based coroutine with ``yield [trig1, trig2]``.
-    Until this becomes possible, a simple workaround is to create a helper
-    function like:
-
-    .. code-block:: python
-
-        @cocotb.coroutine
-        def first_of(triggers):
-            return (yield triggers)
-
-    which thanks to the interoperability between the two types of coroutinue,
-    can then be used as ``await first_of([trig1, trig2])``.
-
+.. note::
+    It is not legal to ``await`` a list of triggers as can be done in
+    ``yield``-based coroutine with ``yield [trig1, trig2]``. Use
+    ``await First(trig1, trig2)`` instead.
 
 Async generators
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is an alternative to #642

This adds support for a new type of object to the scheduler, a `Waitable`.
A `Waitable` is something that produces a new coroutine every time it is yielded.
`yield some_waitable` is nothing more than syntactic sugar for `yield some_waitable._wait()`.

With this new primitive, we can:
* Fix ClockCycles (gh-520)
* Fix Combine (gh-852)
* Remove `yield [a, b]` as a primitive, and build it into a new `yield First(a, b)` waitable. This allows a reasonable amount of simplification to the scheduler.