### PR TITLE
Add VHDL_SOURCES_lib (GHDL only)

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.ghdl
+++ b/cocotb/share/makefiles/simulators/Makefile.ghdl
@@ -58,7 +58,11 @@ GHDL_ARGS += $(EXTRA_ARGS)
 
 # Compilation phase
 analyse: $(VHDL_SOURCES) $(SIM_BUILD)
-	cd $(SIM_BUILD) && $(CMD) -a $(GHDL_ARGS) $(COMPILE_ARGS) --work=$(RTL_LIBRARY) $(VHDL_SOURCES) && $(CMD) -e $(GHDL_ARGS) $(COMPILE_ARGS) --work=$(RTL_LIBRARY) $(TOPLEVEL)
+	cd $(SIM_BUILD) && \
+	$(foreach SOURCES_VAR, $(filter VHDL_SOURCES_%, $(.VARIABLES)), \
+		$(CMD) -a $(GHDL_ARGS) $(COMPILE_ARGS) --work=$(SOURCES_VAR:VHDL_SOURCES_%=%) $($(SOURCES_VAR)) && ) \
+	$(CMD) -a $(GHDL_ARGS) $(COMPILE_ARGS) --work=$(RTL_LIBRARY) $(VHDL_SOURCES) && \
+	$(CMD) -e $(GHDL_ARGS) $(COMPILE_ARGS) --work=$(RTL_LIBRARY) $(TOPLEVEL)
 
 results.xml: analyse  $(COCOTB_LIBS) $(COCOTB_VPI_LIB)
 	cd $(SIM_BUILD); \

--- a/documentation/source/building.rst
+++ b/documentation/source/building.rst
@@ -39,6 +39,9 @@ Make Variables
     ``VHDL_SOURCES``
       A list of the VHDL source files to include.
       
+    ``VHDL_SOURCES_lib``
+      A list of the VHDL source files to include in the VHDL library *lib* (currently GHDL only).
+      
     ``COMPILE_ARGS``
       Any arguments or flags to pass to the compile stage of the simulation. Only applies to simulators with a separate compilation stage (currently Icarus and VCS).
       


### PR DESCRIPTION
Currently, to include external libraries, the user has to manually run
ghdl before launching cocotb. With this commit, it is now possible to
specify in which library a set of VHDL files has to be placed into.
To do so, the files can be specified directly in the makefile under
the VHDL_SOURCES_lib variable. For example:

VHDL_SOURCES = top.vhd
VHDL_SOURCES_mylib = libfile.vhd libfile2.vhd

Here, libfile.vhd and libfile2.vhd will be analyzed with the
--work=mylib flag in GHDL before analyzing top.vhd.