### PR TITLE
Change makefiles to use realpath function.

### DIFF
--- a/cocotb/share/makefiles/Makefile.inc
+++ b/cocotb/share/makefiles/Makefile.inc
@@ -31,13 +31,13 @@
 
 # Directory containing the cocotb Python module
 ifeq ($(COCOTB_PY_DIR),)
-export COCOTB_PY_DIR:=$(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../../..)
+export COCOTB_PY_DIR:=$(realpath $(dir $(lastword $(MAKEFILE_LIST)))/../../..)
 endif
 
 # Directory containing all support files required to build cocotb-based
 # simulations: Makefile fragments, and the simulator libraries.
 ifeq ($(COCOTB_SHARE_DIR),)
-export COCOTB_SHARE_DIR:=$(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+export COCOTB_SHARE_DIR:=$(realpath $(dir $(lastword $(MAKEFILE_LIST)))/..)
 endif
 
 ifeq ($(COCOTB_PY_DIR),$(COCOTB_SHARE_DIR))
@@ -45,7 +45,7 @@ $(warning 'Deprecated cocotb file structure detected. Please use "include $$(she
 endif
 
 ifeq ($(USER_DIR),)
-export USER_DIR:=$(abspath $(dir $(firstword $(MAKEFILE_LIST))))
+export USER_DIR:=$(realpath $(dir $(firstword $(MAKEFILE_LIST))))
 endif
 
 BUILD_DIR=$(USER_DIR)/build

--- a/makefiles/Makefile.inc
+++ b/makefiles/Makefile.inc
@@ -32,5 +32,5 @@
 COCOTB_INSTALL_METHOD = srctree
 export COCOTB_INSTALL_METHOD
 
-_NEW_SHARE_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/../cocotb/share
+_NEW_SHARE_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/../cocotb/share
 include $(_NEW_SHARE_DIR)/makefiles/Makefile.inc

--- a/makefiles/Makefile.sim
+++ b/makefiles/Makefile.sim
@@ -35,5 +35,5 @@
 COCOTB_INSTALL_METHOD = srctree
 export COCOTB_INSTALL_METHOD
 
-_NEW_SHARE_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/../cocotb/share
+_NEW_SHARE_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/../cocotb/share
 include $(_NEW_SHARE_DIR)/makefiles/Makefile.sim


### PR DESCRIPTION
The realpath function returns the canonical absolute name for files
and directories. It removes any . or .. components and resolves
symlinks. It also requires that the file or directory exists. In case of
a failure the empty string is returned.

There were errors occurring in Windows MSYS builds relating to the abspath function that this resolves.