### PR TITLE
Add automatic deploy to pypi on new tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,3 +106,13 @@ jobs:
     - stage: SimTests
       python: 3.7
       env: SIM=ghdl
+
+deploy:
+  provider: pypi
+  user: themperek
+  password:
+    secure: "Olc0PdhY/0b8zYrgsPCUrfusPJgYLRBpAux/c5M6j4OzKyZN3fjjpPw+Yrs6o8RxBPa4uqN/niKo8MmgxLQeq3vAy+3nNo3YukL9Q/AYrbJ+JvHfe+2Be73LaujbNvuS9+A7NX3GOT40bB1eo/kOT/kjgzAJvlFhVnXq8h5a9Gc="  on:
+    tags: true
+    repo: potentialventures/cocotb
+  distributions: sdist
+  


### PR DESCRIPTION
Usage:
- Change the [version](https://github.com/potentialventures/cocotb/blob/master/version) to release one.
- Create a new tag

:crossed_fingers:*

Cannot test this without a trying. Maybe rc1 first?

Related to: https://github.com/potentialventures/cocotb/issues/923