### PR TITLE
Small documentation fixes

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -113,7 +113,24 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+
+# The Read the Docs theme is available from
+# https://github.com/snide/sphinx_rtd_theme
+#
+# Install with
+# - pip install sphinx_rtd_theme
+# or
+# - apt-get install python-sphinx-rtd-theme
+
+try:
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+except ImportError:
+    sys.stderr.write('Warning: The Sphinx \'sphinx_rtd_theme\' HTML theme was '+
+        'not found. Make sure you have the theme installed to produce pretty '+
+        'HTML output. Falling back to the default theme.\n')
+
+    html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -210,6 +210,5 @@ type of generator function that can be iterated with ``async for``:
         async for sample in ten_samples_of(dut.clk, dut.signal):
             assert sample % 2 == 0
 
-More details on this type of generator can be found in `PEP 525`_.
+More details on this type of generator can be found in :pep:`525`.
 
-.. PEP 525: https://www.python.org/dev/peps/pep-0525/

--- a/documentation/source/coroutines.rst
+++ b/documentation/source/coroutines.rst
@@ -10,7 +10,7 @@ Typically coroutines :keyword:`yield` a :any:`Trigger` object which
 indicates to the simulator some event which will cause the coroutine to be woken
 when it occurs.  For example:
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.coroutine
     def wait_10ns():
@@ -20,7 +20,7 @@ when it occurs.  For example:
 
 Coroutines may also yield other coroutines:
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.coroutine
     def wait_100ns():
@@ -30,7 +30,7 @@ Coroutines may also yield other coroutines:
 Coroutines can return a value, so that they can be used by other coroutines.
 Before Python 3.3, this requires a :any:`ReturnValue` to be raised.
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.coroutine
     def get_signal(clk, signal):
@@ -54,7 +54,7 @@ Before Python 3.3, this requires a :any:`ReturnValue` to be raised.
 Coroutines may also yield a list of triggers and coroutines to indicate that
 execution should resume if *any* of them fires:
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.coroutine
     def packet_with_timeout(monitor, timeout):
@@ -65,7 +65,7 @@ execution should resume if *any* of them fires:
 The trigger that caused execution to resume is passed back to the coroutine,
 allowing them to distinguish which trigger fired:
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.coroutine
     def packet_with_timeout(monitor, timeout):
@@ -79,7 +79,7 @@ allowing them to distinguish which trigger fired:
 Coroutines can be forked for parallel operation within a function of that code and
 the forked code.
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.test()
     def test_act_during_reset(dut):
@@ -99,7 +99,7 @@ the forked code.
 
 Coroutines can be joined to end parallel operation within a function.
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.test()
     def test_count_edge_cycles(dut, period=1000, clocks=6):
@@ -124,7 +124,7 @@ Coroutines can be joined to end parallel operation within a function.
 Coroutines can be killed before they complete, forcing their completion before
 they'd naturally end.
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.test()
     def test_different_clocks(dut):
@@ -158,7 +158,7 @@ Async functions
 Python 3.5 introduces :keyword:`async` functions, which provide an alternative
 syntax. For example:
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.coroutine
     async def wait_10ns():
@@ -198,7 +198,7 @@ meaning (rather than being a ``SyntaxError``) which matches the typical meaning
 of ``yield`` within regular python code. It can be used to create a special
 type of generator function that can be iterated with ``async for``:
 
-.. code-block:: python
+.. code-block:: python3
 
     async def ten_samples_of(clk, signal):
         for i in range(10):

--- a/documentation/source/endian_swapper.rst
+++ b/documentation/source/endian_swapper.rst
@@ -32,7 +32,7 @@ It is possible to write directed tests without using a testbench class
 however to encourage code re-use it is good practice to create a distinct class.
 
 
-.. code-block:: python
+.. code-block:: python3
 
     class EndianSwapperTB(object):
     
@@ -55,7 +55,7 @@ With the above code we have created a testbench with the following structure:
 
 If we inspect this line-by-line:
 
-.. code-block:: python
+.. code-block:: python3
 
     self.stream_in  = AvalonSTDriver(dut, "stream_in", dut.clk)
 
@@ -81,7 +81,7 @@ Name                        Type              Description (from Avalon Specifica
 By following the signal naming convention the driver can find the signals associated with this interface automatically.
 
 
-.. code-block:: python
+.. code-block:: python3
 
             self.stream_out = AvalonSTMonitor(dut, "stream_out", dut.clk)
             self.csr = AvalonMaster(dut, "csr", dut.clk)
@@ -89,7 +89,7 @@ By following the signal naming convention the driver can find the signals associ
 We do the same to create the :class:`monitor <cocotb.monitors.avalon.AvalonSTPkts>` on ``stream_out`` and the CSR interface.
 
 
-.. code-block:: python
+.. code-block:: python3
 
             self.expected_output = []
             self.scoreboard = Scoreboard(dut)
@@ -101,7 +101,7 @@ The call to :meth:`.add_interface()` takes a Monitor instance as the first argum
 the second argument is a mechanism for describing the expected output for that interface.
 This could be a callable function but in this example a simple list of expected transactions is sufficient.
 
-.. code-block:: python
+.. code-block:: python3
 
             # Reconstruct the input transactions from the pins and send them to our 'model'
             self.stream_in_recovered = AvalonSTMonitor(dut, "stream_in", dut.clk, callback=self.model)
@@ -115,7 +115,7 @@ We also pass the keyword argument ``callback`` to the monitor constructor which 
 in the supplied function being called for each transaction seen on the bus with the transaction as the first argument.
 Our model function is quite straightforward in this case - we simply append the transaction to the expected output list and increment a counter:
 
-.. code-block:: python
+.. code-block:: python3
 
     def model(self, transaction):
         """Model the DUT based on the input transaction"""
@@ -136,7 +136,7 @@ There are various 'knobs' we can tweak on this testbench to vary the behaviour:
 We want to run different variations of tests but they will all have a very similar structure so we create a common ``run_test`` function.
 To generate backpressure on the ``stream_out`` interface we use the :class:`.BitDriver` class from :mod:`cocotb.drivers`.
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.coroutine
     def run_test(dut, data_in=None, config_coroutine=None, idle_inserter=None, backpressure_inserter=None):
@@ -188,7 +188,7 @@ Test permutations
 
 Having defined a test function we can now auto-generate different permutations of tests using the :class:`.TestFactory` class:
 
-.. code-block:: python
+.. code-block:: python3
 
     factory = TestFactory(run_test)
     factory.add_option("data_in",                 [random_packet_sizes])

--- a/documentation/source/examples.rst
+++ b/documentation/source/examples.rst
@@ -81,7 +81,7 @@ Sorter
 
 Example testbench for snippet of code from `comp.lang.verilog <https://github.com/chiggs/comp.lang.verilog/blob/master/maja55/testbench.py>`_:
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.coroutine
     def run_test(dut, data_generator=random_data, delay_cycles=2):

--- a/documentation/source/hal_cosimulation.rst
+++ b/documentation/source/hal_cosimulation.rst
@@ -123,7 +123,7 @@ to be called when the HAL attempts to perform a read or write.
 These are then passed to the `IO Module`_:
 
 
-.. code-block:: python
+.. code-block:: python3
 
 
     @cocotb.function
@@ -147,7 +147,7 @@ We can then initialise the HAL and call functions, using the :class:`cocotb.exte
 decorator to turn the normal function into a blocking coroutine that we can
 ``yield``:
 
-.. code-block:: python
+.. code-block:: python3
 
     state = hal.endian_swapper_init(0)
     yield cocotb.external(hal.endian_swapper_enable)(state)

--- a/documentation/source/ping_tun_tap.rst
+++ b/documentation/source/ping_tun_tap.rst
@@ -44,7 +44,7 @@ a huge developer base and a quick search of the web reveals a `TUN example`_
 that looks like an ideal starting point for our testbench. Using this example
 we write a function that will create our virtual interface:
 
-.. code-block:: python
+.. code-block:: python3
 
     import subprocess, fcntl, struct
     
@@ -66,7 +66,7 @@ signal and connect up the :class:`Avalon driver <cocotb.drivers.avalon.AvalonSTP
 the testbench we'll enable verbose debug on the drivers and monitors by setting
 the log level to ``logging.DEBUG``.
 
-.. code-block:: python
+.. code-block:: python3
 
     import cocotb
     from cocotb.clock import Clock
@@ -89,7 +89,7 @@ We also need to reset the DUT and drive some default values onto some of the
 bus signals.  Note that we'll need to import the :class:`~.triggers.Timer`
 and :class:`~.triggers.RisingEdge` triggers.
 
-.. code-block:: python
+.. code-block:: python3
 
         # Reset the DUT
         dut._log.debug("Resetting DUT")
@@ -111,7 +111,7 @@ a packet to arrive on the monitor by yielding on :meth:`.wait_for_recv()` and th
 write the received packet back to the TUN file descriptor.
 
 
-.. code-block:: python
+.. code-block:: python3
 
     # Create our interface (destroyed at the end of the test)
     tun = create_tun()

--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -211,7 +211,7 @@ handle is used in all Python files referencing your RTL project. Assuming we
 have a toplevel port called ``clk`` we could create a test file containing the
 following:
 
-.. code-block:: python
+.. code-block:: python3
 
     import cocotb
     from cocotb.triggers import Timer
@@ -239,7 +239,7 @@ and creates a handle called ``dut``. Top-level signals can be accessed using the
 "dot" notation used for accessing object attributes in Python. The same mechanism
 can be used to access signals inside the design.
 
-.. code-block:: python
+.. code-block:: python3
 
     # Get a reference to the "clk" signal on the top-level
     clk = dut.clk
@@ -256,7 +256,7 @@ Values can be assigned to signals using either the
 :attr:`~cocotb.handle.NonHierarchyObject.value` property of a handle object
 or using direct assignment while traversing the hierarchy.
 
-.. code-block:: python
+.. code-block:: python3
     
     # Get a reference to the "clk" signal and assign a value
     clk = dut.clk
@@ -284,7 +284,7 @@ Accessing the :attr:`~cocotb.handle.NonHierarchyObject.value` property of a hand
 Any unresolved bits are preserved and can be accessed using the :attr:`~cocotb.binary.BinaryValue.binstr` attribute,
 or a resolved integer value can be accessed using the :attr:`~cocotb.binary.BinaryValue.integer` attribute.
 
-.. code-block:: python
+.. code-block:: python3
     
     >>> # Read a value back from the DUT
     >>> count = dut.counter.value
@@ -300,7 +300,7 @@ or a resolved integer value can be accessed using the :attr:`~cocotb.binary.Bina
 
 We can also cast the signal handle directly to an integer:
 
-.. code-block:: python
+.. code-block:: python3
 
     >>> print(int(dut.counter))
     42
@@ -310,7 +310,7 @@ We can also cast the signal handle directly to an integer:
 Parallel and sequential execution of coroutines
 -----------------------------------------------
 
-.. code-block:: python
+.. code-block:: python3
 
     @cocotb.coroutine
     def reset_dut(reset_n, duration):

--- a/documentation/source/simulator_support.rst
+++ b/documentation/source/simulator_support.rst
@@ -9,7 +9,7 @@ Icarus
 
 Accessing bits of a vector doesn't work:
 
-.. code-block:: python
+.. code-block:: python3
 
     dut.stream_in_data[2] <= 1
 

--- a/documentation/source/testbench_tools.rst
+++ b/documentation/source/testbench_tools.rst
@@ -17,7 +17,7 @@ component with the Python logging functionality.
 
 Log printing levels can also be set on a per-object basis. 
 
-.. code-block:: python
+.. code-block:: python3
 
         class EndianSwapperTB(object):
     
@@ -35,7 +35,7 @@ Log printing levels can also be set on a per-object basis.
 
 And when the logging is actually called
 
-.. code-block:: python
+.. code-block:: python3
 
         class AvalonSTPkts(BusMonitor):
         ...
@@ -73,7 +73,7 @@ Busses are simply defined as collection of signals. The :class:`.Bus` class
 will automatically bundle any group of signals together that are named similar
 to ``dut.<bus_name><separator><signal_name>``. For instance,
 
-.. code-block:: python
+.. code-block:: python3
 
         dut.stream_in_valid
         dut.stream_in_data
@@ -84,7 +84,7 @@ names to signal names is also passed into the :class:`.Bus` class. Busses can
 have values driven onto them, be captured (returning a dictionary), or sampled
 and stored into a similar object. 
 
-.. code-block:: python
+.. code-block:: python3
 
      stream_in_bus = Bus(dut, "stream_in", ["valid", "data"]) # '_' is the default separator
 
@@ -98,7 +98,7 @@ transactions to perform the serialization of transactions onto a physical
 interface. Here is an example using the Avalon bus driver in the ``endian_swapper``
 example:
 
-.. code-block:: python
+.. code-block:: python3
 
     class EndianSwapperTB(object):
     
@@ -140,7 +140,7 @@ have a callback function passed that is a model. This model will often generate
 expected transactions, which are then compared using the :class:`.Scoreboard`
 class.
 
-.. code-block:: python
+.. code-block:: python3
 
     # ==============================================================================
     class BitMonitor(Monitor):
@@ -201,7 +201,7 @@ and the expected outputs can be either a simple list, or a function that
 provides a transaction. Here is some code from the ``dff`` example, similar to
 above with the scoreboard added. 
 
-.. code-block:: python
+.. code-block:: python3
                 
     class DFF_TB(object):
         def __init__(self, dut, init_val):


### PR DESCRIPTION
Fix various smaller things in the documentation:
- Switch to the RTD theme in local builds.
- Use Python 3 syntax highlighting (e.g. to highlight the `await` keyword)
- Fix a broken inline link