### PR TITLE
Fix for ignoring config in AvalonST driver.

### DIFF
--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -555,7 +555,7 @@ class AvalonST(ValidatedBusDriver):
         # Avoid spurious object creation by recycling
         clkedge = RisingEdge(self.clock)
 
-        word = BinaryValue(n_bits=len(self.bus.data), bigEndian=False)
+        word = BinaryValue(n_bits=len(self.bus.data), bigEndian=self.config['firstSymbolInHighOrderBits'])
 
         # Drive some defaults since we don't know what state we're in
         self.bus.valid <= 0


### PR DESCRIPTION
While the config option is used in [the constructor](https://github.com/Matthewar/cocotb/blob/e6ef131493ddd15262eca8403220b613fa36af94/cocotb/drivers/avalon.py#L528), it is ignored in `_driver_send`.