### PR TITLE
Add windows build to travis (conda based)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,15 @@ jobs:
         - tox -e py27
 
     - stage: SimTests
+      python: 3.7
+      os: windows
+      language: shell
+      before_install:
+        - docker build -t cocotb -f Dockerfile.windows .
+      script:
+        - docker run cocotb powershell 'python setup.py install ; make test'
+
+    - stage: SimTests
       os: osx
       language: generic
       python: 3.6

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/windowsservercore:1803
+
+SHELL ["PowerShell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue';"]
+
+COPY . /src
+WORKDIR "c:\src"
+
+RUN Invoke-WebRequest -outfile miniconda3.exe https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe
+RUN Start-Process .\miniconda3.exe -ArgumentList '/S /D=C:\miniconda3' -Wait
+RUN [System.Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\miniconda3;C:\miniconda3\Library\mingw-w64\bin;C:\miniconda3\Library\usr\bin;C:\miniconda3\Library\bin;C:\miniconda3\Scripts;C:\miniconda3\bin;C:\miniconda3\condabin', 'Machine')
+RUN conda install --yes -c msys2 m2-base m2-make m2w64-toolchain libpython
+
+RUN Invoke-WebRequest -Uri http://bleyer.org/icarus/iverilog-10.1.1-x64_setup.exe -OutFile iverilog-10.1.1-x64_setup.exe
+RUN Start-Process .\iverilog-10.1.1-x64_setup -ArgumentList '/VERYSILENT' -Wait
+RUN [System.Environment]::SetEnvironmentVariable('Path', $env:Path+';C:\iverilog\bin', 'Machine')

--- a/cocotb/share/makefiles/simulators/Makefile.icarus
+++ b/cocotb/share/makefiles/simulators/Makefile.icarus
@@ -68,7 +68,8 @@ EXTRA_LIBS := -lvpi
 EXTRA_LIBDIRS := -L$(ICARUS_BIN_DIR)/../lib
 OLD_PATH := $(shell echo "$(PATH)" | sed 's/(/\\(/g' | sed 's/)/\\)/g' | sed 's/ /\\ /g')
 LIB_LOAD = PATH=$(OLD_PATH):$(LIB_DIR)
-NEW_PYTHONPATH := $(shell echo "$(PYTHONPATH)" | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):\//\/\1\//g' -e 's/;/:/g')
+NEW_PYTHONPATH:=$(shell python -c "import sys, os; print(':'.join(['/'+dir.replace(os.sep,'/').replace(':','') for dir in sys.path]))")
+PWD = $(shell pwd)
 
 else
 LIB_LOAD := LD_LIBRARY_PATH=$(LIB_DIR):$(LD_LIBRARY_PATH)


### PR DESCRIPTION
It is in favor of  #703.
It uses [conda](https://conda.io/) since it needs minimal change to makefiles and seems easier to work on windows.
It does not use `tox` since this is much more involved if using conda with msys (I expect checking the packaging on Linux should be enough for now).

Alternative (a bit less nice but 2x faster) is to do without docker: https://github.com/themperek/cocotb/blob/win_conda_2/.travis.yml
