### PR TITLE
Whitelist make command in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,6 @@ deps =
 
 commands =
     make test
+
+whitelist_externals =
+    make


### PR DESCRIPTION
Fix the following warning when running tox:

WARNING:test command found but not installed in testenv
  cmd: /usr/bin/make
  env: /data/home/xxx/src/cocotb/.tox/py35
Maybe you forgot to specify a dependency? See also the
whitelist_externals envconfig setting.