### PR TITLE
Improve performance by avoiding calling logging.getLogger unless something is actually being logged

### DIFF
--- a/cocotb/clock.py
+++ b/cocotb/clock.py
@@ -38,15 +38,19 @@ else:
 import cocotb
 from cocotb.log import SimLog
 from cocotb.triggers import Timer, RisingEdge
-from cocotb.utils import get_sim_steps, get_time_from_sim_steps
+from cocotb.utils import get_sim_steps, get_time_from_sim_steps, lazy_property
 
 
 class BaseClock(object):
     """Base class to derive from."""
     def __init__(self, signal):
         self.signal = signal
-        self.log = SimLog("cocotb.%s.%s" %
-                          (self.__class__.__name__, self.signal._name))
+
+    @lazy_property
+    def log(self):
+        return SimLog("cocotb.%s.%s" % (
+            self.__class__.__name__, self.signal._name
+        ))
 
 
 class Clock(BaseClock):

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -41,7 +41,7 @@ from cocotb.log import SimLog
 from cocotb.result import raise_error, ReturnValue
 from cocotb.utils import (
     get_sim_steps, get_time_from_sim_steps, with_metaclass,
-    ParametrizedSingleton, exec_
+    ParametrizedSingleton, exec_, lazy_property
 )
 from cocotb import decorators
 from cocotb import outcomes
@@ -55,9 +55,12 @@ class Trigger(object):
     """Base class to derive from."""
     
     def __init__(self):
-        self.log = SimLog("cocotb.%s" % (self.__class__.__name__), id(self))
         self.signal = None
         self.primed = False
+
+    @lazy_property
+    def log(self):
+        return SimLog("cocotb.%s" % (self.__class__.__name__), id(self))
 
     def prime(self, *args):
         """FIXME: document"""

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -34,6 +34,7 @@ import math
 import os
 import sys
 import weakref
+import functools
 
 if "COCOTB_SIM" in os.environ:
     import simulator
@@ -556,6 +557,31 @@ def reject_remaining_kwargs(name, kwargs):
         raise TypeError(
             '{}() got an unexpected keyword argument {!r}'.format(name, bad_arg)
         )
+
+
+class lazy_property(object):
+    """
+    A property that is executed the first time, then cached forever.
+
+    It does this by replacing itself on the instance, which works because
+    unlike `@property` it does not define __set__.
+
+    This should be used for expensive members of objects that are not always
+    used.
+    """
+    def __init__(self, fget):
+        self.fget = fget
+
+        # copy the getter function's docstring and other attributes
+        functools.update_wrapper(self, fget)
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self
+
+        value = self.fget(obj)
+        setattr(obj, self.fget.__name__, value)
+        return value
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This:
* Adds a `lazy_property` decorator, to handle computing expensive attributes the first time they're used.
* Hides all `SimLog` instance behind a lazy_property. This is especially important for the Trigger, coroutine, and RunningCoroutine objects which are constructed and destroyed the most frequently.
* Hides the only guaranteed call to `.log` behind the same `COCOTB_SCHEDULER_DEBUG` environment variable, to avoid paying for a logger for every coroutine.

For a very contrived test-case of the following, this brought the runtime from ~10s to ~7.5s (Python 2.7):

```python
import cocotb
from cocotb.triggers import Timer, RisingEdge, First
from cocotb.clock import Clock

@cocotb.test()
def test1(dut):
    clk_gen = cocotb.fork(Clock(dut.clk, 100).start())
    for i in range(10000):
        yield [RisingEdge(dut.clk), Timer(200)]
```