### PR TITLE
Fixes 893: No error traceback in forked coroutines

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -470,6 +470,9 @@ class Scheduler(object):
                 # throws an error if the background coroutine errored
                 # and no one was monitoring it
                 coro.retval
+            except TestComplete as test_result:
+                self.log.debug("TestComplete received: {}".format(test_result.__class__.__name__))
+                self.finish_test(test_result)
             except Exception as e:
                 self.finish_test(create_error(self, "Forked coroutine {} raised exception: {}".format(coro, e)))
 

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -471,11 +471,7 @@ class Scheduler(object):
                 # and no one was monitoring it
                 coro.retval
             except Exception as e:
-                self._test_result = TestError(
-                    "Forked coroutine {} raised exception {}"
-                    .format(coro, e)
-                )
-                self._terminate = True
+                self.finish_test(create_error(self, "Forked coroutine {} raised exception: {}".format(coro, e)))
 
     def save_write(self, handle, value):
         if self._mode == Scheduler._MODE_READONLY:

--- a/tests/test_cases/issue_892/Makefile
+++ b/tests/test_cases/issue_892/Makefile
@@ -1,0 +1,33 @@
+###############################################################################
+# Copyright (c) 2013 Potential Ventures Ltd
+# Copyright (c) 2013 SolarFlare Communications Inc
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Potential Ventures Ltd,
+#       SolarFlare Communications Inc nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_892

--- a/tests/test_cases/issue_892/issue_892.py
+++ b/tests/test_cases/issue_892/issue_892.py
@@ -1,0 +1,13 @@
+import cocotb
+from cocotb.triggers import Timer
+from cocotb.result import TestSuccess
+
+@cocotb.coroutine
+def raise_test_success():
+    yield Timer(1, units='ns')
+    raise TestSuccess("TestSuccess")
+
+@cocotb.test()
+def error_test(dut):
+    cocotb.fork(raise_test_success())
+    yield Timer(10, units='ns')

--- a/tests/test_cases/issue_893/Makefile
+++ b/tests/test_cases/issue_893/Makefile
@@ -1,0 +1,33 @@
+###############################################################################
+# Copyright (c) 2013 Potential Ventures Ltd
+# Copyright (c) 2013 SolarFlare Communications Inc
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Potential Ventures Ltd,
+#       SolarFlare Communications Inc nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL POTENTIAL VENTURES LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_893

--- a/tests/test_cases/issue_893/issue_893.py
+++ b/tests/test_cases/issue_893/issue_893.py
@@ -1,0 +1,13 @@
+import cocotb
+from cocotb.triggers import Timer, NullTrigger
+
+@cocotb.coroutine
+def coroutine_with_undef():
+    new_variable = undefined_variable
+    yield Timer(1, units='ns')
+
+@cocotb.test(expect_error=True)
+def fork_erroring_coroutine(dut):
+    cocotb.fork(coroutine_with_undef())
+    yield Timer(10, units='ns')
+


### PR DESCRIPTION
Previously, when a forked coroutine caught an exception, it didn't actually log the error before finishing the test, now it does. 