### PR TITLE
Cache NextTimeStep() and ReadWrite() for performance

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -209,7 +209,9 @@ class Scheduler(object):
     _MODE_TERM     = 4  # noqa
 
     # Singleton events, recycled to avoid spurious object creation
-    _readonly = ReadOnly()
+    _next_time_step = NextTimeStep()
+    _read_write = ReadWrite()
+    _read_only = ReadOnly()
     _timer1 = Timer(1)
 
     def __init__(self):
@@ -254,9 +256,9 @@ class Scheduler(object):
         while True:
             yield self._writes_pending.wait()
             if self._mode != Scheduler._MODE_NORMAL:
-                yield NextTimeStep()
+                yield self._next_time_step
 
-            yield ReadWrite()
+            yield self._read_write
 
             while self._writes:
                 handle, value = self._writes.popitem()
@@ -374,7 +376,7 @@ class Scheduler(object):
                                    str(trigger))
                 return
 
-            if trigger is self._readonly:
+            if trigger is self._read_only:
                 self._mode = Scheduler._MODE_READONLY
             # Only GPI triggers affect the simulator scheduling mode
             elif isinstance(trigger, GPITrigger):


### PR DESCRIPTION
This optimization was here before too, but it was removed accidentally while handling the trigger duplication in 07d28be1559f0b424703f67ad55e998de164f0db.

This adds back the optimization without adding back the `copy.copy` hack that motivated the original change.

No idea how effective this optimization is, but it seems harmless, and it met the bar for inclusion the first time around.