### PR TITLE
Throw TypeError instead of terminating the simulation

### DIFF
--- a/cocotb/decorators.py
+++ b/cocotb/decorators.py
@@ -111,9 +111,10 @@ class RunningCoroutine(object):
         self._outcome = None
 
         if not hasattr(self._coro, "send"):
-            self.log.error("%s isn't a valid coroutine! Did you use the yield "
-                           "keyword?" % self.funcname)
-            raise CoroutineComplete()
+            raise TypeError(
+                "%s isn't a valid coroutine! Did you use the yield "
+                "keyword?" % self.funcname
+            )
 
     @lazy_property
     def log(self):
@@ -298,20 +299,7 @@ class coroutine(object):
         return SimLog("cocotb.coroutine.%s" % self._func.__name__, id(self))
 
     def __call__(self, *args, **kwargs):
-        try:
-            return RunningCoroutine(self._func(*args, **kwargs), self)
-        except Exception as e:
-            traceback.print_exc()
-            result = TestError(str(e))
-            if sys.version_info[0] >= 3:
-                buff = StringIO()
-                traceback.print_exc(file=buff)
-            else:
-                buff_bytes = BytesIO()
-                traceback.print_exc(file=buff_bytes)
-                buff = StringIO(buff_bytes.getvalue().decode("UTF-8"))
-            result.stderr.write(buff.getvalue())
-            raise result
+        return RunningCoroutine(self._func(*args, **kwargs), self)
 
     def __get__(self, obj, type=None):
         """Permit the decorator to be used on class methods

--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -599,16 +599,16 @@ class Scheduler(object):
         if isinstance(coroutine, cocotb.decorators.coroutine):
             raise TypeError(
                 "Attempt to schedule a coroutine that hasn't started: {}.\n"
-                "Did you forget to add parentheses to the @test decorator?"
+                "Did you forget to add parentheses to the @cocotb.test() "
+                "decorator?"
                 .format(coroutine)
             )
 
         elif not isinstance(coroutine, cocotb.decorators.RunningCoroutine):
             raise TypeError(
-                "Attempt to add something to the scheduler which isn't a "
-                "coroutine.\n"
-                "Got: {} ({!r})\n"
-                "Did you use the @coroutine decorator?"
+                "Attempt to add a object of type {} to the scheduler, which "
+                "isn't a coroutine: {!r}\n"
+                "Did you forget to use the @cocotb.coroutine decorator?"
                 .format(type(coroutine), coroutine)
             )
 
@@ -671,10 +671,10 @@ class Scheduler(object):
             return self._trigger_from_waitable(result)
 
         raise TypeError(
-            "Coroutine yielded something the scheduler can't handle\n"
-            "Got type: {} repr: {!r} str: {}\n"
+            "Coroutine yielded an object of type {}, which the scheduler can't "
+            "handle: {!r}\n"
             "Did you forget to decorate with @cocotb.coroutine?"
-            .format(type(result), result, result)
+            .format(type(result), result)
         )
 
     def schedule(self, coroutine, trigger=None):

--- a/cocotb/triggers.py
+++ b/cocotb/triggers.py
@@ -421,13 +421,20 @@ class Lock(PythonTrigger):
 
 
 class NullTrigger(Trigger):
-    """Trigger for internal interfacing use call the callback as soon
-    as it is primed and then remove itself from the scheduler.
     """
-    def __init__(self, name=""):
-        Trigger.__init__(self)
+    A trigger that fires instantly, primarily for internal scheduler use.
+    """
+    def __init__(self, name="", outcome=None):
+        super(NullTrigger, self).__init__()
         self._callback = None
         self.name = name
+        self.__outcome = outcome
+
+    @property
+    def _outcome(self):
+        if self.__outcome is not None:
+            return self.__outcome
+        return super(NullTrigger, self)._outcome
 
     def prime(self, callback):
         callback(self)

--- a/tests/test_cases/test_cocotb/test_cocotb.py
+++ b/tests/test_cases/test_cocotb/test_cocotb.py
@@ -85,7 +85,8 @@ def test_function_not_decorated(dut):
     try:
         yield normal_function(dut)
     except TypeError as exc:
-        assert "yielded something the scheduler can't handle" in str(exc)
+        assert "yielded" in str(exc)
+        assert "scheduler can't handle" in str(exc)
     except:
         raise TestFailure
 


### PR DESCRIPTION
Previously, doing all of these things would cause the simulation to terminate:
* `yield bad_obj`
* `cocotb.fork(bad_obj)`
* Invoking a function decorated with `@cocotb.coroutine` that does not produce a generator (typically: contains no yields)

Instead, these operations now throw an exception at the point where they occur, meaning the user gets a proper stack trace, and can still perform cleanup in a try / finally.

This extends `NullTrigger` to allow its result to be overriden, which is used here to throw an exception at a yield point.