### PR TITLE
Rename context for clarity.

### DIFF
--- a/cocotb/share/include/cocotb_utils.h
+++ b/cocotb/share/include/cocotb_utils.h
@@ -43,25 +43,25 @@ extern "C" {
 extern void* utils_dyn_open(const char* lib_name);
 extern void* utils_dyn_sym(void *handle, const char* sym_name);
 
-extern int context;
+extern int is_python_context;
 
 void to_python(void) {
-    if (context) {
+    if (is_python_context) {
         fprintf(stderr, "FATAL: We are calling up again\n");
         exit(1);
     }
-    ++context;
-    //fprintf(stderr, "INFO: Calling up to python %d\n", context);
+    ++is_python_context;
+    //fprintf(stderr, "INFO: Calling up to python %d\n", is_python_context);
 }
 
 void to_simulator(void) {
-    if (!context) {
+    if (!is_python_context) {
         fprintf(stderr, "FATAL: We have returned twice from python\n");
         exit(1);
     }
 
-    --context;
-    //fprintf(stderr, "INFO: Returning back to simulator %d\n", context);
+    --is_python_context;
+    //fprintf(stderr, "INFO: Returning back to simulator %d\n", is_python_context);
 }
 
 #ifdef __cplusplus

--- a/cocotb/share/lib/simulator/simulatormodule.c
+++ b/cocotb/share/lib/simulator/simulatormodule.c
@@ -822,7 +822,7 @@ static PyObject *get_sim_time(PyObject *self, PyObject *args)
 {
     struct sim_time local_time;
 
-    if (context) {
+    if (is_python_context) {
         gpi_get_sim_time(&local_time.high, &local_time.low);
     } else {
         local_time = cache_time;

--- a/cocotb/share/lib/utils/cocotb_utils.c
+++ b/cocotb/share/lib/utils/cocotb_utils.c
@@ -37,7 +37,7 @@
 #endif
 
 // Tracks if we are in the context of Python or Simulator
-int context = 0;
+int is_python_context = 0;
 
 void* utils_dyn_open(const char* lib_name)
 {


### PR DESCRIPTION
Add named constants for clarity when reading and modifying the libraries.