### PR TITLE
Update avalon.py

### DIFF
--- a/cocotb/drivers/avalon.py
+++ b/cocotb/drivers/avalon.py
@@ -550,7 +550,7 @@ class AvalonST(ValidatedBusDriver):
         Args:
             value: data to drive onto the bus.
         """
-        self.log.debug("Sending Avalon transmission: %d" % value)
+        self.log.debug("Sending Avalon transmission: %r" % value)
 
         # Avoid spurious object creation by recycling
         clkedge = RisingEdge(self.clock)
@@ -591,7 +591,7 @@ class AvalonST(ValidatedBusDriver):
         word.binstr   = ("x"*len(self.bus.data))
         self.bus.data <= word
 
-        self.log.debug("Successfully sent Avalon transmission: %d" % value)
+        self.log.debug("Successfully sent Avalon transmission: %r" % value)
 
 
 class AvalonSTPkts(ValidatedBusDriver):


### PR DESCRIPTION
Changing the logging statements to allow byte strings to be passed to the AvalonST driver. 
Byte strings can be sent in the AvalonSTPkts driver but not the AvalonST driver because the logging statement requires integers.