### PR TITLE
Make the scheduler deterministic on old versions of python

### DIFF
--- a/tests/test_cases/test_closedown/test_closedown.py
+++ b/tests/test_cases/test_closedown/test_closedown.py
@@ -56,7 +56,7 @@ def clock_mon(dut):
     yield RisingEdge(dut.clk)
 
 
-@cocotb.test(expect_error=True)
+@cocotb.test(expect_fail=True)
 def test_failure_from_system_task(dut):
     """Allow the dut to call $fail_test() from verilog"""
     clock = Clock(dut.clk, 100)


### PR DESCRIPTION
The scheduler has various points where it iterates over keys in a dictionary.
However, this iteration order is random before CPython 3.6 / Python 3.7.

To fix that, we use `collections.OrderedDict`, which is ordered in all versions.
We cannot use `defaultdict` with this, so use the `setdefault` method, which is a little clumsier.

The test now fails rather than errors, which looking at the implementation of the `$fatal` handler looks like what was intended to happen in the first place.

This fixes gh-934 and gh-928. Closes #930.