### PR TITLE
Issue #253: Make VpiImpl::get_root_handle() return a GPI_MODULE always

### DIFF
--- a/cocotb/share/lib/vpi/VpiImpl.cpp
+++ b/cocotb/share/lib/vpi/VpiImpl.cpp
@@ -418,6 +418,8 @@ GpiObjHdl *VpiImpl::get_root_handle(const char* name)
     }
 
     for (root = vpi_scan(iterator); root != NULL; root = vpi_scan(iterator)) {
+        if (to_gpi_objtype(vpi_get(vpiType, root)) != GPI_MODULE)
+            continue;
 
         if (name == NULL || !strcmp(name, vpi_get_str(vpiFullName, root)))
             break;


### PR DESCRIPTION
In the event that the user doesn't specify the `TOPLEVEL` environment
variable to indicate the DUT Cocotb is supposed to automatically
detect it by scanning which top level handles are available and
returning the correct one.

In Icarus, it seems there are multiple top levels, and not all of them
are of type `GPI_MODULE`. This was meaning an unexpected handle was
returned from `VpiImpl::get_root_handle()` causing a test to fail.

This change causes the VPI implementation to ignore all top level
handles that are not of type `GPI_MODULE`.