### PR TITLE
Delete local references to triggers and coroutines in the event loop

### DIFF
--- a/tests/test_cases/issue_957/Makefile
+++ b/tests/test_cases/issue_957/Makefile
@@ -1,0 +1,3 @@
+include ../../designs/sample_module/Makefile
+
+MODULE = issue_957

--- a/tests/test_cases/issue_957/issue_957.py
+++ b/tests/test_cases/issue_957/issue_957.py
@@ -1,0 +1,17 @@
+import cocotb
+from cocotb.triggers import Timer, RisingEdge, First
+
+@cocotb.coroutine
+def wait_edge(dut):
+    # this trigger never fires
+    yield First(
+        RisingEdge(dut.and_output)
+    )
+
+@cocotb.test()
+def test1(dut):
+    cocotb.fork(wait_edge(dut))
+
+    yield Timer(1000)
+
+test2 = test1


### PR DESCRIPTION
By doing this, we are able to process (and ignore) Event` objects scheduled within coroutine destructors, as the destructor now runs before the `while self._pending_events` loop terminates.

Destructor runtime is not super deterministic (and will not work on PyPI), so this might not be a sufficient fix for all cases.

Fixes gh-957