### PR TITLE
Use COMPILE_ARGS and SIM_ARGS for xrun call.

### DIFF
--- a/cocotb/share/makefiles/simulators/Makefile.xcelium
+++ b/cocotb/share/makefiles/simulators/Makefile.xcelium
@@ -45,6 +45,10 @@ else
     export XCELIUM_BIN_DIR
 endif
 
+EXTRA_ARGS += $(COMPILE_ARGS)
+EXTRA_ARGS += $(SIM_ARGS)
+EXTRA_ARGS += -licqueue
+
 ifneq ($(ARCH),i686)
     EXTRA_ARGS += -64
 endif


### PR DESCRIPTION
Fixes #1000 by making ``Makefile.xcelium`` the same as ``Makefile.ius`` in that area.
The ``-licqueue`` argument is present in ``Makefile.ius`` too.