### PR TITLE
Use a with statement to ensure the threading.Condition is always released

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -227,7 +227,6 @@ class Scheduler(object):
         self._writes = {}
 
         self._pending_coros = []
-        self._pending_callbacks = []
         self._pending_triggers = []
         self._pending_threads = []
         self._pending_events = []   # Events we need to call set on once we've unwound
@@ -692,10 +691,6 @@ class Scheduler(object):
         # Handle any newly queued coroutines that need to be scheduled
         while self._pending_coros:
             self.add(self._pending_coros.pop(0))
-
-        while self._pending_callbacks:
-            self._pending_callbacks.pop(0)()
-
 
     def finish_test(self, test_result):
         """Cache the test result and set the terminate flag."""


### PR DESCRIPTION
```python
cond.acquire()
stuff()
cond.release()
```
is better spelt
```python
with cond:
    stuff()
```
as the latter calls release even if an exception is thrown.

I don't think this causes any observable bugs right now.