### PR TITLE
Remove an incorrect optimization in __await__

### DIFF
--- a/tests/test_cases/test_cocotb/test_cocotb_35.py
+++ b/tests/test_cases/test_cocotb/test_cocotb_35.py
@@ -107,3 +107,12 @@ async def test_trigger_await_gives_self(dut):
     t = Timer(1)
     t2 = await t
     assert t2 is t
+
+
+@cocotb.test()
+async def test_await_causes_start(dut):
+    """ Test that an annotated async coroutine gets marked as started """
+    coro = produce.async_annotated(Value(1))
+    assert not coro.has_started()
+    await coro
+    assert coro.has_started()


### PR DESCRIPTION
Directly yielding from the inner coroutine to bypasses the scheduler turns out to break parts of the public API.
This adds a previously-failing test, and fixes it.

If you want the efficiency of bypassing the scheduler, then the answer is simply to not attach a `@coroutine` decorator.

Follow up to #633 