### PR TITLE
WIP: parallel execution without Makefile - demo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,7 @@ jobs:
       python: 3.7
       before_install: *travis_linx_prep
       script:
+        - python setup.py install
         - cd examples/dff/tests
         - pytest -s dff_cocotb.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,13 @@ jobs:
       script:
         - tox -e py37
 
+    - stage: pytest
+      python: 3.7
+      before_install: *travis_linx_prep
+      script:
+        - cd examples/dff/tests
+        - pytest -s dff_cocotb.py
+
   allow_failures:
     - stage: SimTests
       python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,8 +107,8 @@ jobs:
       before_install: *travis_linx_prep
       script:
         - python setup.py install
-        - cd examples/dff/tests
-        - pytest -s dff_cocotb.py
+        - cd examples/dff
+        - pytest -s
 
   allow_failures:
     - stage: SimTests

--- a/cocotb/clock.py
+++ b/cocotb/clock.py
@@ -30,10 +30,11 @@
 import os
 import itertools
 
-if "SPHINX_BUILD" in os.environ:
-    simulator = None
-else:
+if "COCOTB_SIM" in os.environ:
     import simulator
+else:
+    simulator = None
+
 import cocotb
 from cocotb.log import SimLog
 from cocotb.triggers import Timer, RisingEdge

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -459,7 +459,9 @@ class TestFactory(object):
     Tests are simply named ``test_function_N``. The docstring for the test (hence
     the test description) includes the name and description of each generator.
     """
-
+    
+    __test__ = False    
+    
     def __init__(self, test_function, *args, **kwargs):
         """
         Args:

--- a/cocotb/result.py
+++ b/cocotb/result.py
@@ -77,6 +77,8 @@ class ReturnValue(Exception):
 
 
 class TestComplete(Exception):
+    __test__ = False
+
     """Exception showing that test was completed. Sub-exceptions detail the exit status."""
     def __init__(self, *args, **kwargs):
         super(TestComplete, self).__init__(*args, **kwargs)

--- a/cocotb/run.py
+++ b/cocotb/run.py
@@ -1,0 +1,175 @@
+"""A run class."""
+
+from subprocess import Popen
+import os
+import sys
+import sysconfig
+import cocotb
+import errno
+import distutils
+
+from setuptools import Extension
+from setuptools.command.build_ext import build_ext
+from setuptools.dist import Distribution
+
+cfg_vars = distutils.sysconfig.get_config_vars()
+for key, value in cfg_vars.items():
+    if type(value) == str:
+        cfg_vars[key] = value.replace("-Wstrict-prototypes", "")
+
+
+def _symlink_force(target, link_name):
+    try:
+        os.symlink(target, link_name)
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            os.remove(link_name)
+            os.symlink(target, link_name)
+        else:
+            raise e
+
+
+def _build_lib(lib, dist):
+    dist.ext_modules = [lib]
+    _build_ext = build_ext(dist)
+    _build_ext.finalize_options()
+
+    _build_ext.run()
+    out_lib = _build_ext.get_outputs()
+
+    lib_name = lib.name
+    lib_path = os.path.abspath(out_lib[0])
+    dir_name = os.path.dirname(lib_path)
+    ext_name = os.path.splitext(lib_path)[1][1:]
+
+    print("Building:", out_lib[0])
+
+    _symlink_force(
+        lib_path, os.path.join(os.path.abspath(dir_name), lib_name + "." + ext_name)
+    )
+
+    return dir_name
+
+
+def build_libs():
+    share_dir = os.path.join(os.path.dirname(cocotb.__file__), "share")
+
+    python_lib = sysconfig.get_config_var("LDLIBRARY")
+    python_lib_link = os.path.splitext(python_lib)[0][3:]
+
+    dist = Distribution()
+    dist.parse_config_files()
+
+    libcocotbutils = Extension(
+        "libcocotbutils",
+        include_dirs=[share_dir + "/include"],
+        sources=[share_dir + "/lib/utils/cocotb_utils.c"],
+    )
+
+    lib_path = _build_lib(libcocotbutils, dist)
+
+    libgpilog = Extension(
+        "libgpilog",
+        include_dirs=[share_dir + "/include"],
+        libraries=[python_lib_link, "pthread", "dl", "util", "rt", "m", "cocotbutils"],
+        library_dirs=[lib_path],
+        sources=[share_dir + "/lib/gpi_log/gpi_logging.c"],
+    )
+
+    _build_lib(libgpilog, dist)
+
+    libcocotb = Extension(
+        "libcocotb",
+        define_macros=[("PYTHON_SO_LIB", python_lib)],
+        include_dirs=[share_dir + "/include"],
+        sources=[share_dir + "/lib/embed/gpi_embed.c"],
+    )
+
+    _build_lib(libcocotb, dist)
+
+    libgpi = Extension(
+        "libgpi",
+        include_dirs=[share_dir + "/include"],
+        libraries=["cocotbutils", "gpilog", "cocotb", "stdc++"],
+        library_dirs=[lib_path],
+        sources=[
+            share_dir + "/lib/gpi/GpiCbHdl.cpp",
+            share_dir + "/lib/gpi/GpiCommon.cpp",
+        ],
+    )
+
+    _build_lib(libgpi, dist)
+
+    libsim = Extension(
+        "libsim",
+        include_dirs=[share_dir + "/include"],
+        sources=[share_dir + "/lib/simulator/simulatormodule.c"],
+    )
+
+    _build_lib(libsim, dist)
+
+    libvpi = Extension(
+        "libvpi",
+        include_dirs=[share_dir + "/include"],
+        libraries=["gpi", "gpilog"],
+        library_dirs=[lib_path],
+        sources=[
+            share_dir + "/lib/vpi/VpiImpl.cpp",
+            share_dir + "/lib/vpi/VpiCbHdl.cpp",
+        ],
+    )
+
+    _build_lib(libvpi, dist)
+
+    _symlink_force(
+        os.path.join(os.path.abspath(lib_path), "libvpi.so"),
+        os.path.join(os.path.abspath(lib_path), "gpivpi.vpl"),
+    )
+    _symlink_force(
+        os.path.join(os.path.abspath(lib_path), "libvpi.so"),
+        os.path.join(os.path.abspath(lib_path), "cocotb.vpl"),
+    )
+    _symlink_force(
+        os.path.join(os.path.abspath(lib_path), "libsim.so"),
+        os.path.join(os.path.abspath(lib_path), "simulator.so"),
+    )
+
+    return lib_path
+
+
+def Run(sources, toplevel, module):
+
+    libs_dir = build_libs()
+
+    my_env = os.environ
+    my_env["LD_LIBRARY_PATH"] = libs_dir + ":" + sysconfig.get_config_var("LIBDIR")
+
+    python_path = ":".join(sys.path)
+    my_env["PYTHONPATH"] = python_path + ":" + libs_dir
+    my_env["TOPLEVEL"] = toplevel
+    my_env["TOPLEVEL_LANG"] = "verilog"
+    my_env["COCOTB_SIM"] = "1"
+    my_env["MODULE"] = module
+
+    os.makedirs("sim_build", exist_ok=True)
+
+    sources_abs = []
+    for src in sources:
+        sources_abs.append(os.path.abspath(src))
+
+    comp_cmd = [
+        "iverilog",
+        "-o",
+        "sim_build/sim.vvp",
+        "-D",
+        "COCOTB_SIM=1",
+        "-s",
+        toplevel,
+        "-g2012",
+    ] + sources_abs
+    print(" ".join(comp_cmd))
+    process = Popen(comp_cmd).wait()
+
+    cmd = ["vvp", "-M", libs_dir, "-m", "gpivpi", "sim_build/sim.vvp"]
+    print(" ".join(cmd))
+    process = Popen(cmd).wait()

--- a/cocotb/run.py
+++ b/cocotb/run.py
@@ -179,6 +179,6 @@ def Run(sources, toplevel, module=None):
     print(" ".join(comp_cmd))
     process = subprocess.check_call(comp_cmd)
 
-    cmd = ["vvp", "-M", libs_dir, "-m", "gpivpi", sim_comopile_file]
+    cmd = ["vvp", "-M", libs_dir, "-m", "gpivpi", sim_compile_file]
     print(" ".join(cmd))
     process = subprocess.check_call(cmd)

--- a/cocotb/run.py
+++ b/cocotb/run.py
@@ -159,7 +159,7 @@ def Run(sources, toplevel, module=None):
 
     sim_build_dir = os.path.join(run_dir_name, "sim_build")
     os.makedirs(sim_build_dir, exist_ok=True)
-    sim_comopile_file = os.path.join(sim_build_dir, "sim.vvp")
+    sim_compile_file = os.path.join(sim_build_dir, "sim.vvp")
 
     sources_abs = []
     for src in sources:
@@ -168,7 +168,7 @@ def Run(sources, toplevel, module=None):
     comp_cmd = [
         "iverilog",
         "-o",
-        sim_comopile_file,
+        sim_compile_file,
         "-D",
         "COCOTB_SIM=1",
         "-s",

--- a/examples/dff/tests/Makefile
+++ b/examples/dff/tests/Makefile
@@ -16,7 +16,7 @@ else
 endif
 
 TOPLEVEL=dff
-MODULE=$(TOPLEVEL)_cocotb
+MODULE=test_$(TOPLEVEL)
 
 CUSTOM_SIM_DEPS=$(CWD)/Makefile
 

--- a/examples/dff/tests/dff_cocotb.py
+++ b/examples/dff/tests/dff_cocotb.py
@@ -37,6 +37,7 @@ from cocotb.binary import BinaryValue
 from cocotb.regression import TestFactory
 from cocotb.scoreboard import Scoreboard
 from cocotb.result import TestFailure, TestSuccess
+from cocotb.run import Run
 
 # ==============================================================================
 class BitMonitor(Monitor):
@@ -139,3 +140,10 @@ def run_test(dut):
 # Register the test.
 factory = TestFactory(run_test)
 factory.generate_tests()
+
+def test_run():
+    Run(sources=['../hdl/dff.v'], toplevel='dff', module='dff_cocotb')
+
+if __name__ == "__main__":
+    test_run()
+

--- a/examples/dff/tests/test_dff.py
+++ b/examples/dff/tests/test_dff.py
@@ -142,7 +142,7 @@ factory = TestFactory(run_test)
 factory.generate_tests()
 
 def test_run():
-    Run(sources=['../hdl/dff.v'], toplevel='dff', module='dff_cocotb')
+    Run(sources=['../hdl/dff.v'], toplevel='dff')
 
 if __name__ == "__main__":
     test_run()


### PR DESCRIPTION
A very unpolished demo for #696 that removes the need for Makefiles (for discussion).
Libraries are build using setuptools Extension.
Allow basic discovery by pytest (better integration TBD).
Better portability.

The use case would be to run `pytest -n 16` which would discover all the test and run them in parallel/distributed using [pytest-xdist](https://github.com/pytest-dev/pytest-xdist).

Usage is to add somewhere in the test module (no Makefile needed):
```python3
def test_run():
    Run(sources=['../hdl/dff.v'], toplevel='dff')
```
and run `pytest`

Comments, suggestions help highly appreciated.