### PR TITLE
Enforce that no new flake8 violations are added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       os: linux
       python: 3.5
       install: pip install flake8
-      script: flake8 --exit-zero cocotb/
+      script: flake8
 
     - stage: SimTests
       os: linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,48 @@
+[flake8]
+exclude =
+    bin
+    documentation
+    examples
+    makefiles
+    tests
+    venv
+
+# TODO: fix some of these
+ignore =
+    E111  # indentation is not a multiple of four
+    E123  # closing bracket does not match indentation of opening bracket's line
+    E126  # continuation line over-indented for hanging indent
+    E127  # continuation line over-indented for visual indent
+    E128  # continuation line under-indented for visual indent
+    E131  # continuation line unaligned for hanging indent
+    E202  # whitespace before ')'
+    E203  # whitespace before ',' / ':'
+    E221  # multiple spaces before operator
+    E225  # missing whitespace around operator
+    E226  # missing whitespace around arithmetic operator
+    E228  # missing whitespace around modulo operator
+    E231  # missing whitespace after ...
+    E241  # multiple spaces after ...
+    E261  # at least two spaces before inline comment
+    E302  # expected 2 blank lines, found ...
+    E303  # too many blank lines (...)
+    E305  # expected 2 blank lines after class or function definition, found ...
+    E401  # multiple imports on one line
+    E402  # module level import not at top of file
+    E501  # line too long (... > 79 characters)
+    E701  # multiple statements on one line (colon)
+    E713  # test for membership should be 'not in'
+    E714  # test for object identity should be 'is not'
+    E722  # do not use bare 'except'
+    E741  # ambiguous variable name 'l'
+    F401  # '...' imported but unused
+    F403  # 'from ... import *' used; unable to detect
+    F405  # ... may be undefined, or defined from star
+    F632  # use ==/!= to compare str, bytes, and int literals
+    F821  # undefined name ...
+    F841  # local variable ... is assigned to but never used
+    W291  # trailing whitespace
+    W293  # blank line contains whitespace
+    W391  # blank line at end of file
+    W504  # line break after binary operator
+    W605  # invalid escape sequence ...


### PR DESCRIPTION
This takes the current flake8 failures, adds them to a whitelist, and turns on flake8 actually failing if new violations are detected.

Some of these are outright bugs which are not caught by tests. I'll do some follow-ups to fix some of these problems.