### PR TITLE
Fix crash due to invoking a function storing state in the function itself

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -330,13 +330,12 @@ class function(object):
             event.outcome = _outcome
             event.set()
 
-        self._event = threading.Event()
-        self._event.result = None
-        waiter = cocotb.scheduler.queue_function(execute_function(self, self._event))
+        event = threading.Event()
+        waiter = cocotb.scheduler.queue_function(execute_function(self, event))
         # This blocks the calling external thread until the coroutine finishes
-        self._event.wait()
+        event.wait()
         waiter.thread_resume()
-        return self._event.outcome.get()
+        return event.outcome.get()
 
     def __get__(self, obj, type=None):
         """Permit the decorator to be used on class methods


### PR DESCRIPTION
This test previously failed with:
```
Traceback (most recent call last):
  File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line 245, in _advance
    return outcome.send(self._coro)
  File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line 51, in send
    return gen.throw(self.error)
  File "/home/eric/win-home/Repos/cocotb/tests/test_cases/test_external/test_external.py", line 380, in test_function_called_in_parallel
    v1 = yield t1
  File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line 141, in _advance
    return outcome.send(self._coro)
  File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line 37, in send
    return gen.send(self.value)
  File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line 363, in wrapper
    ret = ext.result  # raises if there was an exception
  File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/scheduler.py", line 105, in result
    return self._outcome.get()
  File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line 54, in get
    raise self.error
  File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/outcomes.py", line 17, in capture
    return Value(fn(*args, **kwargs))
  File "/home/eric/win-home/Repos/cocotb/tests/test_cases/test_external/test_external.py", line 375, in call_function
    return function(x)
  File "/mnt/c/Users/wiese/Repos/cocotb/cocotb/decorators.py", line 339, in __call__
    return self._event.outcome.get()
AttributeError: 'Event' object has no attribute 'outcome'
```

The cause was sharing an Event object between all function invocations, when there should have been one per call.