### PR TITLE
Don't compute the list of integer types every time

### DIFF
--- a/cocotb/binary.py
+++ b/cocotb/binary.py
@@ -28,7 +28,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import print_function
-from cocotb.utils import get_python_integer_types
+from cocotb.utils import integer_types
 
 import os
 import random
@@ -154,7 +154,7 @@ class BinaryValue(object):
         Args:
             value (str or int or long): The value to assign.
         """
-        if isinstance(value, get_python_integer_types()):
+        if isinstance(value, integer_types):
             self.value = value
         elif isinstance(value, str):
             try:
@@ -640,11 +640,11 @@ class BinaryValue(object):
 
     def __setitem__(self, key, val):
         """BinaryValue uses Verilog/VHDL style slices as opposed to Python style."""
-        if not isinstance(val, str) and not isinstance(val, get_python_integer_types()):
+        if not isinstance(val, str) and not isinstance(val, integer_types):
             raise TypeError('BinaryValue slices only accept string or integer values')
 
         # convert integer to string
-        if isinstance(val, get_python_integer_types()):
+        if isinstance(val, integer_types):
             if isinstance(key, slice):
                 num_slice_bits = abs(key.start - key.stop) + 1
             else:

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -47,7 +47,7 @@ import cocotb
 from cocotb.binary import BinaryValue
 from cocotb.log import SimLog
 from cocotb.result import TestError
-from cocotb.utils import get_python_integer_types
+from cocotb.utils import integer_types
 
 # Only issue a warning for each deprecated attribute access
 _deprecation_warned = {}
@@ -582,13 +582,13 @@ class ModifiableObject(NonConstantObject):
             TypeError: If target is not wide enough or has an unsupported type 
                  for value assignment.
         """
-        if isinstance(value, get_python_integer_types()) and value < 0x7fffffff and len(self) <= 32:
+        if isinstance(value, integer_types) and value < 0x7fffffff and len(self) <= 32:
             simulator.set_signal_val_long(self._handle, value)
             return
 
         if isinstance(value, ctypes.Structure):
             value = BinaryValue(value=cocotb.utils.pack(value), n_bits=len(self))
-        elif isinstance(value, get_python_integer_types()):
+        elif isinstance(value, integer_types):
             value = BinaryValue(value=value, n_bits=len(self), bigEndian=False)
         elif isinstance(value, dict):
             # We're given a dictionary with a list of values and a bit size...
@@ -677,7 +677,7 @@ class EnumObject(ModifiableObject):
         """
         if isinstance(value, BinaryValue):
             value = int(value)
-        elif not isinstance(value, get_python_integer_types()):
+        elif not isinstance(value, integer_types):
             self._log.critical("Unsupported type for integer value assignment: %s (%s)" % (type(value), repr(value)))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 
@@ -705,7 +705,7 @@ class IntegerObject(ModifiableObject):
         """
         if isinstance(value, BinaryValue):
             value = int(value)
-        elif not isinstance(value, get_python_integer_types()):
+        elif not isinstance(value, integer_types):
             self._log.critical("Unsupported type for integer value assignment: %s (%s)" % (type(value), repr(value)))
             raise TypeError("Unable to set simulator value with type %s" % (type(value)))
 

--- a/cocotb/utils.py
+++ b/cocotb/utils.py
@@ -34,6 +34,7 @@ import math
 import os
 import sys
 import weakref
+import warnings
 
 if "COCOTB_SIM" in os.environ:
     import simulator
@@ -42,14 +43,19 @@ else:
     simulator = None
     _LOG_SIM_PRECISION = -15
 
-# python2 to python3 helper functions
+# This is six.integer_types
+if sys.version_info.major >= 3:
+    integer_types = (int,)
+else:
+    integer_types = (int, long)
+
+
 def get_python_integer_types():
-    try:
-        isinstance(1, long)
-    except NameError:
-        return (int,)  # python 3
-    else:
-        return (int, long)  # python 2
+    warnings.warn(
+        "This is an internal cocotb function, use six.integer_types instead",
+        DeprecationWarning)
+    return integer_types
+
 
 # Simulator helper functions
 def get_sim_time(units=None):


### PR DESCRIPTION
From the investigation at gh-961, this is shown to be 3% of the runtime on master.
The version of python does not change at runtime, so we can replace this function with a simple constant.
Doing so also brings our name in line with six's.

Note that this is independent of the regressions identified in that issue