### PR TITLE
Add README.md to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include cocotb/share *.c* *.h Makefile.* Makefile
 recursive-include examples *.v *.py Makefile *.tcl *.cfg
 include version
+include README.md


### PR DESCRIPTION
On Python 2.7 and 3.5 Travis CI fails with the following error:

```
Processing ./.tox/.tmp/package/1/cocotb-1.1.0.zip
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-yHQ_rk/setup.py", line 53, in <module>
        long_description=read_file('README.md'),
      File "/tmp/pip-req-build-yHQ_rk/setup.py", line 36, in read_file
        return open(path.join(path.dirname(__file__), fname)).read()
    IOError: [Errno 2] No such file or directory: '/tmp/pip-req-build-yHQ_rk/README.md'
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-req-build-yHQ_rk/
```