### PR TITLE
Remove StringIO import from scheduler

### DIFF
--- a/cocotb/scheduler.py
+++ b/cocotb/scheduler.py
@@ -48,7 +48,7 @@ else:
 
 # Debug mode controlled by environment variables
 if "COCOTB_ENABLE_PROFILING" in os.environ:
-    import cProfile, StringIO, pstats
+    import cProfile, pstats
     _profile = cProfile.Profile()
     _profiling = True
 else:


### PR DESCRIPTION
StringIO is still used in a couple other places, so that's not a complete fix for the general problem, but at least a fix for the mentioned bug.

Fixes #971