### PR TITLE
Ensure exceptions caught in C code are printed

### DIFF
--- a/cocotb/share/lib/embed/gpi_embed.c
+++ b/cocotb/share/lib/embed/gpi_embed.c
@@ -374,6 +374,7 @@ void embed_sim_event(gpi_event_t level, const char *msg)
             PyTuple_SetItem(fArgs, 1, PyString_FromString("No message provided"));
         PyObject *pValue = PyObject_CallObject(pEventFn, fArgs);
         if (!pValue) {
+            PyErr_Print();
             LOG_ERROR("Passing event to upper layer failed");
         }
 

--- a/cocotb/share/lib/gpi_log/gpi_logging.c
+++ b/cocotb/share/lib/gpi_log/gpi_logging.c
@@ -151,16 +151,22 @@ void gpi_log(const char *name, long level, const char *pathname, const char *fun
 
     PyObject *check_args = PyTuple_New(1);
     PyTuple_SetItem(check_args, 0, PyLong_FromLong(level));
-    PyObject *retuple = PyObject_CallObject(pLogFilter, check_args);
 
-    if (retuple != Py_True) {
-        Py_DECREF(check_args);
+    PyObject *filter_ret = PyObject_CallObject(pLogFilter, check_args);
+    Py_DECREF(check_args);
+    if (filter_ret == NULL) {
+        PyErr_Print();
         PyGILState_Release(gstate);
         return;
     }
 
-    Py_DECREF(retuple);
-    Py_DECREF(check_args);
+    if (filter_ret == Py_True) {
+        Py_DECREF(filter_ret);
+        PyGILState_Release(gstate);
+        return;
+    }
+
+    Py_DECREF(filter_ret);
 
     va_start(ap, msg);
     n = vsnprintf(log_buff, LOG_SIZE, msg, ap);
@@ -173,15 +179,14 @@ void gpi_log(const char *name, long level, const char *pathname, const char *fun
     PyTuple_SetItem(call_args, 3, PyUnicode_FromString(log_buff));   // Note: This function steals a reference.
     PyTuple_SetItem(call_args, 4, PyUnicode_FromString(funcname));
 
-    retuple = PyObject_CallObject(pLogHandler, call_args);
-
-    if (retuple != Py_True) {
+    PyObject *handler_ret = PyObject_CallObject(pLogHandler, call_args);
+    Py_DECREF(call_args);
+    if (handler_ret == NULL){
+        PyErr_Print();
         PyGILState_Release(gstate);
         return;
     }
-
-    Py_DECREF(call_args);
-    Py_DECREF(retuple);
+    Py_DECREF(handler_ret);
 
     PyGILState_Release(gstate);
 }


### PR DESCRIPTION
Not only does this print them, but it also ensures a dangling exception is not left thrown without a stack (ie, calls `PyErr_Clear()`.