### PR TITLE
Ci test 2

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -464,7 +464,7 @@ class Scheduler(object):
                 del self._trigger2coros[trigger]
 
         if Join(coro) in self._trigger2coros:
-            self._pending_triggers.append(Join(coro))
+            self.react(Join(coro))
         else:
             try:
                 # throws an error if the background coroutine errored

--- a/tests/test_cases/test_external/test_external.py
+++ b/tests/test_cases/test_external/test_external.py
@@ -313,7 +313,7 @@ def test_external_returns_exception(dut):
     if not isinstance(result, ValueError):
         raise TestFailure('Exception was not returned')
 
-@cocotb.test(skip=True)
+@cocotb.test()
 def test_function_raised_exception(dut):
     """ Test that exceptions thrown by @function coroutines can be caught """
     # workaround for gh-637


### PR DESCRIPTION
Another test of #928.

This is re-triggering CI of #917 to try and pinpoint why the branch CI passed but the merge CI failed.