### PR TITLE
Move non-inline functions out of headers

### DIFF
--- a/cocotb/share/include/cocotb_utils.h
+++ b/cocotb/share/include/cocotb_utils.h
@@ -34,9 +34,6 @@
 extern "C" {
 #endif
 
-#include <stdio.h>
-#include <stdlib.h>
-
 #define xstr(a) str(a)
 #define str(a) #a
 
@@ -45,24 +42,8 @@ extern void* utils_dyn_sym(void *handle, const char* sym_name);
 
 extern int is_python_context;
 
-void to_python(void) {
-    if (is_python_context) {
-        fprintf(stderr, "FATAL: We are calling up again\n");
-        exit(1);
-    }
-    ++is_python_context;
-    //fprintf(stderr, "INFO: Calling up to python %d\n", is_python_context);
-}
-
-void to_simulator(void) {
-    if (!is_python_context) {
-        fprintf(stderr, "FATAL: We have returned twice from python\n");
-        exit(1);
-    }
-
-    --is_python_context;
-    //fprintf(stderr, "INFO: Returning back to simulator %d\n", is_python_context);
-}
+void to_python(void);
+void to_simulator(void);
 
 #ifdef __cplusplus
 }

--- a/cocotb/share/lib/utils/cocotb_utils.c
+++ b/cocotb/share/lib/utils/cocotb_utils.c
@@ -29,6 +29,7 @@
 
 #include <cocotb_utils.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #if defined(__linux__) || defined(__APPLE__)
 #include <dlfcn.h>
@@ -38,6 +39,25 @@
 
 // Tracks if we are in the context of Python or Simulator
 int is_python_context = 0;
+
+void to_python(void) {
+    if (is_python_context) {
+        fprintf(stderr, "FATAL: We are calling up again\n");
+        exit(1);
+    }
+    ++is_python_context;
+    //fprintf(stderr, "INFO: Calling up to python %d\n", is_python_context);
+}
+
+void to_simulator(void) {
+    if (!is_python_context) {
+        fprintf(stderr, "FATAL: We have returned twice from python\n");
+        exit(1);
+    }
+
+    --is_python_context;
+    //fprintf(stderr, "INFO: Returning back to simulator %d\n", is_python_context);
+}
 
 void* utils_dyn_open(const char* lib_name)
 {


### PR DESCRIPTION
With this in the header a `multiple definition of `to_simulator'` error is emitted by the linker if two different compilation units include this header.

The alternative was to mark these functions as `inline`, but discussion on github favored not doing this.

Redo of #954, since that was merged before I could push a passing version.