### PR TITLE
Revert "Always respond to triggers through react, so that the event loop is always involved"

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -462,7 +462,7 @@ class Scheduler(object):
                 del self._trigger2coros[trigger]
 
         if Join(coro) in self._trigger2coros:
-            self.react(Join(coro))
+            self._pending_triggers.append(Join(coro))
         else:
             try:
                 # throws an error if the background coroutine errored

--- a/tests/test_cases/test_external/test_external.py
+++ b/tests/test_cases/test_external/test_external.py
@@ -313,7 +313,7 @@ def test_external_returns_exception(dut):
     if not isinstance(result, ValueError):
         raise TestFailure('Exception was not returned')
 
-@cocotb.test()
+@cocotb.test(skip=True)
 def test_function_raised_exception(dut):
     """ Test that exceptions thrown by @function coroutines can be caught """
     # workaround for gh-637


### PR DESCRIPTION
Reverts potentialventures/cocotb#917

Just to check if this is really the cause of CI failure OF #928