### PR TITLE
Support `exc_info` in SimBaseLog

### DIFF
--- a/cocotb/log.py
+++ b/cocotb/log.py
@@ -176,6 +176,17 @@ class SimLogFormatter(logging.Formatter):
                       ':' + self.ljust(str(record.lineno), _LINENO_CHARS) + \
                       ' in ' + self.ljust(str(record.funcName), _FUNCNAME_CHARS) + ' '
 
+        # these lines are copied from the builtin logger
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            if msg[-1:] != "\n":
+                msg = msg + "\n"
+            msg = msg + record.exc_text
+
         prefix_len = len(prefix)
         if coloured:
             prefix_len -= (len(level) - _LEVEL_CHARS)

--- a/cocotb/regression.py
+++ b/cocotb/regression.py
@@ -164,7 +164,7 @@ class RegressionManager(object):
                     except TestError:
                         skip = True
                         self.log.warning("Failed to initialize test %s" %
-                                         thing.name)
+                                         thing.name, exc_info=True)
 
                     if skip:
                         self.log.info("Skipping test %s" % thing.name)


### PR DESCRIPTION
Previously, passing this argument would be ignored.
Also use it in one new place in the regression manager, to prove it works