### PR TITLE
Error when compiling VhpiCbHdl.cpp

### DIFF
--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -784,7 +784,7 @@ int VhpiStartupCbHdl::run_callback() {
 
         argv_iter = vhpi_iterator(vhpiArgvs, tool);
         if (argv_iter) {
-            while ((argv_hdl = vhpi_scan(argv_iter))) {
+            while ((argv_hdl = vhpi_scan(argv_iter)))  {
                 tool_argv[i] = const_cast<char*>(static_cast<const char*>(vhpi_get_str(vhpiStrValP, argv_hdl)));
                 i++;
             }

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -784,7 +784,7 @@ int VhpiStartupCbHdl::run_callback() {
 
         argv_iter = vhpi_iterator(vhpiArgvs, tool);
         if (argv_iter) {
-            while ((argv_hdl = vhpi_scan(argv_iter)))  {
+            while ((argv_hdl = vhpi_scan(argv_iter))) {
                 tool_argv[i] = const_cast<char*>(static_cast<const char*>(vhpi_get_str(vhpiStrValP, argv_hdl)));
                 i++;
             }

--- a/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
+++ b/cocotb/share/lib/vhpi/VhpiCbHdl.cpp
@@ -784,7 +784,7 @@ int VhpiStartupCbHdl::run_callback() {
 
         argv_iter = vhpi_iterator(vhpiArgvs, tool);
         if (argv_iter) {
-            while (argv_hdl = vhpi_scan(argv_iter)) {
+            while ((argv_hdl = vhpi_scan(argv_iter))) {
                 tool_argv[i] = const_cast<char*>(static_cast<const char*>(vhpi_get_str(vhpiStrValP, argv_hdl)));
                 i++;
             }


### PR DESCRIPTION
On a fresh install: 
RH6.6
GCC8.1.0
Python37

Getting this error when building:

```
> VhpiCbHdl.cpp: In member function 'virtual int VhpiStartupCbHdl::run_callback()':
> VhpiCbHdl.cpp:787:29: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
>              while (argv_hdl = vhpi_scan(argv_iter)) {
>                     ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
> cc1plus: all warnings being treated as errors   
```

Simply adding extra parenthesis solves it.