### PR TITLE
Simplify the logging wrappers

### DIFF
--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -223,16 +223,16 @@ int embed_sim_init(gpi_sim_info_t *info)
         fprintf(stderr, "Failed to to get simlog object\n");
     }
 
-    simlog_func = PyObject_GetAttrString(simlog_obj, "_printRecord");
+    simlog_func = PyObject_GetAttrString(simlog_obj, "_logFromC");
     if (simlog_func == NULL) {
         PyErr_Print();
-        fprintf(stderr, "Failed to get the _printRecord method");
+        fprintf(stderr, "Failed to get the _logFromC method");
         goto cleanup;
     }
 
     if (!PyCallable_Check(simlog_func)) {
         PyErr_Print();
-        fprintf(stderr, "_printRecord is not callable");
+        fprintf(stderr, "_logFromC is not callable");
         goto cleanup;
     }
 
@@ -240,16 +240,16 @@ int embed_sim_init(gpi_sim_info_t *info)
 
     Py_DECREF(simlog_func);
 
-    simlog_func = PyObject_GetAttrString(simlog_obj, "_willLog");
+    simlog_func = PyObject_GetAttrString(simlog_obj, "isEnabledFor");
     if (simlog_func == NULL) {
         PyErr_Print();
-        fprintf(stderr, "Failed to get the _willLog method");
+        fprintf(stderr, "Failed to get the isEnabledFor method");
         goto cleanup;
     }
 
     if (!PyCallable_Check(simlog_func)) {
         PyErr_Print();
-        fprintf(stderr, "_willLog is not callable");
+        fprintf(stderr, "isEnabledFor is not callable");
         goto cleanup;
     }
 

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -599,7 +599,7 @@ class StrCallCounter(object):
 @cocotb.test()
 def test_logging_with_args(dut):
     counter = StrCallCounter()
-    dut._log.logger.setLevel(logging.INFO)  # To avoid logging debug message, to make next line run without error
+    dut._log.setLevel(logging.INFO)  # To avoid logging debug message, to make next line run without error
     dut._log.debug("%s", counter)
     assert counter.str_counter == 0
 


### PR DESCRIPTION
It seems to me the only purpose of the `SimLog` object is to allow C to call into the python logging infrastructure via `_printRecord`.

However, that desire alone does not justify the need to create our own class - we can simply move the  `_printRecord` method into `SimLogBase` (renamed to `_log_from_c`), and then none of rest of the wrapping is needed.

This also fixes some other problems:
* `SimBaseLog` did not call the right `__init__`, and re-initialized members already initialized by the base class
* `SimLog` did not support all of the features of the underlying logger (such as exception information)

Tested by looking at the travis log file before and after, and seeing nothing has changed (marking as draft until I actually have CI results to verify this against)